### PR TITLE
feat: add framework app lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,10 @@ a generated React+TypeScript frontend, Atlas-backed migrations. Module path
 This repo has completed the **M0 spike** and is beginning **M1 runtime** work.
 It has a root `go.mod`, a minimal root Go package, CI/lint wiring, docs,
 ADR-011, the M0-2 Huma-over-Gin contract spike under `internal/contractspike`,
-and the initial public `config.Config` boundary with `examples/config`. It does
-not yet have stable runtime framework source beyond that config boundary,
-generated app templates, migrations, frontend source, or full example apps.
+the initial public `config.Config` boundary with `examples/config`, and the
+initial `framework.App` lifecycle surface with `examples/lifecycle`. It does not
+yet have stable runtime framework source beyond those M1 surfaces, generated
+app templates, migrations, frontend source, or full example apps.
 Don't assume a runtime codebase layout exists; check `git log` / `ls` before
 describing "how the code works."
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@
   "Current state").
   Prefer a direct `Read` of `docs/GOMBIT_BUILD_PLAN.md` over spawning an
   Explore subagent for backlog/dependency lookups — there is no stable runtime
-  source tree yet beyond the initial public `config.Config` boundary.
+  source tree yet beyond the initial public `config.Config` boundary and
+  `framework.App` lifecycle surface.
 - When creating or editing GitHub issues, keep the `[ID]` title prefix and the
   milestone/label mapping from build plan §6. Don't rename, re-bucket, or
   merge existing issues without being asked.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Gombit
 
 Gombit is a Django-for-Go full-stack framework. The current repository has
-completed the M0 spike and contains the module skeleton, project documentation,
-CI wiring, ADR-011, and the Huma-over-Gin contract spike.
+completed the M0 spike and is beginning M1 runtime work with typed config and
+the initial `framework.App` lifecycle surface.
 
 ## Development
 
@@ -22,3 +22,4 @@ The authoritative implementation backlog and architecture decisions live in
 
 Accepted architecture decisions are recorded under [`docs/adr/`](docs/adr/).
 Runtime configuration is documented in [`docs/config.md`](docs/config.md).
+Application lifecycle is documented in [`docs/lifecycle.md`](docs/lifecycle.md).

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -23,14 +23,44 @@ return framework.Run(app)
 
 Start hooks run in registration order. Stop hooks run in reverse registration
 order so cleanup unwinds deterministically. Stop hooks receive a bounded
-shutdown context; the default timeout is 10 seconds.
+shutdown context; the default timeout is 10 seconds. Stop hooks also run after
+a start-hook failure, so they must tolerate partial application startup and be
+safe to call when the resource they clean up was never initialized.
+
+`RunContext` binds the listener before start hooks run, which lets hooks read
+`App.Addr()` even when the configured HTTP address uses port `0`. The HTTP
+server starts serving only after all start hooks succeed.
 
 `App.Router()` exposes the underlying `*gin.Engine` as the raw Gin escape hatch
 required by ADR-011. Public API routes that belong in OpenAPI still need Huma
 typed handlers in later contract work.
 
-The M1-2 runtime owns the lifecycle skeleton from the design doc: typed config,
-HTTP server construction, basic runtime probes, signal handling, graceful
-shutdown, and dependency cleanup hooks. Database, migrations, cache, auth,
-observability, middleware parity, and embedded frontend mounting remain scoped
-to later backlog issues.
+The default router installs `gin.Recovery()` so panics in runtime probes or raw
+Gin escape-hatch handlers do not terminate the process. Production config sets
+Gin release mode before the default router is constructed.
+
+## Lifecycle Ownership
+
+M1-2 introduces the framework-owned skeleton. Later issues fill in the lifecycle
+steps that need their own runtime surfaces.
+
+| Step | Status |
+| --- | --- |
+| 1. config loading | Owned in M1-1/M1-2 through `config.Config` and `framework.New`. |
+| 2. logging initialization | Deferred to M1-6. |
+| 3. database connection | Deferred to M1-4. |
+| 4. migration state checks | Deferred to M2. |
+| 5. optional Redis/cache connection | Deferred to M1-5. |
+| 6. auth infrastructure | Deferred to M5. |
+| 7. tracing and metrics | Deferred to M1-7. |
+| 8. HTTP server construction | Owned in M1-2 through `framework.Run` and `RunContext`. |
+| 9. middleware installation | Recovery is owned in M1-2; full middleware parity is deferred to M1-3/M1-7. |
+| 10. module registration | Deferred to M1-3. |
+| 11. readiness/liveness endpoints | Basic raw Gin probes are owned in M1-2; DB/cache-aware readiness is deferred to M1-4/M1-5. |
+| 12. frontend static asset mounting when embedded | Deferred to M5-5. |
+| 13. signal handling | Owned in M1-2 through `framework.Run`. |
+| 14. graceful shutdown | Owned in M1-2 through bounded `http.Server.Shutdown`. |
+| 15. dependency cleanup | Owned in M1-2 through `OnStop`; concrete DB/cache/log sink cleanup lands with those features. |
+
+The current probes are raw Gin routes with D10-style success bodies. They must
+remain outside generated OpenAPI when Huma is mounted in later contract work.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,0 +1,36 @@
+# Application Lifecycle
+
+The `framework` package owns the application lifecycle introduced in M1-2.
+Applications construct an `App`, register optional hooks, and run it through
+`framework.Run`.
+
+```go
+app, err := framework.New()
+if err != nil {
+    return err
+}
+
+app.OnStart(func(ctx context.Context) error {
+    return nil
+})
+
+app.OnStop(func(ctx context.Context) error {
+    return nil
+})
+
+return framework.Run(app)
+```
+
+Start hooks run in registration order. Stop hooks run in reverse registration
+order so cleanup unwinds deterministically. Stop hooks receive a bounded
+shutdown context; the default timeout is 10 seconds.
+
+`App.Router()` exposes the underlying `*gin.Engine` as the raw Gin escape hatch
+required by ADR-011. Public API routes that belong in OpenAPI still need Huma
+typed handlers in later contract work.
+
+The M1-2 runtime owns the lifecycle skeleton from the design doc: typed config,
+HTTP server construction, basic runtime probes, signal handling, graceful
+shutdown, and dependency cleanup hooks. Database, migrations, cache, auth,
+observability, middleware parity, and embedded frontend mounting remain scoped
+to later backlog issues.

--- a/examples/lifecycle/main.go
+++ b/examples/lifecycle/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+
+	"github.com/LAA-Software-Engineering/gombit/framework"
+)
+
+func main() {
+	app, err := framework.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := framework.Run(app); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/framework/app.go
+++ b/framework/app.go
@@ -1,0 +1,303 @@
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/gin-gonic/gin"
+)
+
+const defaultShutdownTimeout = 10 * time.Second
+
+// Hook is an application lifecycle callback.
+type Hook func(context.Context) error
+
+// Option configures an App.
+type Option func(*App) error
+
+// App owns Gombit's runtime lifecycle and HTTP router.
+type App struct {
+	cfg             config.Config
+	cfgSet          bool
+	router          *gin.Engine
+	startHooks      []Hook
+	stopHooks       []Hook
+	shutdownTimeout time.Duration
+
+	mu     sync.RWMutex
+	server *http.Server
+	addr   string
+}
+
+// New creates an application using process configuration and the default router.
+func New(options ...Option) (*App, error) {
+	app := &App{
+		cfg:             config.Default(),
+		router:          newRouter(),
+		shutdownTimeout: defaultShutdownTimeout,
+	}
+
+	for _, option := range options {
+		if option == nil {
+			continue
+		}
+		if err := option(app); err != nil {
+			return nil, err
+		}
+	}
+
+	if !app.cfgSet {
+		cfg, err := config.Load()
+		if err != nil {
+			return nil, err
+		}
+		app.cfg = cfg
+	}
+
+	if err := app.cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if app.router == nil {
+		return nil, errors.New("framework: nil router")
+	}
+	if app.shutdownTimeout <= 0 {
+		return nil, errors.New("framework: shutdown timeout must be positive")
+	}
+
+	return app, nil
+}
+
+// WithConfig sets the app configuration.
+func WithConfig(cfg config.Config) Option {
+	return func(app *App) error {
+		if err := cfg.Validate(); err != nil {
+			return err
+		}
+		app.cfg = cfg
+		app.cfgSet = true
+		return nil
+	}
+}
+
+// WithRouter sets the app router.
+func WithRouter(router *gin.Engine) Option {
+	return func(app *App) error {
+		if router == nil {
+			return errors.New("framework: nil router")
+		}
+		app.router = router
+		return nil
+	}
+}
+
+// WithShutdownTimeout sets the bounded shutdown timeout.
+func WithShutdownTimeout(timeout time.Duration) Option {
+	return func(app *App) error {
+		if timeout <= 0 {
+			return errors.New("framework: shutdown timeout must be positive")
+		}
+		app.shutdownTimeout = timeout
+		return nil
+	}
+}
+
+// Config returns the typed app configuration.
+func (a *App) Config() config.Config {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.cfg
+}
+
+// Router returns the underlying Gin router escape hatch.
+func (a *App) Router() *gin.Engine {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.router
+}
+
+// Addr returns the bound HTTP address after the app has started.
+func (a *App) Addr() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.addr
+}
+
+// OnStart registers a start hook. Hooks run in registration order.
+func (a *App) OnStart(hook Hook) {
+	if hook == nil {
+		return
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.startHooks = append(a.startHooks, hook)
+}
+
+// OnStop registers a stop hook. Hooks run in reverse registration order.
+func (a *App) OnStop(hook Hook) {
+	if hook == nil {
+		return
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stopHooks = append(a.stopHooks, hook)
+}
+
+// Run runs app until an interrupt or terminate signal is received.
+func Run(app *App) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return RunContext(ctx, app)
+}
+
+// RunContext runs app until ctx is canceled or the HTTP server fails.
+func RunContext(ctx context.Context, app *App) error {
+	if ctx == nil {
+		return errors.New("framework: nil context")
+	}
+	if app == nil {
+		return errors.New("framework: nil app")
+	}
+
+	listener, err := net.Listen("tcp", app.Config().HTTP.Addr)
+	if err != nil {
+		return fmt.Errorf("framework: listen: %w", err)
+	}
+
+	server := &http.Server{
+		Handler:           app.Router(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	app.setServer(server, listener.Addr().String())
+
+	if err := app.runStartHooks(ctx); err != nil {
+		_ = listener.Close()
+		return errors.Join(err, app.runStopHooks())
+	}
+
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+			return
+		}
+		serverErr <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		if err := app.shutdown(); err != nil {
+			return err
+		}
+		if err := <-serverErr; err != nil {
+			return fmt.Errorf("framework: serve: %w", err)
+		}
+		return nil
+	case err := <-serverErr:
+		stopErr := app.runStopHooks()
+		if err != nil {
+			return errors.Join(fmt.Errorf("framework: serve: %w", err), stopErr)
+		}
+		return stopErr
+	}
+}
+
+func (a *App) setServer(server *http.Server, addr string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.server = server
+	a.addr = addr
+}
+
+func (a *App) snapshotStartHooks() []Hook {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return append([]Hook(nil), a.startHooks...)
+}
+
+func (a *App) snapshotStopHooks() []Hook {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return append([]Hook(nil), a.stopHooks...)
+}
+
+func (a *App) runStartHooks(ctx context.Context) error {
+	for i, hook := range a.snapshotStartHooks() {
+		if err := hook(ctx); err != nil {
+			return fmt.Errorf("framework: start hook %d: %w", i+1, err)
+		}
+	}
+	return nil
+}
+
+func (a *App) shutdown() error {
+	a.mu.RLock()
+	server := a.server
+	timeout := a.shutdownTimeout
+	a.mu.RUnlock()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if server != nil {
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return errors.Join(
+				fmt.Errorf("framework: shutdown: %w", err),
+				a.runStopHooksWithContext(shutdownCtx),
+			)
+		}
+	}
+
+	return a.runStopHooksWithContext(shutdownCtx)
+}
+
+func (a *App) runStopHooks() error {
+	a.mu.RLock()
+	timeout := a.shutdownTimeout
+	a.mu.RUnlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return a.runStopHooksWithContext(ctx)
+}
+
+func (a *App) runStopHooksWithContext(ctx context.Context) error {
+	hooks := a.snapshotStopHooks()
+	var joined error
+	for i := len(hooks) - 1; i >= 0; i-- {
+		if err := hooks[i](ctx); err != nil {
+			joined = errors.Join(joined, fmt.Errorf("framework: stop hook %d: %w", i+1, err))
+		}
+	}
+	return joined
+}
+
+func newRouter() *gin.Engine {
+	router := gin.New()
+	router.GET("/livez", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"data": gin.H{
+				"status": "ok",
+			},
+		})
+	})
+	router.GET("/readyz", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"data": gin.H{
+				"status": "ok",
+			},
+		})
+	})
+	return router
+}

--- a/framework/app.go
+++ b/framework/app.go
@@ -42,7 +42,6 @@ type App struct {
 func New(options ...Option) (*App, error) {
 	app := &App{
 		cfg:             config.Default(),
-		router:          newRouter(),
 		shutdownTimeout: defaultShutdownTimeout,
 	}
 
@@ -66,11 +65,12 @@ func New(options ...Option) (*App, error) {
 	if err := app.cfg.Validate(); err != nil {
 		return nil, err
 	}
-	if app.router == nil {
-		return nil, errors.New("framework: nil router")
-	}
 	if app.shutdownTimeout <= 0 {
 		return nil, errors.New("framework: shutdown timeout must be positive")
+	}
+	configureHTTPMode(app.cfg)
+	if app.router == nil {
+		app.router = newRouter()
 	}
 
 	return app, nil
@@ -285,6 +285,7 @@ func (a *App) runStopHooksWithContext(ctx context.Context) error {
 
 func newRouter() *gin.Engine {
 	router := gin.New()
+	router.Use(gin.Recovery())
 	router.GET("/livez", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"data": gin.H{
@@ -300,4 +301,10 @@ func newRouter() *gin.Engine {
 		})
 	})
 	return router
+}
+
+func configureHTTPMode(cfg config.Config) {
+	if cfg.Environment == config.EnvironmentProduction {
+		gin.SetMode(gin.ReleaseMode)
+	}
 }

--- a/framework/app_test.go
+++ b/framework/app_test.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"reflect"
 	"sync"
@@ -143,6 +144,52 @@ func TestStopHooksReceiveBoundedShutdownContext(t *testing.T) {
 	}
 }
 
+func TestDefaultRouterRecoversFromPanics(t *testing.T) {
+	app := newTestApp(t)
+	app.Router().GET("/panic", func(c *gin.Context) {
+		panic("boom")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- RunContext(ctx, app)
+	}()
+
+	waitForHTTP(t, app, "/livez")
+	resp := getHTTP(t, app, "/panic")
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("GET /panic status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+
+	cancel()
+	if err := waitRun(done); err != nil {
+		t.Fatalf("RunContext() error = %v, want nil", err)
+	}
+}
+
+func TestProductionConfigSetsGinReleaseMode(t *testing.T) {
+	previousMode := gin.Mode()
+	t.Cleanup(func() {
+		gin.SetMode(previousMode)
+	})
+
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentProduction
+	cfg.HTTP.Addr = "127.0.0.1:0"
+
+	_, err := New(WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	if got := gin.Mode(); got != gin.ReleaseMode {
+		t.Fatalf("gin.Mode() = %q, want %q", got, gin.ReleaseMode)
+	}
+}
+
 func TestNewValidatesOptions(t *testing.T) {
 	_, err := New(WithShutdownTimeout(0))
 	if err == nil {
@@ -168,6 +215,7 @@ func newTestApp(t *testing.T, options ...Option) *App {
 func waitForHTTP(t *testing.T, app *App, path string) {
 	t.Helper()
 
+	client := &http.Client{Timeout: 100 * time.Millisecond}
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		addr := app.Addr()
@@ -176,7 +224,7 @@ func waitForHTTP(t *testing.T, app *App, path string) {
 			continue
 		}
 
-		resp, err := http.Get("http://" + addr + path)
+		resp, err := client.Get("http://" + addr + path)
 		if err == nil {
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -186,6 +234,28 @@ func waitForHTTP(t *testing.T, app *App, path string) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for %s on %s", path, app.Addr())
+}
+
+func getHTTP(t *testing.T, app *App, path string) *http.Response {
+	t.Helper()
+
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		addr := app.Addr()
+		if addr == "" {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+
+		resp, err := client.Get("http://" + addr + path)
+		if err == nil {
+			return resp
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s on %s", path, app.Addr())
+	return nil
 }
 
 func waitRun(done <-chan error) error {

--- a/framework/app_test.go
+++ b/framework/app_test.go
@@ -1,0 +1,198 @@
+package framework
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/gin-gonic/gin"
+)
+
+func TestRunContextBootsAndShutsDown(t *testing.T) {
+	app := newTestApp(t)
+	app.Router().GET("/ping", func(c *gin.Context) {
+		c.JSON(http.StatusOK, map[string]any{
+			"data": map[string]string{"status": "ok"},
+		})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunContext(ctx, app)
+	}()
+
+	waitForHTTP(t, app, "/livez")
+	waitForHTTP(t, app, "/ping")
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunContext() error = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunContext() did not shut down after context cancellation")
+	}
+}
+
+func TestHooksRunInDeterministicOrder(t *testing.T) {
+	app := newTestApp(t)
+	var (
+		mu    sync.Mutex
+		order []string
+	)
+	record := func(value string) Hook {
+		return func(ctx context.Context) error {
+			mu.Lock()
+			defer mu.Unlock()
+			order = append(order, value)
+			return nil
+		}
+	}
+
+	app.OnStart(record("start-1"))
+	app.OnStart(record("start-2"))
+	app.OnStop(record("stop-1"))
+	app.OnStop(record("stop-2"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunContext(ctx, app)
+	}()
+
+	waitForHTTP(t, app, "/readyz")
+	cancel()
+	if err := waitRun(done); err != nil {
+		t.Fatalf("RunContext() error = %v, want nil", err)
+	}
+
+	want := []string{"start-1", "start-2", "stop-2", "stop-1"}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("hook order = %#v, want %#v", order, want)
+	}
+}
+
+func TestStartFailureRunsStopHooks(t *testing.T) {
+	app := newTestApp(t)
+	startErr := errors.New("start failed")
+	var order []string
+
+	app.OnStart(func(ctx context.Context) error {
+		order = append(order, "start-1")
+		return nil
+	})
+	app.OnStart(func(ctx context.Context) error {
+		order = append(order, "start-2")
+		return startErr
+	})
+	app.OnStop(func(ctx context.Context) error {
+		order = append(order, "stop-1")
+		return nil
+	})
+	app.OnStop(func(ctx context.Context) error {
+		order = append(order, "stop-2")
+		return nil
+	})
+
+	err := RunContext(context.Background(), app)
+	if !errors.Is(err, startErr) {
+		t.Fatalf("RunContext() error = %v, want %v", err, startErr)
+	}
+
+	want := []string{"start-1", "start-2", "stop-2", "stop-1"}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("hook order = %#v, want %#v", order, want)
+	}
+}
+
+func TestStopHooksReceiveBoundedShutdownContext(t *testing.T) {
+	app := newTestApp(t, WithShutdownTimeout(250*time.Millisecond))
+	deadlineSeen := make(chan bool, 1)
+	app.OnStop(func(ctx context.Context) error {
+		_, ok := ctx.Deadline()
+		deadlineSeen <- ok
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunContext(ctx, app)
+	}()
+
+	waitForHTTP(t, app, "/livez")
+	cancel()
+	if err := waitRun(done); err != nil {
+		t.Fatalf("RunContext() error = %v, want nil", err)
+	}
+
+	select {
+	case got := <-deadlineSeen:
+		if !got {
+			t.Fatal("stop hook context had no deadline")
+		}
+	default:
+		t.Fatal("stop hook did not run")
+	}
+}
+
+func TestNewValidatesOptions(t *testing.T) {
+	_, err := New(WithShutdownTimeout(0))
+	if err == nil {
+		t.Fatal("New(WithShutdownTimeout(0)) error = nil, want error")
+	}
+}
+
+func newTestApp(t *testing.T, options ...Option) *App {
+	t.Helper()
+
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentTest
+	cfg.HTTP.Addr = "127.0.0.1:0"
+
+	options = append([]Option{WithConfig(cfg)}, options...)
+	app, err := New(options...)
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	return app
+}
+
+func waitForHTTP(t *testing.T, app *App, path string) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		addr := app.Addr()
+		if addr == "" {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+
+		resp, err := http.Get("http://" + addr + path)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s on %s", path, app.Addr())
+}
+
+func waitRun(done <-chan error) error {
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		return errors.New("RunContext did not return")
+	}
+}

--- a/framework/doc.go
+++ b/framework/doc.go
@@ -1,0 +1,2 @@
+// Package framework provides Gombit's runtime application lifecycle.
+package framework


### PR DESCRIPTION
## Summary

Adds the M1-2 framework App lifecycle surface.

This PR adds:

- public framework.App construction with typed config ownership
- framework.Run and framework.RunContext entrypoints
- OnStart and OnStop hooks with deterministic ordering
- bounded shutdown context for cleanup
- raw Gin Router access for the ADR-011 escape hatch
- basic livez and readyz runtime probes
- graceful shutdown and hook-order tests
- docs/lifecycle.md and examples/lifecycle
- current-state updates in AGENTS.md, CLAUDE.md, and README.md

Closes #5

## Acceptance criteria

- Minimal example boots via framework.Run in examples/lifecycle.
- Graceful shutdown test passes through framework.RunContext context cancellation.
- Hook ordering and bounded stop context are covered by tests.

## Scope notes

Database, migrations, cache, auth, observability parity, middleware parity, generated apps, and frontend embedding remain scoped to later backlog issues.

## Validation

- go test ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run
- project code-review checklist found no blockers or major issues.