### PR TITLE
feat: add typed config boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,12 @@ a generated React+TypeScript frontend, Atlas-backed migrations. Module path
 
 ## Current state
 
-This repo is in the **M0 spike** stage. It has a root `go.mod`, a minimal root
-Go package, CI/lint wiring, docs, and the M0-2 Huma-over-Gin contract spike
-under `internal/contractspike`. It does not yet have stable runtime framework
-source, generated app templates, migrations, frontend source, or example apps.
+This repo has completed the **M0 spike** and is beginning **M1 runtime** work.
+It has a root `go.mod`, a minimal root Go package, CI/lint wiring, docs,
+ADR-011, the M0-2 Huma-over-Gin contract spike under `internal/contractspike`,
+and the initial public `config.Config` boundary with `examples/config`. It does
+not yet have stable runtime framework source beyond that config boundary,
+generated app templates, migrations, frontend source, or full example apps.
 Don't assume a runtime codebase layout exists; check `git log` / `ls` before
 describing "how the code works."
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,11 @@
   — reviews a diff/PR against the Agent Working Agreement in
   docs/GOMBIT_BUILD_PLAN.md §5. Invoke with `/code-review` or ask to review a
   PR/diff; it overrides the bundled `/code-review` for this repo.
-- This repo is in the M0 spike stage (see AGENTS.md "Current state").
+- This repo has completed M0 and is beginning M1 runtime work (see AGENTS.md
+  "Current state").
   Prefer a direct `Read` of `docs/GOMBIT_BUILD_PLAN.md` over spawning an
   Explore subagent for backlog/dependency lookups — there is no stable runtime
-  source tree yet.
+  source tree yet beyond the initial public `config.Config` boundary.
 - When creating or editing GitHub issues, keep the `[ID]` title prefix and the
   milestone/label mapping from build plan §6. Don't rename, re-bucket, or
   merge existing issues without being asked.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Gombit
 
-Gombit is a Django-for-Go full-stack framework. The current repository is in
-the M0 spike stage and contains the module skeleton, project documentation,
-CI wiring, and the M0-2 Huma-over-Gin contract spike.
+Gombit is a Django-for-Go full-stack framework. The current repository has
+completed the M0 spike and contains the module skeleton, project documentation,
+CI wiring, ADR-011, and the Huma-over-Gin contract spike.
 
 ## Development
 
@@ -21,3 +21,4 @@ The authoritative implementation backlog and architecture decisions live in
 [`docs/GOMBIT_BUILD_PLAN.md`](docs/GOMBIT_BUILD_PLAN.md).
 
 Accepted architecture decisions are recorded under [`docs/adr/`](docs/adr/).
+Runtime configuration is documented in [`docs/config.md`](docs/config.md).

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,184 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	envAppName   = "GOMBIT_APP_NAME"
+	envEnv       = "GOMBIT_ENV"
+	envHTTPAddr  = "GOMBIT_HTTP_ADDR"
+	envAPIPrefix = "GOMBIT_API_PREFIX"
+)
+
+// Environment is the runtime environment name.
+type Environment string
+
+const (
+	// EnvironmentDevelopment is the default local development environment.
+	EnvironmentDevelopment Environment = "development"
+	// EnvironmentTest is used by tests and ephemeral verification.
+	EnvironmentTest Environment = "test"
+	// EnvironmentProduction is used by deployed production applications.
+	EnvironmentProduction Environment = "production"
+)
+
+// Config is the typed configuration consumed by Gombit runtime packages.
+type Config struct {
+	AppName     string
+	Environment Environment
+	HTTP        HTTPConfig
+	API         APIConfig
+}
+
+// HTTPConfig contains HTTP server configuration.
+type HTTPConfig struct {
+	Addr string
+}
+
+// APIConfig contains public API configuration.
+type APIConfig struct {
+	Prefix string
+}
+
+// EnvLookup reads an environment variable by name.
+type EnvLookup func(key string) (value string, ok bool)
+
+// Default returns the default development configuration.
+func Default() Config {
+	return Config{
+		AppName:     "Gombit",
+		Environment: EnvironmentDevelopment,
+		HTTP: HTTPConfig{
+			Addr: ":8080",
+		},
+		API: APIConfig{
+			Prefix: "/api/v1",
+		},
+	}
+}
+
+// Load reads configuration from the process environment and validates it.
+func Load() (Config, error) {
+	return LoadFromEnv(os.LookupEnv)
+}
+
+// LoadFromEnv reads configuration through lookup and validates it.
+func LoadFromEnv(lookup EnvLookup) (Config, error) {
+	if lookup == nil {
+		return Config{}, errors.New("config: nil environment lookup")
+	}
+
+	cfg := Default()
+	applyString(lookup, envAppName, &cfg.AppName)
+	applyEnvironment(lookup, envEnv, &cfg.Environment)
+	applyString(lookup, envHTTPAddr, &cfg.HTTP.Addr)
+	applyString(lookup, envAPIPrefix, &cfg.API.Prefix)
+
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
+}
+
+// Validate returns explicit field errors for invalid configuration values.
+func (c Config) Validate() error {
+	var errs FieldErrors
+
+	if strings.TrimSpace(c.AppName) == "" {
+		errs = append(errs, FieldError{
+			Field:   "AppName",
+			Env:     envAppName,
+			Value:   c.AppName,
+			Message: "must not be empty",
+		})
+	}
+
+	switch c.Environment {
+	case EnvironmentDevelopment, EnvironmentTest, EnvironmentProduction:
+	default:
+		errs = append(errs, FieldError{
+			Field:   "Environment",
+			Env:     envEnv,
+			Value:   string(c.Environment),
+			Message: "must be one of development, test, production",
+		})
+	}
+
+	if strings.TrimSpace(c.HTTP.Addr) == "" {
+		errs = append(errs, FieldError{
+			Field:   "HTTP.Addr",
+			Env:     envHTTPAddr,
+			Value:   c.HTTP.Addr,
+			Message: "must not be empty",
+		})
+	}
+
+	if !strings.HasPrefix(c.API.Prefix, "/") {
+		errs = append(errs, FieldError{
+			Field:   "API.Prefix",
+			Env:     envAPIPrefix,
+			Value:   c.API.Prefix,
+			Message: "must start with /",
+		})
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
+}
+
+func applyString(lookup EnvLookup, key string, dest *string) {
+	if value, ok := lookup(key); ok {
+		*dest = strings.TrimSpace(value)
+	}
+}
+
+func applyEnvironment(lookup EnvLookup, key string, dest *Environment) {
+	if value, ok := lookup(key); ok {
+		*dest = Environment(strings.TrimSpace(value))
+	}
+}
+
+// FieldError is one explicit configuration validation failure.
+type FieldError struct {
+	Field   string
+	Env     string
+	Value   string
+	Message string
+}
+
+// Error returns a human-readable validation message.
+func (e FieldError) Error() string {
+	if e.Env == "" {
+		return fmt.Sprintf("%s: %s", e.Field, e.Message)
+	}
+
+	return fmt.Sprintf("%s (%s): %s", e.Field, e.Env, e.Message)
+}
+
+// FieldErrors is a set of configuration validation failures.
+type FieldErrors []FieldError
+
+// Error returns a human-readable validation summary.
+func (e FieldErrors) Error() string {
+	switch len(e) {
+	case 0:
+		return "config: no validation errors"
+	case 1:
+		return "config: " + e[0].Error()
+	default:
+		var b strings.Builder
+		fmt.Fprintf(&b, "config: %d validation errors:", len(e))
+		for _, err := range e {
+			fmt.Fprintf(&b, " %s", err.Error())
+		}
+		return b.String()
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,6 +55,43 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvUsesDefaultsWhenUnset(t *testing.T) {
+	got, err := LoadFromEnv(mapLookup(nil))
+	if err != nil {
+		t.Fatalf("LoadFromEnv() error = %v, want nil", err)
+	}
+
+	if !reflect.DeepEqual(got, Default()) {
+		t.Fatalf("LoadFromEnv() = %#v, want default %#v", got, Default())
+	}
+}
+
+func TestLoadUsesProcessEnvironment(t *testing.T) {
+	t.Setenv(envAppName, "Process Example")
+	t.Setenv(envEnv, string(EnvironmentProduction))
+	t.Setenv(envHTTPAddr, ":9090")
+	t.Setenv(envAPIPrefix, "/api")
+
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+
+	want := Config{
+		AppName:     "Process Example",
+		Environment: EnvironmentProduction,
+		HTTP: HTTPConfig{
+			Addr: ":9090",
+		},
+		API: APIConfig{
+			Prefix: "/api",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Load() = %#v, want %#v", got, want)
+	}
+}
+
 func TestLoadFromEnvRequiresLookup(t *testing.T) {
 	_, err := LoadFromEnv(nil)
 	if err == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDefault(t *testing.T) {
+	got := Default()
+
+	if got.AppName != "Gombit" {
+		t.Fatalf("AppName = %q, want %q", got.AppName, "Gombit")
+	}
+	if got.Environment != EnvironmentDevelopment {
+		t.Fatalf("Environment = %q, want %q", got.Environment, EnvironmentDevelopment)
+	}
+	if got.HTTP.Addr != ":8080" {
+		t.Fatalf("HTTP.Addr = %q, want %q", got.HTTP.Addr, ":8080")
+	}
+	if got.API.Prefix != "/api/v1" {
+		t.Fatalf("API.Prefix = %q, want %q", got.API.Prefix, "/api/v1")
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestLoadFromEnv(t *testing.T) {
+	env := map[string]string{
+		envAppName:   " Example ",
+		envEnv:       " test ",
+		envHTTPAddr:  " 127.0.0.1:9000 ",
+		envAPIPrefix: " /api ",
+	}
+
+	got, err := LoadFromEnv(mapLookup(env))
+	if err != nil {
+		t.Fatalf("LoadFromEnv() error = %v, want nil", err)
+	}
+
+	want := Config{
+		AppName:     "Example",
+		Environment: EnvironmentTest,
+		HTTP: HTTPConfig{
+			Addr: "127.0.0.1:9000",
+		},
+		API: APIConfig{
+			Prefix: "/api",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("LoadFromEnv() = %#v, want %#v", got, want)
+	}
+}
+
+func TestLoadFromEnvRequiresLookup(t *testing.T) {
+	_, err := LoadFromEnv(nil)
+	if err == nil {
+		t.Fatal("LoadFromEnv(nil) error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "nil environment lookup") {
+		t.Fatalf("LoadFromEnv(nil) error = %q, want nil lookup message", err)
+	}
+}
+
+func TestValidateReportsExplicitFieldErrors(t *testing.T) {
+	cfg := Config{
+		AppName:     " ",
+		Environment: "staging",
+		HTTP: HTTPConfig{
+			Addr: "",
+		},
+		API: APIConfig{
+			Prefix: "api",
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want validation errors")
+	}
+
+	var fieldErrors FieldErrors
+	if !errors.As(err, &fieldErrors) {
+		t.Fatalf("Validate() error type = %T, want FieldErrors", err)
+	}
+
+	want := []FieldError{
+		{Field: "AppName", Env: envAppName, Value: " ", Message: "must not be empty"},
+		{
+			Field:   "Environment",
+			Env:     envEnv,
+			Value:   "staging",
+			Message: "must be one of development, test, production",
+		},
+		{Field: "HTTP.Addr", Env: envHTTPAddr, Value: "", Message: "must not be empty"},
+		{Field: "API.Prefix", Env: envAPIPrefix, Value: "api", Message: "must start with /"},
+	}
+	if !reflect.DeepEqual([]FieldError(fieldErrors), want) {
+		t.Fatalf("Validate() field errors = %#v, want %#v", []FieldError(fieldErrors), want)
+	}
+
+	message := err.Error()
+	for _, wantPart := range []string{envAppName, envEnv, envHTTPAddr, envAPIPrefix} {
+		if !strings.Contains(message, wantPart) {
+			t.Fatalf("Validate() error = %q, want it to contain %q", message, wantPart)
+		}
+	}
+}
+
+func TestLoadFromEnvReturnsValidationErrors(t *testing.T) {
+	_, err := LoadFromEnv(mapLookup(map[string]string{
+		envEnv:       "prod",
+		envAPIPrefix: "api",
+	}))
+	if err == nil {
+		t.Fatal("LoadFromEnv() error = nil, want validation errors")
+	}
+
+	var fieldErrors FieldErrors
+	if !errors.As(err, &fieldErrors) {
+		t.Fatalf("LoadFromEnv() error type = %T, want FieldErrors", err)
+	}
+	if len(fieldErrors) != 2 {
+		t.Fatalf("LoadFromEnv() field error count = %d, want 2", len(fieldErrors))
+	}
+}
+
+func mapLookup(values map[string]string) EnvLookup {
+	return func(key string) (string, bool) {
+		value, ok := values[key]
+		return value, ok
+	}
+}

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,0 +1,5 @@
+// Package config provides Gombit's typed configuration boundary.
+//
+// Runtime packages should receive Config values instead of reading environment
+// variables directly.
+package config

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,32 @@
+# Typed Configuration
+
+Gombit's runtime packages receive typed configuration through
+`config.Config`. Environment reads belong at this boundary, not in low-level
+runtime packages.
+
+## Defaults
+
+`config.Default()` returns the current development defaults:
+
+- app name: `Gombit`
+- environment: `development`
+- HTTP address: `:8080`
+- API prefix: `/api/v1`
+
+## Environment
+
+`config.Load()` reads the process environment and validates the resulting
+configuration. The M1-1 boundary recognizes:
+
+| Variable | Field | Default |
+| --- | --- | --- |
+| `GOMBIT_APP_NAME` | `Config.AppName` | `Gombit` |
+| `GOMBIT_ENV` | `Config.Environment` | `development` |
+| `GOMBIT_HTTP_ADDR` | `Config.HTTP.Addr` | `:8080` |
+| `GOMBIT_API_PREFIX` | `Config.API.Prefix` | `/api/v1` |
+
+Validation returns `config.FieldErrors`, which names the typed field, the
+environment variable, the invalid value, and the validation message.
+
+Runtime extraction work should accept `config.Config` values instead of calling
+`os.Getenv` or `os.LookupEnv` directly.

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,8 +25,17 @@ configuration. The M1-1 boundary recognizes:
 | `GOMBIT_HTTP_ADDR` | `Config.HTTP.Addr` | `:8080` |
 | `GOMBIT_API_PREFIX` | `Config.API.Prefix` | `/api/v1` |
 
+`GOMBIT_ENV` accepts the exact lowercase values `development`, `test`, and
+`production`.
+
 Validation returns `config.FieldErrors`, which names the typed field, the
 environment variable, the invalid value, and the validation message.
+
+Appendix C production checks, such as JWT secret strength, secure cookies,
+CORS credentials, debug Gin mode, database settings, and Redis settings, land
+with the features that introduce those typed fields. This boundary only
+validates the keys listed above. Future secret-bearing fields must not copy
+secret values into `FieldError.Value`.
 
 Runtime extraction work should accept `config.Config` values instead of calling
 `os.Getenv` or `os.LookupEnv` directly.

--- a/examples/config/main.go
+++ b/examples/config/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%s listens on %s with API prefix %s\n", cfg.AppName, cfg.HTTP.Addr, cfg.API.Prefix)
+}


### PR DESCRIPTION
## Summary

Adds the M1-1 typed configuration boundary as package config. Runtime packages can consume config.Config instead of reading process environment directly.

This PR adds config.Default, config.Load, config.LoadFromEnv, typed config structs, explicit FieldErrors validation, unit tests, docs/config.md, and a compiling examples/config app.

Closes #4

## Acceptance criteria

- No os.Getenv calls exist outside config; source env lookup is confined to config.Load using os.LookupEnv.
- Existing behavior is unchanged because no prior runtime config consumers existed; defaults preserve the current development assumptions.
- Config validation errors are explicit through FieldErrors with field, env name, value, and message.

## Validation

- go test ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run
- environment-read search confirmed only config uses process env lookup in source
- Project code-review checklist: no blockers or major issues found.