### PR TITLE
docs: record Atlas GORM migration ADR

### DIFF
--- a/docs/adr/012-migrations-atlas-gorm-provider.md
+++ b/docs/adr/012-migrations-atlas-gorm-provider.md
@@ -1,0 +1,115 @@
+# ADR-012: Migrations Use Atlas GORM Provider
+
+## Status
+
+Accepted.
+
+## Context
+
+Gombit needs Django-style `makemigrations` for Go/GORM models without
+inventing a schema diff engine or a migration DSL. The build plan locks the
+direction to `ariga.io/atlas-provider-gorm` plus Atlas versioned migrations,
+but M2-0 is the go/no-go gate for licensing, driver coverage, Program Mode,
+and open-core boundaries.
+
+This ADR was verified against upstream Atlas documentation on 2026-08-15.
+
+Atlas provides two relevant pieces:
+
+- `ariga.io/atlas-provider-gorm`, a Go module that loads GORM models into an
+  Atlas external schema.
+- The Atlas CLI, which can compare that desired schema to the current
+  migration directory state and write versioned SQL migrations with
+  `atlas migrate diff`.
+
+Gombit's generated apps use feature packages under `internal/<feature>/`, so
+the migration loader must handle GORM models spread across multiple packages.
+Atlas's GORM Program Mode supports this shape: the application-owned loader is
+a Go program that imports each feature package and passes every model to
+`gormschema.New(driver).Load(...)`.
+
+## Decision
+
+Gombit will wrap Atlas and `ariga.io/atlas-provider-gorm` for M2 migrations.
+
+`gombit db makemigrations` will:
+
+1. Resolve the configured database driver.
+2. Generate or run an application-owned Atlas loader program that imports the
+   registered feature-package models.
+3. Use `ariga.io/atlas-provider-gorm/gormschema` in Program Mode to expose the
+   GORM schema as an Atlas external schema.
+4. Invoke `atlas migrate diff` against Gombit's migration directory to write a
+   versioned SQL migration for the selected driver.
+
+The supported v0.1 drivers remain SQLite, PostgreSQL, and MySQL. Although
+issue #11 mentions SQLite and PostgreSQL, the build plan is authoritative and
+M1-4 has already established MySQL as part of the runtime database boundary.
+Atlas documents SQLite, PostgreSQL, and MySQL as open-supported drivers, and
+the GORM provider documents support for the same three databases.
+
+The fallback from the build plan, a hand-rolled migration DSL and diff engine,
+is rejected. The open-source Atlas path covers the required v0.1 workflow:
+database inspection, schema diffing, migration planning, versioned migrations,
+and execution for the supported drivers.
+
+## Licensing and Feature Boundary
+
+The provider repository is Apache-2.0 licensed. Atlas describes its core
+engine as open source under Apache-2.0 and lists database inspection, schema
+diffing, versioned migrations, declarative migrations, PostgreSQL, MySQL, and
+SQLite as open features.
+
+M2 must not depend on Atlas Pro-only features unless a later issue explicitly
+changes the product decision. The following are outside the v0.1 open-source
+dependency surface:
+
+- `atlas migrate lint` migration safety analysis.
+- Pre-migration checks and deploy-time drift detection.
+- Atlas Registry and Cloud-backed drift monitoring.
+- Atlas migration/schema testing framework.
+- Advanced schema objects that Atlas marks as Pro for the supported drivers,
+  including views, triggers, functions, procedures, row-level security,
+  partitions, and similar database-specific extensions.
+
+Gombit may document those as optional future integrations, but they are not
+part of M2 acceptance criteria.
+
+## Consequences
+
+- M2-1 should build a thin wrapper around Atlas Program Mode and
+  `atlas migrate diff`; it should not introduce a Gombit migration DSL.
+- Model discovery remains explicit and generator-owned. Generated apps should
+  register model types in a known place so the loader can pass concrete model
+  values to the provider without runtime reflection discovery.
+- Migration output is SQL owned by the application. Users can still add
+  hand-written SQL or HCL migrations in the migration directory as an escape
+  hatch.
+- Atlas writes and validates an `atlas.sum` file for its versioned migration
+  directory. That does not replace Gombit's runtime migration metadata
+  decision from D4: applied revisions are still tracked as
+  `version, name, batch, applied_at`, with no checksum in Gombit's own
+  revision table.
+- Safety checks in M2/M4 CI must use open-source mechanisms unless the project
+  intentionally accepts an Atlas Pro dependency. In particular, do not make
+  `atlas migrate lint`, drift detection, or the Atlas Registry required for
+  the default v0.1 workflow.
+- The database conformance matrix remains required for SQLite, PostgreSQL, and
+  MySQL because Atlas support does not replace runtime verification against
+  real drivers.
+
+## References
+
+- Issue #11: `[M2-0] ADR-012: Migrations = Atlas GORM provider`
+- Issue #7: `[M1-4] Multi-driver database.Open + capability model`
+- `docs/GOMBIT_BUILD_PLAN.md`
+- Atlas GORM Program Mode:
+  https://atlasgo.io/guides/orms/gorm/program
+- Atlas feature compatibility:
+  https://atlasgo.io/features
+- Atlas community edition:
+  https://atlasgo.io/community-edition
+- GORM provider repository:
+  https://github.com/ariga/atlas-provider-gorm
+- GORM provider package:
+  https://pkg.go.dev/ariga.io/atlas-provider-gorm

--- a/docs/adr/012-migrations-atlas-gorm-provider.md
+++ b/docs/adr/012-migrations-atlas-gorm-provider.md
@@ -55,16 +55,23 @@ and execution for the supported drivers.
 
 ## Licensing and Feature Boundary
 
-The provider repository is Apache-2.0 licensed. Atlas describes its core
-engine as open source under Apache-2.0 and lists database inspection, schema
-diffing, versioned migrations, declarative migrations, PostgreSQL, MySQL, and
-SQLite as open features.
+The default M2 workflow will wrap the Atlas Community Edition CLI plus
+`ariga.io/atlas-provider-gorm`. The provider repository is Apache-2.0
+licensed, and Atlas Community Edition is the Apache-2.0 Atlas CLI build. It
+includes the v0.1 commands Gombit needs for the generated migration path:
+`atlas migrate diff`, `atlas migrate apply`, and `atlas migrate status`.
 
-M2 must not depend on Atlas Pro-only features unless a later issue explicitly
-changes the product decision. The following are outside the v0.1 open-source
-dependency surface:
+Do not conflate Atlas Community Edition with the standard Atlas CLI. Atlas's
+standard distribution is free to download and includes additional commands, but
+it is licensed under the Atlas MSA. The standard CLI may remain a user-selected
+escape hatch later, but the default v0.1 M2 implementation must not require it.
+
+M2 must not depend on commands or features that are absent from Community
+Edition unless a later issue explicitly changes the product decision. The
+following are outside the v0.1 Apache-2.0 dependency surface:
 
 - `atlas migrate lint` migration safety analysis.
+- `atlas migrate down`, `checkpoint`, `rebase`, `edit`, and `rm`.
 - Pre-migration checks and deploy-time drift detection.
 - Atlas Registry and Cloud-backed drift monitoring.
 - Atlas migration/schema testing framework.
@@ -90,10 +97,14 @@ part of M2 acceptance criteria.
   decision from D4: applied revisions are still tracked as
   `version, name, batch, applied_at`, with no checksum in Gombit's own
   revision table.
+- M2-2 rollback is a Gombit-owned runtime operation over the D4 revision table
+  and application-owned down SQL. It must not wrap `atlas migrate down`,
+  because that command is unavailable in Atlas Community Edition.
 - Safety checks in M2/M4 CI must use open-source mechanisms unless the project
-  intentionally accepts an Atlas Pro dependency. In particular, do not make
-  `atlas migrate lint`, drift detection, or the Atlas Registry required for
-  the default v0.1 workflow.
+  intentionally accepts a standard Atlas CLI or Atlas Pro dependency. In
+  particular, do not make `atlas migrate lint`, drift detection, Atlas
+  Registry, or advanced migration commands required for the default v0.1
+  workflow.
 - The database conformance matrix remains required for SQLite, PostgreSQL, and
   MySQL because Atlas support does not replace runtime verification against
   real drivers.

--- a/docs/database.md
+++ b/docs/database.md
@@ -3,6 +3,10 @@
 M1-4 introduces the runtime database boundary. Gombit opens GORM directly and
 keeps `*gorm.DB` reachable; it does not define a second ORM interface.
 
+Migration generation is tracked separately in
+`docs/adr/012-migrations-atlas-gorm-provider.md`: M2 will wrap Atlas and
+`ariga.io/atlas-provider-gorm` rather than defining a Gombit migration DSL.
+
 ## Drivers
 
 `database.Open` supports:


### PR DESCRIPTION
## Summary

- Add ADR-012 recording the M2 go/no-go decision to use Atlas plus `ariga.io/atlas-provider-gorm` for migrations.
- Document the open-source vs Atlas Pro feature boundary so M2 does not accidentally depend on linting, drift detection, registry, or advanced schema objects.
- Cross-link the migration decision from the database docs.

Closes #11

## Acceptance criteria

- [x] Go/no-go gate for M2 recorded: proceed with Atlas GORM provider and `atlas migrate diff`; reject the hand-rolled DSL fallback.
- [x] Confirmed Program Mode covers feature-package models by importing model packages and passing concrete model values to `gormschema.New(driver).Load(...)`.
- [x] Confirmed the required SQLite, PostgreSQL, and MySQL driver path stays within open Atlas features per the build plan.
- [x] Confirmed Pro-only capabilities are not required for v0.1 M2 acceptance criteria.

## Scope notes

- This PR records the ADR only. `gombit db makemigrations`, loader generation, Atlas invocation, and migration application remain for later M2 issues.
- Atlas Pro-only migration linting, drift detection, registry workflows, and migration/schema tests are explicitly out of scope for the default v0.1 path.

## Validation

- [ ] `go test ./...`
  - Attempted with the default cache; blocked by sandbox read-only access to `/home/leonardo/.cache/go-build`.
  - Retried with `GOCACHE=/tmp/gombit-go-build-cache`; unchanged SQLite-backed tests fail with a `github.com/mattn/go-sqlite3` cgo segmentation fault in `database` and `framework`.
  - Retried outside the sandbox with the same `GOCACHE`; SQLite cgo segmentation fault still reproduces.
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
  - Not run; this is a Markdown-only ADR/docs change and no Go code changed.
- [x] `git diff --check`
- [x] Project `code-review` skill run against this diff

## Working agreement checklist

- [ ] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix
  - N/A: docs-only ADR, no runtime behavior or DB code changed.
- [ ] Stable features ship docs and appear in an example app
  - N/A: this records the M2 migration decision; feature examples belong with the implementation issues.
- [ ] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests
  - N/A: no extraction or source movement.
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators)
  - N/A: no generator changes.
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR
  - N/A: no API changes.
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
  - No frontend changes.
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies
