### PR TITLE
feat: de-domain the router

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,12 @@ a generated React+TypeScript frontend, Atlas-backed migrations. Module path
 This repo has completed the **M0 spike** and is beginning **M1 runtime** work.
 It has a root `go.mod`, a minimal root Go package, CI/lint wiring, docs,
 ADR-011, the M0-2 Huma-over-Gin contract spike under `internal/contractspike`,
-the initial public `config.Config` boundary with `examples/config`, and the
-initial `framework.App` lifecycle surface with `examples/lifecycle`. It does not
-yet have stable runtime framework source beyond those M1 surfaces, generated
-app templates, migrations, frontend source, or full example apps.
+the initial public `config.Config` boundary with `examples/config`, the
+initial `framework.App` lifecycle surface with `examples/lifecycle`, and the
+application-owned route registration surface (M1-3) with `examples/router`.
+It does not yet have stable runtime framework source beyond those M1
+surfaces, generated app templates, migrations, frontend source, or full
+example apps.
 Don't assume a runtime codebase layout exists; check `git log` / `ls` before
 describing "how the code works."
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,9 @@
   "Current state").
   Prefer a direct `Read` of `docs/GOMBIT_BUILD_PLAN.md` over spawning an
   Explore subagent for backlog/dependency lookups — there is no stable runtime
-  source tree yet beyond the initial public `config.Config` boundary and
-  `framework.App` lifecycle surface.
+  source tree yet beyond the initial public `config.Config` boundary,
+  `framework.App` lifecycle surface, and application-owned route
+  registration surface.
 - When creating or editing GitHub issues, keep the `[ID]` title prefix and the
   milestone/label mapping from build plan §6. Don't rename, re-bucket, or
   merge existing issues without being asked.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Gombit
 
 Gombit is a Django-for-Go full-stack framework. The current repository has
-completed the M0 spike and is beginning M1 runtime work with typed config and
-the initial `framework.App` lifecycle surface.
+completed the M0 spike and is beginning M1 runtime work with typed config,
+the `framework.App` lifecycle surface, and application-owned route
+registration.
 
 ## Development
 
@@ -23,3 +24,4 @@ The authoritative implementation backlog and architecture decisions live in
 Accepted architecture decisions are recorded under [`docs/adr/`](docs/adr/).
 Runtime configuration is documented in [`docs/config.md`](docs/config.md).
 Application lifecycle is documented in [`docs/lifecycle.md`](docs/lifecycle.md).
+Application-owned route registration is documented in [`docs/router.md`](docs/router.md).

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -54,8 +54,8 @@ steps that need their own runtime surfaces.
 | 6. auth infrastructure | Deferred to M5. |
 | 7. tracing and metrics | Deferred to M1-7. |
 | 8. HTTP server construction | Owned in M1-2 through `framework.Run` and `RunContext`. |
-| 9. middleware installation | Recovery is owned in M1-2; full middleware parity is deferred to M1-3/M1-7. |
-| 10. module registration | Deferred to M1-3. |
+| 9. middleware installation | Recovery is owned in M1-2. Route-registration composition (independently-registered route groups, each with optional group-scoped middleware) is owned in M1-3 — see [`docs/router.md`](router.md). The concrete security/observability middleware set (CORS, security headers, rate limiting, request-id/timeout, trusted-proxy) is owned by M1-7. |
+| 10. module registration | Owned in M1-3 — applications register feature routes directly against `app.Router()`; see [`docs/router.md`](router.md). |
 | 11. readiness/liveness endpoints | Basic raw Gin probes are owned in M1-2; DB/cache-aware readiness is deferred to M1-4/M1-5. |
 | 12. frontend static asset mounting when embedded | Deferred to M5-5. |
 | 13. signal handling | Owned in M1-2 through `framework.Run`. |

--- a/docs/router.md
+++ b/docs/router.md
@@ -20,10 +20,11 @@ return framework.Run(app)
 ```
 
 Each `registerXRoutes` function is the runtime equivalent of a feature
-package's `routes.go` (build plan §3.2 / `.cursor/skills/create-feature`):
-registration is **explicit**, called from `main`, and never discovered
-through reflection (principle 6.2). `examples/router` demonstrates this with
-two independent toy route groups, `ping` and `echo`.
+package's `routes.go` (build plan §3.2 /
+`.cursor/skills/create-feature/references/layout.md`): registration is
+**explicit**, called from `main`, and never discovered through reflection
+(principle 6.2). `examples/router` demonstrates this with two independent
+toy route groups, `ping` and `echo`.
 
 ## No module/registry abstraction
 

--- a/docs/router.md
+++ b/docs/router.md
@@ -1,0 +1,71 @@
+# Application-Owned Route Registration
+
+M1-3 de-domains the router introduced in M1-2: `framework.New` builds a
+`*gin.Engine` with zero knowledge of any application domain and mounts only
+its own endpoints. Today that means `/livez` and `/readyz`; metrics and the
+OpenAPI document join later (M1-7, M3).
+
+Applications register their own routes directly against the escape hatch:
+
+```go
+app, err := framework.New()
+if err != nil {
+    return err
+}
+
+registerProductRoutes(app.Router())
+registerAccountRoutes(app.Router())
+
+return framework.Run(app)
+```
+
+Each `registerXRoutes` function is the runtime equivalent of a feature
+package's `routes.go` (build plan §3.2 / `.cursor/skills/create-feature`):
+registration is **explicit**, called from `main`, and never discovered
+through reflection (principle 6.2). `examples/router` demonstrates this with
+two independent toy route groups, `ping` and `echo`.
+
+## No module/registry abstraction
+
+Gombit does not provide a `Module` type, a route registry, or any
+composition layer beyond `*gin.Engine` itself. `app.Router()` already is the
+idiomatic mechanism: `router.Group(prefix)` gives a feature its own route
+group and its own group-scoped middleware, and two features registered this
+way cannot interfere with each other. Adding a bespoke abstraction on top
+would duplicate what Gin already does well and cut against the "no reflection
+discovery" principle — see `framework/router_test.go`'s
+`TestApplicationOwnedRouteRegistrationComposesIndependently`, which proves
+two independently-registered groups compose without cross-module leakage.
+
+## Middleware ordering
+
+Framework middleware installed before `New` returns — currently
+`gin.Recovery()` — wraps every route registered afterward, including
+application route groups and their own group-scoped middleware. Order is:
+
+```text
+framework middleware (e.g. Recovery)
+  -> feature group middleware (if any)
+    -> feature handler
+```
+
+`framework/router_test.go`'s `TestDefaultRouterMountsOnlyFrameworkEndpoints`
+and `TestApplicationOwnedRouteRegistrationComposesIndependently` cover this;
+`framework/app_test.go`'s `TestDefaultRouterRecoversFromPanics` covers
+Recovery still applying to an application-registered route.
+
+## What is not here yet
+
+This surface does not include CORS, security/XSS headers, rate limiting,
+request-id/timeout, trusted-proxy configuration, or authentication
+middleware. Those are extracted with their own runtime dependencies in later
+issues:
+
+- rate limiting and the cache interface: M1-5
+- Mongo-backed access logging: M1-6
+- request-id/timeout, security headers, trusted-proxy parity: M1-7
+- auth middleware: M5
+
+Until then, an application that needs one of these can add it directly via
+`app.Router().Use(...)` or on its own route groups; the framework will not
+silently reorder or override it.

--- a/examples/router/main.go
+++ b/examples/router/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/LAA-Software-Engineering/gombit/framework"
+	"github.com/gin-gonic/gin"
+)
+
+// registerPingRoutes stands in for a feature package's routes.go,
+// registered explicitly from main rather than discovered by the framework.
+func registerPingRoutes(router *gin.Engine) {
+	ping := router.Group("/ping")
+	ping.GET("", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "pong"}})
+	})
+}
+
+// registerEchoRoutes stands in for a second, independent feature package.
+func registerEchoRoutes(router *gin.Engine) {
+	echo := router.Group("/echo")
+	echo.POST("", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok"}})
+	})
+}
+
+func main() {
+	app, err := framework.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	registerPingRoutes(app.Router())
+	registerEchoRoutes(app.Router())
+
+	if err := framework.Run(app); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/framework/router_test.go
+++ b/framework/router_test.go
@@ -1,0 +1,147 @@
+package framework
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestDefaultRouterMountsOnlyFrameworkEndpoints(t *testing.T) {
+	app := newTestApp(t)
+
+	var got []string
+	for _, route := range app.Router().Routes() {
+		got = append(got, route.Method+" "+route.Path)
+	}
+	sort.Strings(got)
+
+	want := []string{"GET /livez", "GET /readyz"}
+	if len(got) != len(want) {
+		t.Fatalf("Router().Routes() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Router().Routes() = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestApplicationOwnedRouteRegistrationComposesIndependently(t *testing.T) {
+	app := newTestApp(t)
+
+	var (
+		mu    sync.Mutex
+		order []string
+	)
+	record := func(value string) {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, value)
+	}
+
+	ping := app.Router().Group("/ping")
+	ping.Use(func(c *gin.Context) {
+		record("ping-middleware")
+		c.Next()
+	})
+	ping.GET("", func(c *gin.Context) {
+		record("ping-handler")
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok"}})
+	})
+
+	echo := app.Router().Group("/echo")
+	echo.Use(func(c *gin.Context) {
+		record("echo-middleware")
+		c.Next()
+	})
+	echo.POST("", func(c *gin.Context) {
+		record("echo-handler")
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok"}})
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunContext(ctx, app)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		if err := waitRun(done); err != nil {
+			t.Fatalf("RunContext() error = %v, want nil", err)
+		}
+	})
+
+	waitForHTTP(t, app, "/livez")
+
+	pingResp := getHTTP(t, app, "/ping")
+	_, _ = io.Copy(io.Discard, pingResp.Body)
+	_ = pingResp.Body.Close()
+	if pingResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /ping status = %d, want %d", pingResp.StatusCode, http.StatusOK)
+	}
+
+	mu.Lock()
+	afterPing := append([]string(nil), order...)
+	mu.Unlock()
+
+	wantAfterPing := []string{"ping-middleware", "ping-handler"}
+	if !equalStrings(afterPing, wantAfterPing) {
+		t.Fatalf("order after GET /ping = %v, want %v (no cross-module leakage, deterministic order)", afterPing, wantAfterPing)
+	}
+
+	echoResp := postHTTP(t, app, "/echo")
+	_, _ = io.Copy(io.Discard, echoResp.Body)
+	_ = echoResp.Body.Close()
+	if echoResp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /echo status = %d, want %d", echoResp.StatusCode, http.StatusOK)
+	}
+
+	mu.Lock()
+	afterEcho := append([]string(nil), order...)
+	mu.Unlock()
+
+	wantAfterEcho := []string{"ping-middleware", "ping-handler", "echo-middleware", "echo-handler"}
+	if !equalStrings(afterEcho, wantAfterEcho) {
+		t.Fatalf("order after POST /echo = %v, want %v (echo middleware must not have fired for /ping)", afterEcho, wantAfterEcho)
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func postHTTP(t *testing.T, app *App, path string) *http.Response {
+	t.Helper()
+
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		addr := app.Addr()
+		if addr == "" {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+
+		resp, err := client.Post("http://"+addr+path, "application/json", nil)
+		if err == nil {
+			return resp
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for POST %s on %s", path, app.Addr())
+	return nil
+}

--- a/framework/router_test.go
+++ b/framework/router_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"reflect"
 	"sort"
 	"sync"
 	"testing"
@@ -22,13 +23,8 @@ func TestDefaultRouterMountsOnlyFrameworkEndpoints(t *testing.T) {
 	sort.Strings(got)
 
 	want := []string{"GET /livez", "GET /readyz"}
-	if len(got) != len(want) {
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Router().Routes() = %v, want %v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("Router().Routes() = %v, want %v", got, want)
-		}
 	}
 }
 
@@ -91,7 +87,7 @@ func TestApplicationOwnedRouteRegistrationComposesIndependently(t *testing.T) {
 	mu.Unlock()
 
 	wantAfterPing := []string{"ping-middleware", "ping-handler"}
-	if !equalStrings(afterPing, wantAfterPing) {
+	if !reflect.DeepEqual(afterPing, wantAfterPing) {
 		t.Fatalf("order after GET /ping = %v, want %v (no cross-module leakage, deterministic order)", afterPing, wantAfterPing)
 	}
 
@@ -107,21 +103,9 @@ func TestApplicationOwnedRouteRegistrationComposesIndependently(t *testing.T) {
 	mu.Unlock()
 
 	wantAfterEcho := []string{"ping-middleware", "ping-handler", "echo-middleware", "echo-handler"}
-	if !equalStrings(afterEcho, wantAfterEcho) {
+	if !reflect.DeepEqual(afterEcho, wantAfterEcho) {
 		t.Fatalf("order after POST /echo = %v, want %v (echo middleware must not have fired for /ping)", afterEcho, wantAfterEcho)
 	}
-}
-
-func equalStrings(got, want []string) bool {
-	if len(got) != len(want) {
-		return false
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func postHTTP(t *testing.T, app *App, path string) *http.Response {


### PR DESCRIPTION
## Summary

Adds the M1-3 application-owned route registration surface.

`framework.App`'s router was built domain-agnostic from the start in M1-2
(no `Book`/`User` knowledge was ever introduced), so there was nothing to
literally extract or remove. This PR makes the remaining M1-3 surface
explicit: application-owned route registration composing independently via
`app.Router()`, proven with new tests, an `examples/router` app, and
`docs/router.md`. It also corrects `docs/lifecycle.md`'s middleware-ownership
table, which previously hedged "M1-3/M1-7" — that ambiguity is now resolved:
M1-3 owns route-registration composition, M1-7 owns the concrete
security/observability middleware set.

Closes #6

## Acceptance criteria

- runtime package contains zero example-domain models — covered by
  `framework/router_test.go`'s `TestDefaultRouterMountsOnlyFrameworkEndpoints`
  (asserts the default router exposes exactly `GET /livez`, `GET /readyz`)
  and a repo-wide `Book`/`User` grep.
- middleware order preserved and tested — covered by
  `TestApplicationOwnedRouteRegistrationComposesIndependently` (two
  independently-registered route groups, each with its own group-scoped
  middleware, compose without cross-module leakage in deterministic order)
  and the existing `TestDefaultRouterRecoversFromPanics` (framework Recovery
  still applies to app-registered routes).

## Scope notes

No middleware from `golang-rest-api-template` (CORS, security headers, rate
limiting, request-id/timeout, trusted-proxy, JWT/API-key auth, Mongo access
logging) was ported — those stay with M1-4/M1-5/M1-6/M1-7 per the build plan
and issue #10's explicit scope. No new framework-level `Module`/registry
abstraction was added; `app.Router()` remains the sanctioned mechanism, per
principle 6.2 (no reflection discovery).

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- `go run ./examples/router`, curled `/livez`, `/readyz`, `/ping`, `/echo`
- project `code-review` skill: no blockers or majors; two minor nits (a
  redundant test helper, an imprecise doc citation) fixed in a follow-up
  commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)