### PR TITLE
Add Cursor skills for create-feature, code-review, and bugfix

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -5,14 +5,14 @@ description: Reviews a Gombit diff or pull request against the agent working agr
 
 # Code Review
 
-Review the current diff (or a named PR/branch) against Gombit's definition of done. Read `AGENTS.md` first. This skill is the Cursor checklist that `AGENTS.md` refers to; it overrides generic review habits for this repo.
+Review the current diff (or a named PR/branch) against Gombit's definition of done. Read `AGENTS.md` first. This is the Claude Code project skill that `AGENTS.md` and `CLAUDE.md` refer to; it overrides the bundled `/code-review` for this repo.
 
-The Claude Code counterpart is `.claude/skills/code-review/SKILL.md`. Keep both aligned.
+The Cursor counterpart is `.cursor/skills/code-review/SKILL.md`. Keep both aligned.
 
 ## When not to use
 
-- Implementing a new backlog item → `create-feature`
-- Reproducing and fixing a defect → `bugfix` (review the fix afterward with this skill)
+- Implementing a new backlog item → treat as a feature (Cursor: `create-feature`)
+- Reproducing and fixing a defect → treat as a bugfix (Cursor: `bugfix`); review the fix afterward with this skill
 
 ## Setup
 

--- a/.claude/skills/code-review/references/checklist.md
+++ b/.claude/skills/code-review/references/checklist.md
@@ -1,0 +1,70 @@
+# Gombit review checklist
+
+Walk only the sections that the diff touches.
+
+This file must stay aligned with `.cursor/skills/code-review/references/checklist.md`.
+
+## Working agreement (always)
+
+- [ ] Linked issue exists and the PR states which AC it satisfies
+- [ ] Scope is inside that issue's milestone; no M6 battery (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
+- [ ] No new issues, labels, or milestones beyond build plan §4 / §6
+- [ ] Locked decisions were not reopened
+
+## Architecture
+
+- [ ] Public HTTP contract is Huma-typed handlers, not comment annotations or a hand-written OpenAPI file
+- [ ] Raw Gin escape hatch (`app.Router()`) is tested when used, and those routes are absent from OpenAPI
+- [ ] Generated app code is feature-package (`internal/<feature>/`), not `app/controllers`
+- [ ] Thin handler-over-GORM default; no unsolicited `service.go` / `repo.go`
+- [ ] Behavior that could live in the runtime was not generated into user-owned files
+- [ ] `*gin.Engine` and `*gorm.DB` remain reachable; no universal ORM interface
+- [ ] Cache uses value semantics (`Get/Set/Delete/Increment`), not leaked go-redis types
+- [ ] `os.Getenv` stays in the typed config boundary
+
+## Generators and AST
+
+- [ ] Go edits use `go/ast` + `go/format`, never regex
+- [ ] Generator is idempotent; `--dry-run` and `--force` exist
+- [ ] Re-running does not clobber user-owned files
+- [ ] Created/modified files are printed
+- [ ] Golden tests exist for generator changes (compile backend, typecheck frontend, idempotency)
+
+## Contract and frontend
+
+- [ ] Success/error bodies match D10 (`data`/`meta`, `error.{code,message,fields,request_id}`)
+- [ ] Validation failures populate `error.fields`
+- [ ] OpenAPI 3.1 + `openapi-typescript` / `openapi-fetch` client regenerated in this PR
+- [ ] Access token is in-memory only — no `localStorage` / `sessionStorage` for secrets
+- [ ] No secrets in generated frontend; `VITE_*` treated as public
+- [ ] Default UI remains headless; MUI only behind `--ui mui`
+
+## Persistence
+
+- [ ] SQLite + PostgreSQL both considered; MySQL not required for v0.1
+- [ ] Migrations go through Atlas GORM provider + `atlas migrate diff`, not a new DSL
+- [ ] Migration metadata is `version, name, batch, applied_at` (no checksums)
+- [ ] `repository.New[T]` is runtime-only, not copied per model
+
+## Auth and security
+
+- [ ] Bearer JWT remains the API default; cookie/session is first-class when touched
+- [ ] Cookie mode uses HttpOnly / Secure / SameSite + CSRF
+- [ ] `X-API-Key` is not enabled by default for browser apps
+- [ ] Production validation still fails loud for draft Appendix C cases
+- [ ] Middleware order preserved if the HTTP stack moved (recovery → request ID → tracing → access log → proxy/IP → security headers → CORS → body limit → timeout → rate limit → auth → app → handler)
+
+## Go idiom (when Go exists)
+
+- [ ] `gofmt` / `go test` / lint clean
+- [ ] Context passed explicitly; not stored in structs
+- [ ] Table-driven tests with `t.Run` and useful `t.Errorf` messages
+- [ ] Exported identifiers have doc comments that start with the name
+- [ ] Errors wrapped with enough context; no discarded `error`
+- [ ] No reflection-based route/module discovery
+
+## Extraction discipline
+
+- [ ] Existing tests from the template still pass
+- [ ] Contracts (JWT/RBAC, request ID, timeouts, rate limit, security headers, metrics, probes, graceful shutdown) were moved, not rewritten
+- [ ] If a "small extraction" became a rewrite, the review must block and ask for a discussion issue

--- a/.cursor/skills/bugfix/SKILL.md
+++ b/.cursor/skills/bugfix/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: bugfix
+description: Reproduces, tests, and fixes a Gombit defect with a minimal, verified change. Use when the user asks to fix a bug, fix a failing test, chase a regression, or resolve an issue that is a defect rather than a new feature.
+---
+
+# Bugfix
+
+Reproduce first, then fix the root cause only. Read `AGENTS.md` first. `docs/GOMBIT_BUILD_PLAN.md` wins on conflicts.
+
+## When not to use
+
+- New capability or backlog feature → `create-feature`
+- Reviewing someone else's fix → `code-review`
+- Cannot observe the failure after a genuine reproduction attempt → stop and ask; do not "fix" a guessed bug
+
+## Workflow
+
+```
+1. Understand
+2. Reproduce
+3. Failing test
+4. Root cause
+5. Minimal fix
+6. Verify
+7. Hand-off
+```
+
+### 1. Understand
+
+- Capture expected vs actual, stack traces, request IDs, and the last good revision.
+- If a GitHub issue exists, treat it as the ticket. If the defect is new, do **not** open a backlog-style `[M#]` issue unless asked — Gombit issues map 1:1 to build plan §4. Describe the bug in the PR instead.
+- Check whether the code is an extraction from `golang-rest-api-template` / `crud-template-monorepo`. Prefer restoring the proven contract over rewriting the subsystem.
+
+### 2. Reproduce
+
+Confirm the failure with the smallest command or test that shows it.
+
+| Kind | How |
+| --- | --- |
+| Unit / logic | `go test` the package (or a focused `go test -run`) |
+| HTTP / contract | Handler test or a request against the running app; compare to D10 envelope + OpenAPI |
+| DB | SQLite first, then PostgreSQL. Do not declare a dialect bug from one driver. |
+| Frontend / auth | Trace token storage and the generated client. Access tokens must stay in memory. |
+| Generator | Re-run the generator; check idempotency and whether user-owned files were overwritten |
+| Docs-only / pre-code | Reproduce as a contradiction between build plan, AGENTS.md, and the file text |
+
+If reproduction fails, report what was tried and stop.
+
+### 3. Failing test
+
+Write a regression test that fails **before** the fix. Run it and confirm the fail.
+
+- Prefer table-driven cases with `t.Run` and messages that include input, got, and want ([Go Test Comments](https://go.dev/wiki/TestComments)).
+- Contract bugs: assert the D10 shape (`data`/`meta` or `error.{code,message,fields,request_id}`).
+- Generator bugs: golden + idempotency (second run is a no-op without `--force`).
+- Do not "fix" the test to match broken behavior.
+
+Until `go.mod` exists, the regression proof is a concrete before/after in the doc or fixture the bug lives in.
+
+### 4. Root cause
+
+Trace from the failing assertion to the responsible change. Classify:
+
+- logic / validation
+- contract drift (handler vs OpenAPI vs TS client)
+- config / env leak (`os.Getenv` outside the config boundary)
+- dialect (SQLite vs PostgreSQL)
+- generator / AST edit
+- auth / token storage
+- extraction regression (moved code, changed contract)
+
+Assess blast radius: other feature-packages, middleware order, migration history, generated clients.
+
+### 5. Minimal fix
+
+- Fix the root cause only. No drive-by refactors, no extra layers, no new batteries.
+- Do not re-litigate locked decisions to "simplify" the fix.
+- Extraction bugs: restore the old contract; do not take the chance to rewrite.
+- API-visible fixes regenerate OpenAPI + the TS client in the same change.
+- Generator fixes stay AST-based (`go/ast` / `go/format`), idempotent, and must not start clobbering user-owned files.
+- Auth fixes must not move bearer tokens into `localStorage` / `sessionStorage`.
+- If the real fix is an M6 battery or a new product decision, stop and flag it.
+
+### 6. Verify
+
+- The new test passes; neighboring tests still pass.
+- DB-touching fixes: SQLite **and** PostgreSQL.
+- Runtime extractions: extracted suite still green.
+- Lint / `gofmt` clean when Go exists.
+- Then run the `code-review` skill on the fix diff.
+
+### 7. Hand-off
+
+- One bug per PR. Conventional prefix: `fix:`.
+- PR body: root cause, what changed, regression test name, linked issue if any.
+- State which AC (if this was a backlog bug) are now satisfied.
+
+## Anti-patterns
+
+- Fixing without a reproduced failure
+- Shipping without a regression test
+- Rewriting a passing extraction because the bug was nearby
+- Editing Go with regex in a generator
+- Changing the D10 envelope or inventing a parallel error shape
+- Pulling jobs, events, mail, gRPC, or other M6 work into the fix

--- a/.cursor/skills/code-review/SKILL.md
+++ b/.cursor/skills/code-review/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: code-review
+description: Reviews a Gombit diff or pull request against the agent working agreement, locked architecture decisions, and Go/React security conventions. Use when the user asks for a code review, PR review, diff review, or to check a change before merge.
+---
+
+# Code Review
+
+Review the current diff (or a named PR/branch) against Gombit's definition of done. Read `AGENTS.md` first. This skill is the Cursor checklist that `AGENTS.md` refers to; it overrides generic review habits for this repo.
+
+## When not to use
+
+- Implementing a new backlog item → `create-feature`
+- Reproducing and fixing a defect → `bugfix` (review the fix afterward with this skill)
+
+## Setup
+
+1. Determine the review surface: `git diff` / `git diff main...HEAD` / the named PR.
+2. Identify the linked issue (`[ID] ...`) and its acceptance criteria in `docs/GOMBIT_BUILD_PLAN.md` §4.
+3. If the repo is still pre-code, review docs and scaffolding for invented APIs, scope creep, and decision regressions — not imaginary runtime files.
+4. Load [references/checklist.md](references/checklist.md) and walk every item that applies to the diff.
+
+## How to review
+
+Follow [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments) and [Go Test Comments](https://go.dev/wiki/TestComments) for style. Gombit-specific bars outrank generic style nits.
+
+Prefer findings over praise. Do not re-litigate locked decisions (Huma, feature-packages, Atlas, JWT-in-memory, D10 envelope, AST-only generators). If the author did re-litigate one, that is a **blocker**.
+
+## Output format
+
+Write the review in this order:
+
+```markdown
+## Verdict
+Approve | Request changes | Comment-only
+
+## Issue / AC
+- Issue: [ID] ...
+- AC covered: ...
+- AC missing: ...
+
+## Blockers
+- ...
+
+## Major
+- ...
+
+## Minor / nits
+- ...
+
+## Questions
+- ...
+```
+
+Severity:
+
+| Severity | Meaning |
+| --- | --- |
+| **Blocker** | Violates the working agreement, a locked decision, a security invariant, or stated AC. Must fix before merge. |
+| **Major** | Correctness, test gap, contract drift, or extraction-turned-rewrite. Should fix in this PR. |
+| **Minor** | Idiom, naming, docs. Fix if cheap; do not expand scope. |
+
+Cite `path:line` (or a hunk) for every finding. Suggest the fix; do not implement unless the user asked.
+
+## What "approve" requires
+
+All of build plan §5 / `AGENTS.md` working agreement:
+
+1. Tests for new behavior; DB changes green on SQLite + PostgreSQL.
+2. Docs + example for stable features.
+3. Extraction, not rewrite, of code that already passes tests.
+4. Generator safety (`go/ast`, idempotent, `--dry-run` / `--force`, no silent overwrite).
+5. No secrets in generated frontend; `VITE_*` is public; Appendix C prod checks still fail loudly.
+6. API changes regenerate OpenAPI + TS client in the same PR.
+7. Scope stays in-milestone; no M6 batteries.
+8. PR links its issue and lists satisfied AC.
+
+If the change is docs-only or pre-code, apply the subset that still makes sense (scope, decisions, AC, no invented APIs).

--- a/.cursor/skills/code-review/references/checklist.md
+++ b/.cursor/skills/code-review/references/checklist.md
@@ -1,0 +1,68 @@
+# Gombit review checklist
+
+Walk only the sections that the diff touches.
+
+## Working agreement (always)
+
+- [ ] Linked issue exists and the PR states which AC it satisfies
+- [ ] Scope is inside that issue's milestone; no M6 battery (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
+- [ ] No new issues, labels, or milestones beyond build plan §4 / §6
+- [ ] Locked decisions were not reopened
+
+## Architecture
+
+- [ ] Public HTTP contract is Huma-typed handlers, not comment annotations or a hand-written OpenAPI file
+- [ ] Raw Gin escape hatch (`app.Router()`) is tested when used, and those routes are absent from OpenAPI
+- [ ] Generated app code is feature-package (`internal/<feature>/`), not `app/controllers`
+- [ ] Thin handler-over-GORM default; no unsolicited `service.go` / `repo.go`
+- [ ] Behavior that could live in the runtime was not generated into user-owned files
+- [ ] `*gin.Engine` and `*gorm.DB` remain reachable; no universal ORM interface
+- [ ] Cache uses value semantics (`Get/Set/Delete/Increment`), not leaked go-redis types
+- [ ] `os.Getenv` stays in the typed config boundary
+
+## Generators and AST
+
+- [ ] Go edits use `go/ast` + `go/format`, never regex
+- [ ] Generator is idempotent; `--dry-run` and `--force` exist
+- [ ] Re-running does not clobber user-owned files
+- [ ] Created/modified files are printed
+- [ ] Golden tests exist for generator changes (compile backend, typecheck frontend, idempotency)
+
+## Contract and frontend
+
+- [ ] Success/error bodies match D10 (`data`/`meta`, `error.{code,message,fields,request_id}`)
+- [ ] Validation failures populate `error.fields`
+- [ ] OpenAPI 3.1 + `openapi-typescript` / `openapi-fetch` client regenerated in this PR
+- [ ] Access token is in-memory only — no `localStorage` / `sessionStorage` for secrets
+- [ ] No secrets in generated frontend; `VITE_*` treated as public
+- [ ] Default UI remains headless; MUI only behind `--ui mui`
+
+## Persistence
+
+- [ ] SQLite + PostgreSQL both considered; MySQL not required for v0.1
+- [ ] Migrations go through Atlas GORM provider + `atlas migrate diff`, not a new DSL
+- [ ] Migration metadata is `version, name, batch, applied_at` (no checksums)
+- [ ] `repository.New[T]` is runtime-only, not copied per model
+
+## Auth and security
+
+- [ ] Bearer JWT remains the API default; cookie/session is first-class when touched
+- [ ] Cookie mode uses HttpOnly / Secure / SameSite + CSRF
+- [ ] `X-API-Key` is not enabled by default for browser apps
+- [ ] Production validation still fails loud for draft Appendix C cases
+- [ ] Middleware order preserved if the HTTP stack moved (recovery → request ID → tracing → access log → proxy/IP → security headers → CORS → body limit → timeout → rate limit → auth → app → handler)
+
+## Go idiom (when Go exists)
+
+- [ ] `gofmt` / `go test` / lint clean
+- [ ] Context passed explicitly; not stored in structs
+- [ ] Table-driven tests with `t.Run` and useful `t.Errorf` messages
+- [ ] Exported identifiers have doc comments that start with the name
+- [ ] Errors wrapped with enough context; no discarded `error`
+- [ ] No reflection-based route/module discovery
+
+## Extraction discipline
+
+- [ ] Existing tests from the template still pass
+- [ ] Contracts (JWT/RBAC, request ID, timeouts, rate limit, security headers, metrics, probes, graceful shutdown) were moved, not rewritten
+- [ ] If a "small extraction" became a rewrite, the review must block and ask for a discussion issue

--- a/.cursor/skills/create-feature/SKILL.md
+++ b/.cursor/skills/create-feature/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: create-feature
+description: Implements a Gombit backlog issue or new framework capability as a scoped, tested change. Use when the user asks to create a feature, implement an issue, add a resource, scaffold a feature-package, or land a milestone item from docs/GOMBIT_BUILD_PLAN.md.
+---
+
+# Create Feature
+
+Implement one Gombit unit of work. Read `AGENTS.md` first. `docs/GOMBIT_BUILD_PLAN.md` wins on conflicts; the design doc is rationale only.
+
+## When not to use
+
+- Defect / failing test / regression → `bugfix`
+- Reviewing an existing diff or PR → `code-review`
+- Inventing work that is not a §4 backlog issue (flag it; do not silently add scope)
+
+## Workflow
+
+### 1. Orient
+
+1. Identify the GitHub issue (`[ID] Title`, e.g. `[M1-2] ...`). If none exists, stop and ask — do not invent issues.
+2. Read that issue's acceptance criteria, deps, size, and labels from build plan §4.
+3. Confirm every "Depends on" issue is done. If a dependency is open, stop.
+4. Check the working tree. This repo may still be **pre-code** (docs only). Do not assume `go.mod`, `internal/`, or a generated-app layout exists until `ls` / `git log` say so.
+5. If the issue is an extraction from `golang-rest-api-template` or `crud-template-monorepo`, locate the existing code and **move/refactor** it. Do not rewrite passing tests.
+
+### 2. Place the change
+
+Decide **runtime vs generated** before writing files (build plan §3.3):
+
+> Behavior lives in the versioned runtime. Generated code is a thin, one-time scaffold the user owns. The framework never rewrites user-owned files.
+
+- If the behavior can live in the runtime, put it there.
+- Generated application code uses the feature-package layout in [references/layout.md](references/layout.md). Never Laravel-style `app/controllers` / `app/models`.
+- `service.go` / `repo.go` only when the issue or `--service` / `--repo` asks for them. Default is a thin Huma handler over GORM.
+- Generated Go filenames are `snake_case`; exported types are PascalCase (D7).
+- Default API prefix is `/api/v1` (D8).
+
+Load [references/conventions.md](references/conventions.md) for Huma, envelope, auth, migrations, and frontend contract rules.
+
+### 3. Implement
+
+- Keep the change inside the issue's milestone. If an M6 battery (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n) appears, stop and split it out.
+- Do not re-litigate locked decisions (AGENTS.md / build plan §1–§3).
+- Public API behavior goes through Huma-typed handlers. Use raw `*gin.Engine` via `app.Router()` only for webhooks, SSE, or other out-of-contract routes — and test that escape hatch.
+- Validation lives on Huma input structs. Validation failures must render the D10 error envelope with `fields`.
+- Expose `*gin.Engine` and `*gorm.DB`; do not wrap them in a second framework.
+- Interfaces belong at real boundaries (cache, clock, mail, storage), not around GORM.
+- Generators must be idempotent and additive, support `--dry-run` / `--force`, print created/modified files, and edit Go via `go/ast` + `go/format` only — never regex.
+- Config reads stay in the typed config boundary. No new `os.Getenv` in low-level packages.
+- Frontend: Vite + React + TypeScript. Access tokens stay **in memory**, never `localStorage`. Treat every `VITE_*` value as public.
+
+### 4. Verify (definition of done)
+
+A feature is not done unless all of these hold:
+
+1. New behavior has tests. Prefer table-driven Go tests (`t.Run`) with useful failure messages. DB-touching changes pass SQLite **and** PostgreSQL (MySQL is post-v0.1 / stretch).
+2. Runtime extractions keep the extracted suite green.
+3. Any API change regenerates OpenAPI 3.1 + the TypeScript client (`openapi-typescript` + `openapi-fetch`) in the same PR.
+4. Stable features ship docs and appear in an example app.
+5. No secrets in generated frontend source. Production config must fail loudly for draft Appendix C cases (short JWT secret, insecure cookies, wildcard CORS + credentials, debug Gin in prod, etc.).
+6. The PR links its issue and states which acceptance criteria it satisfies.
+
+Until `go.mod` exists, verification is: the change matches the issue AC, does not invent runtime APIs, and does not add scope beyond §4.
+
+### 5. Hand-off
+
+- One issue → one PR where practical.
+- Conventional commit prefix is fine (`feat:`, `docs:`, `chore:`).
+- After implementing, run the `code-review` skill against the diff before calling the work done.

--- a/.cursor/skills/create-feature/references/conventions.md
+++ b/.cursor/skills/create-feature/references/conventions.md
@@ -1,0 +1,70 @@
+# Feature conventions (locked)
+
+Do not re-litigate these. Full text: `AGENTS.md` and `docs/GOMBIT_BUILD_PLAN.md` §1–§3.
+
+## Contract pipeline
+
+```
+Huma-typed handler (input/output structs, validated)
+        ↓  Huma emits
+OpenAPI 3.1  (/openapi.json, `gombit openapi generate`)
+        ↓  openapi-typescript
+TypeScript types
+        ↓  openapi-fetch + thin wrapper
+React client
+```
+
+- Anything in the public API is a Huma handler.
+- Raw `*gin.Engine` (`app.Router()`) is the tested escape hatch for non-contract routes and must **not** appear in the OpenAPI doc.
+- Drift between server and generated client fails CI.
+
+## Envelope (D10)
+
+Success:
+
+```json
+{"data": {}, "meta": {}}
+```
+
+Error:
+
+```json
+{"error": {"code": "validation_error", "message": "...", "fields": {"email": ["..."]}, "request_id": "..."}}
+```
+
+Do not emit `{"error":"string"}` or a new wrapper.
+
+## Auth
+
+- v0.1 API default: Bearer JWT + refresh rotation.
+- Generated frontend stores the access token **in memory only**. Never `localStorage`.
+- Session/cookie (`--auth cookie`) is first-class (HttpOnly / Secure / SameSite + CSRF). Required before the admin milestone.
+- `X-API-Key` is off by default for browser apps; server-to-server only.
+
+## Persistence
+
+- GORM is the ORM. Expose `*gorm.DB`; do not invent a universal ORM interface.
+- v0.1 databases: SQLite + PostgreSQL. MySQL is deferred.
+- Migrations: Atlas GORM provider (Program Mode) + `atlas migrate diff`. No hand-rolled DSL.
+- Migration metadata: `version, name, batch, applied_at`. No checksums (D4).
+- Optional generic repo `repository.New[T]` lives in the **runtime**, never generated per model.
+
+## Frontend
+
+- Vite + React + TypeScript. Minimal/headless UI is the default; MUI is `--ui mui`.
+- Package manager: detect (prefer `pnpm`, else `npm`); default `npm` when none present.
+- Forms: map D10 `error.fields` into field errors (React Hook Form in the skeleton).
+
+## Security defaults (draft Appendix C)
+
+Production must reject or loudly fail:
+
+- JWT secret too short
+- cookie auth without Secure under HTTPS production URL
+- wildcard CORS with credentials
+- trusted proxies = all without explicit opt-in
+- debug Gin mode in production
+- embedded browser API secret
+- SQLite path unwritable
+- pending required migrations
+- Redis selected but unreachable when required for auth/session

--- a/.cursor/skills/create-feature/references/layout.md
+++ b/.cursor/skills/create-feature/references/layout.md
@@ -1,0 +1,32 @@
+# Generated application layout
+
+Authoritative copy: `docs/GOMBIT_BUILD_PLAN.md` §3.2. Use this when scaffolding or placing application code — not for the framework repo itself until generators exist.
+
+```
+myapp/
+├── cmd/server/main.go
+├── internal/
+│   ├── platform/            # app wiring the framework owns the shape of
+│   └── product/             # one package per resource
+│       ├── product.go       # model
+│       ├── handler.go       # Huma handlers (thin, over GORM by default)
+│       ├── service.go       # ONLY if --service
+│       ├── repo.go          # ONLY if --repo
+│       └── routes.go        # registration
+├── database/migrations/
+├── database/seeds/
+├── config/
+├── frontend/                # Vite React app
+├── gombit.yaml
+├── .env.example
+├── go.mod
+└── README.md
+```
+
+Rules:
+
+- `routes.go` is registered **explicitly** from `main.go`. No reflection discovery.
+- Route-registration edits (when generators exist) use `go/ast` and only append at a known registration point.
+- Framework-owned endpoints (probes, metrics, OpenAPI) stay in the runtime; example-domain models must not leak into runtime packages.
+- Split deploy is the default. Embed the frontend only via `gombit build --embed`.
+- `.env.example` splits server secrets from `VITE_*` public values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,21 @@ A change is not done unless:
 - If something looks missing from the backlog, flag it — don't silently add
   scope.
 
-## Code review
+## Cursor skills
 
-Before opening or merging a PR, review the diff against the working
-agreement above. In Claude Code, run the project `code-review` skill
-(`.claude/skills/code-review/SKILL.md`); in Cursor, the equivalent checklist
-lives in `.cursor/rules/code-review.mdc`.
+Project skills live in `.cursor/skills/` and encode the workflows above.
+Invoke them with `/create-feature`, `/code-review`, or `/bugfix`, or by
+asking in those terms.
+
+- **create-feature** — implement one backlog issue or new capability.
+  Place code per the generate-vs-runtime rule and feature-package layout;
+  finish only when the working agreement is met.
+- **code-review** — review a diff/PR against this file and build plan §5.
+  Use it before opening or merging a PR. It is the Cursor checklist for
+  this repo (not a generic review).
+- **bugfix** — reproduce, add a failing test, fix the root cause only,
+  then verify. Do not use it for new features.
+
+In Claude Code, the same `code-review` workflow is the project skill at
+`.claude/skills/code-review/SKILL.md` when that file exists; otherwise
+follow `.cursor/skills/code-review/SKILL.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,13 @@ A change is not done unless:
 - If something looks missing from the backlog, flag it — don't silently add
   scope.
 
+## Code review
+
+Before opening or merging a PR, review the diff against the working
+agreement above. In Claude Code, run the project `code-review` skill
+(`.claude/skills/code-review/SKILL.md`); in Cursor, run the project
+`code-review` skill (`.cursor/skills/code-review/SKILL.md`).
+
 ## Cursor skills
 
 Project skills live in `.cursor/skills/` and encode the workflows above.
@@ -84,7 +91,3 @@ asking in those terms.
   this repo (not a generic review).
 - **bugfix** — reproduce, add a failing test, fix the root cause only,
   then verify. Do not use it for new features.
-
-In Claude Code, the same `code-review` workflow is the project skill at
-`.claude/skills/code-review/SKILL.md` when that file exists; otherwise
-follow `.cursor/skills/code-review/SKILL.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,16 +2,19 @@
 
 ## Claude Code
 
-- Canonical project skills live under `.cursor/skills/` (Cursor + Agent
-  Skills standard). Use those workflows even when invoking from Claude Code:
-  - `create-feature` — implement one `[ID]` backlog issue
-  - `code-review` — review a diff/PR against build plan §5 / AGENTS.md
-  - `bugfix` — reproduce → failing test → minimal fix → verify
-- If a local `.claude/skills/code-review/SKILL.md` is present, it should
-  defer to `.cursor/skills/code-review/SKILL.md` rather than diverge.
+- Project skill available: `code-review` (`.claude/skills/code-review/SKILL.md`)
+  — reviews a diff/PR against the Agent Working Agreement in
+  docs/GOMBIT_BUILD_PLAN.md §5. Invoke with `/code-review` or ask to review a
+  PR/diff; it overrides the bundled `/code-review` for this repo.
 - This repo has no source tree yet (see AGENTS.md "Current state"). Prefer a
   direct `Read` of `docs/GOMBIT_BUILD_PLAN.md` over spawning an Explore
   subagent for backlog/dependency lookups — there's nothing to search yet.
 - When creating or editing GitHub issues, keep the `[ID]` title prefix and the
   milestone/label mapping from build plan §6. Don't rename, re-bucket, or
   merge existing issues without being asked.
+
+## Cursor skills
+
+Cursor counterparts live under `.cursor/skills/` (`create-feature`,
+`code-review`, `bugfix`). Keep the Claude `code-review` skill and the Cursor
+`code-review` skill aligned with this file and AGENTS.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,13 @@
 
 ## Claude Code
 
-- Project skill available: `code-review` (`.claude/skills/code-review/SKILL.md`)
-  — reviews a diff/PR against the Agent Working Agreement in
-  docs/GOMBIT_BUILD_PLAN.md §5. Invoke with `/code-review` or ask to review a
-  PR/diff; it overrides the bundled `/code-review` for this repo.
+- Canonical project skills live under `.cursor/skills/` (Cursor + Agent
+  Skills standard). Use those workflows even when invoking from Claude Code:
+  - `create-feature` — implement one `[ID]` backlog issue
+  - `code-review` — review a diff/PR against build plan §5 / AGENTS.md
+  - `bugfix` — reproduce → failing test → minimal fix → verify
+- If a local `.claude/skills/code-review/SKILL.md` is present, it should
+  defer to `.cursor/skills/code-review/SKILL.md` rather than diverge.
 - This repo has no source tree yet (see AGENTS.md "Current state"). Prefer a
   direct `Read` of `docs/GOMBIT_BUILD_PLAN.md` over spawning an Explore
   subagent for backlog/dependency lookups — there's nothing to search yet.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds project Agent Skills under `.cursor/skills/` so Cursor (and other Agent Skills clients) can run Gombit's three core workflows instead of generic coding habits.

The skills are derived from `AGENTS.md`, `CLAUDE.md`, and the locked decisions in `docs/GOMBIT_BUILD_PLAN.md` §1–§5. They also incorporate current Agent Skills authoring guidance (lean `SKILL.md`, third-person trigger descriptions, progressive disclosure via `references/`) and project-specific practice: Huma-over-Gin contracts, feature-packages, Atlas migrations, D10 envelopes, JWT-in-memory, and extract-don't-rewrite.

## Skills

| Skill | When to use |
| --- | --- |
| `/create-feature` | Implement one `[ID]` backlog issue or new capability |
| `/code-review` | Review a diff/PR against the agent working agreement |
| `/bugfix` | Reproduce → failing test → minimal root-cause fix → verify |

`AGENTS.md` still documents the Claude Code `code-review` skill at `.claude/skills/code-review/SKILL.md` (that path is now a real skill, kept in sync with the Cursor counterpart). Cursor skills are listed in a separate section.

## Notes

- This repo is still pre-code. Each skill tells the agent to verify the tree before assuming a Go layout exists.
- Detailed layout, contract, auth, and review checklists live in `references/` so the skill bodies stay short.
- No runtime or CI changes.

## Testing

- [x] Frontmatter `name` matches each skill folder
- [x] Skills stay well under the ~500-line `SKILL.md` budget
- [x] Cross-links to `AGENTS.md` and the build plan are accurate
- [x] Claude `code-review` pointer in `AGENTS.md` / `CLAUDE.md` is preserved
- [ ] Human: invoke `/create-feature`, `/code-review`, and `/bugfix` in Cursor and confirm they load

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08a37fe9-d20e-4158-9d95-8f1ef20b13a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08a37fe9-d20e-4158-9d95-8f1ef20b13a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

