### PR TITLE
feat: preserve observability security runtime tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,8 @@ const (
 	envAppName                 = "GOMBIT_APP_NAME"
 	envEnv                     = "GOMBIT_ENV"
 	envHTTPAddr                = "GOMBIT_HTTP_ADDR"
+	envHTTPTrustedProxies      = "GOMBIT_HTTP_TRUSTED_PROXIES"
+	envHTTPRequestTimeout      = "GOMBIT_HTTP_REQUEST_TIMEOUT"
 	envAPIPrefix               = "GOMBIT_API_PREFIX"
 	envDatabaseDriver          = "GOMBIT_DATABASE_DRIVER"
 	envDatabaseDSN             = "GOMBIT_DATABASE_DSN"
@@ -44,7 +46,9 @@ type Config struct {
 
 // HTTPConfig contains HTTP server configuration.
 type HTTPConfig struct {
-	Addr string
+	Addr           string
+	TrustedProxies []string
+	RequestTimeout time.Duration
 }
 
 // APIConfig contains public API configuration.
@@ -82,7 +86,8 @@ func Default() Config {
 		AppName:     "Gombit",
 		Environment: EnvironmentDevelopment,
 		HTTP: HTTPConfig{
-			Addr: ":8080",
+			Addr:           ":8080",
+			RequestTimeout: 60 * time.Second,
 		},
 		API: APIConfig{
 			Prefix: "/api/v1",
@@ -109,9 +114,17 @@ func LoadFromEnv(lookup EnvLookup) (Config, error) {
 	applyString(lookup, envAppName, &cfg.AppName)
 	applyEnvironment(lookup, envEnv, &cfg.Environment)
 	applyString(lookup, envHTTPAddr, &cfg.HTTP.Addr)
+	applyStringList(lookup, envHTTPTrustedProxies, &cfg.HTTP.TrustedProxies)
 	applyString(lookup, envAPIPrefix, &cfg.API.Prefix)
 
 	var errs FieldErrors
+	applyDuration(
+		lookup,
+		envHTTPRequestTimeout,
+		"HTTP.RequestTimeout",
+		&cfg.HTTP.RequestTimeout,
+		&errs,
+	)
 	applyDatabaseDriver(lookup, envDatabaseDriver, &cfg.Database.Driver)
 	applyString(lookup, envDatabaseDSN, &cfg.Database.DSN)
 	applyInt(lookup, envDatabaseMaxOpenConns, "Database.MaxOpenConns", &cfg.Database.MaxOpenConns, &errs)
@@ -169,6 +182,34 @@ func (c Config) Validate() error {
 			Value:   c.HTTP.Addr,
 			Message: "must not be empty",
 		})
+	}
+
+	if c.HTTP.RequestTimeout < 0 {
+		errs = append(errs, FieldError{
+			Field:   "HTTP.RequestTimeout",
+			Env:     envHTTPRequestTimeout,
+			Value:   c.HTTP.RequestTimeout.String(),
+			Message: "must be greater than or equal to zero",
+		})
+	}
+
+	for _, proxy := range c.HTTP.TrustedProxies {
+		if strings.TrimSpace(proxy) == "" {
+			errs = append(errs, FieldError{
+				Field:   "HTTP.TrustedProxies",
+				Env:     envHTTPTrustedProxies,
+				Value:   proxy,
+				Message: "must not contain empty entries",
+			})
+		}
+		if c.Environment == EnvironmentProduction && isUnsafeTrustedProxy(proxy) {
+			errs = append(errs, FieldError{
+				Field:   "HTTP.TrustedProxies",
+				Env:     envHTTPTrustedProxies,
+				Value:   proxy,
+				Message: "must not trust all proxies in production",
+			})
+		}
 	}
 
 	if !strings.HasPrefix(c.API.Prefix, "/") {
@@ -262,6 +303,21 @@ func applyString(lookup EnvLookup, key string, dest *string) {
 	}
 }
 
+func applyStringList(lookup EnvLookup, key string, dest *[]string) {
+	value, ok := lookup(key)
+	if !ok {
+		return
+	}
+
+	var parsed []string
+	for _, part := range strings.Split(value, ",") {
+		if item := strings.TrimSpace(part); item != "" {
+			parsed = append(parsed, item)
+		}
+	}
+	*dest = parsed
+}
+
 func applyEnvironment(lookup EnvLookup, key string, dest *Environment) {
 	if value, ok := lookup(key); ok {
 		*dest = Environment(strings.TrimSpace(value))
@@ -290,6 +346,15 @@ func applyInt(lookup EnvLookup, key string, field string, dest *int, errs *Field
 		return
 	}
 	*dest = parsed
+}
+
+func isUnsafeTrustedProxy(proxy string) bool {
+	switch strings.TrimSpace(proxy) {
+	case "*", "0.0.0.0/0", "::/0":
+		return true
+	default:
+		return false
+	}
 }
 
 func applyDuration(lookup EnvLookup, key string, field string, dest *time.Duration, errs *FieldErrors) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,6 +20,9 @@ func TestDefault(t *testing.T) {
 	if got.HTTP.Addr != ":8080" {
 		t.Fatalf("HTTP.Addr = %q, want %q", got.HTTP.Addr, ":8080")
 	}
+	if got.HTTP.RequestTimeout != 60*time.Second {
+		t.Fatalf("HTTP.RequestTimeout = %v, want 60s", got.HTTP.RequestTimeout)
+	}
 	if got.API.Prefix != "/api/v1" {
 		t.Fatalf("API.Prefix = %q, want %q", got.API.Prefix, "/api/v1")
 	}
@@ -39,6 +42,8 @@ func TestLoadFromEnv(t *testing.T) {
 		envAppName:                 " Example ",
 		envEnv:                     " test ",
 		envHTTPAddr:                " 127.0.0.1:9000 ",
+		envHTTPTrustedProxies:      " 10.0.0.1, 10.0.0.0/24 ",
+		envHTTPRequestTimeout:      " 15s ",
 		envAPIPrefix:               " /api ",
 		envDatabaseDriver:          " postgres ",
 		envDatabaseDSN:             " host=localhost user=gombit dbname=app sslmode=disable ",
@@ -56,7 +61,9 @@ func TestLoadFromEnv(t *testing.T) {
 		AppName:     "Example",
 		Environment: EnvironmentTest,
 		HTTP: HTTPConfig{
-			Addr: "127.0.0.1:9000",
+			Addr:           "127.0.0.1:9000",
+			TrustedProxies: []string{"10.0.0.1", "10.0.0.0/24"},
+			RequestTimeout: 15 * time.Second,
 		},
 		API: APIConfig{
 			Prefix: "/api",
@@ -85,6 +92,18 @@ func TestLoadFromEnvUsesDefaultsWhenUnset(t *testing.T) {
 	}
 }
 
+func TestLoadFromEnvAllowsDisabledHTTPRequestTimeout(t *testing.T) {
+	got, err := LoadFromEnv(mapLookup(map[string]string{
+		envHTTPRequestTimeout: "0",
+	}))
+	if err != nil {
+		t.Fatalf("LoadFromEnv() error = %v, want nil", err)
+	}
+	if got.HTTP.RequestTimeout != 0 {
+		t.Fatalf("HTTP.RequestTimeout = %v, want disabled timeout", got.HTTP.RequestTimeout)
+	}
+}
+
 func TestLoadUsesProcessEnvironment(t *testing.T) {
 	t.Setenv(envAppName, "Process Example")
 	t.Setenv(envEnv, string(EnvironmentProduction))
@@ -102,7 +121,8 @@ func TestLoadUsesProcessEnvironment(t *testing.T) {
 		AppName:     "Process Example",
 		Environment: EnvironmentProduction,
 		HTTP: HTTPConfig{
-			Addr: ":9090",
+			Addr:           ":9090",
+			RequestTimeout: 60 * time.Second,
 		},
 		API: APIConfig{
 			Prefix: "/api",
@@ -132,7 +152,8 @@ func TestValidateReportsExplicitFieldErrors(t *testing.T) {
 		AppName:     " ",
 		Environment: "staging",
 		HTTP: HTTPConfig{
-			Addr: "",
+			Addr:           "",
+			RequestTimeout: -time.Second,
 		},
 		API: APIConfig{
 			Prefix: "api",
@@ -165,6 +186,12 @@ func TestValidateReportsExplicitFieldErrors(t *testing.T) {
 			Message: "must be one of development, test, production",
 		},
 		{Field: "HTTP.Addr", Env: envHTTPAddr, Value: "", Message: "must not be empty"},
+		{
+			Field:   "HTTP.RequestTimeout",
+			Env:     envHTTPRequestTimeout,
+			Value:   "-1s",
+			Message: "must be greater than or equal to zero",
+		},
 		{Field: "API.Prefix", Env: envAPIPrefix, Value: "api", Message: "must start with /"},
 		{
 			Field:   "Database.Driver",
@@ -201,6 +228,7 @@ func TestValidateReportsExplicitFieldErrors(t *testing.T) {
 		envAppName,
 		envEnv,
 		envHTTPAddr,
+		envHTTPRequestTimeout,
 		envAPIPrefix,
 		envDatabaseDriver,
 		envDatabaseDSN,
@@ -211,6 +239,34 @@ func TestValidateReportsExplicitFieldErrors(t *testing.T) {
 		if !strings.Contains(message, wantPart) {
 			t.Fatalf("Validate() error = %q, want it to contain %q", message, wantPart)
 		}
+	}
+}
+
+func TestValidateRejectsUnsafeTrustedProxyInProduction(t *testing.T) {
+	cfg := Default()
+	cfg.Environment = EnvironmentProduction
+	cfg.HTTP.TrustedProxies = []string{"0.0.0.0/0"}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want trusted proxy validation error")
+	}
+
+	var fieldErrors FieldErrors
+	if !errors.As(err, &fieldErrors) {
+		t.Fatalf("Validate() error type = %T, want FieldErrors", err)
+	}
+
+	want := []FieldError{
+		{
+			Field:   "HTTP.TrustedProxies",
+			Env:     envHTTPTrustedProxies,
+			Value:   "0.0.0.0/0",
+			Message: "must not trust all proxies in production",
+		},
+	}
+	if !reflect.DeepEqual([]FieldError(fieldErrors), want) {
+		t.Fatalf("Validate() field errors = %#v, want %#v", []FieldError(fieldErrors), want)
 	}
 }
 
@@ -236,6 +292,7 @@ func TestLoadFromEnvReturnsParseErrors(t *testing.T) {
 	_, err := LoadFromEnv(mapLookup(map[string]string{
 		envDatabaseMaxOpenConns:    "many",
 		envDatabaseConnMaxLifetime: "later",
+		envHTTPRequestTimeout:      "soon",
 	}))
 	if err == nil {
 		t.Fatal("LoadFromEnv() error = nil, want parse errors")
@@ -245,8 +302,8 @@ func TestLoadFromEnvReturnsParseErrors(t *testing.T) {
 	if !errors.As(err, &fieldErrors) {
 		t.Fatalf("LoadFromEnv() error type = %T, want FieldErrors", err)
 	}
-	if len(fieldErrors) != 2 {
-		t.Fatalf("LoadFromEnv() field error count = %d, want 2", len(fieldErrors))
+	if len(fieldErrors) != 3 {
+		t.Fatalf("LoadFromEnv() field error count = %d, want 3", len(fieldErrors))
 	}
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -11,6 +11,7 @@ runtime packages.
 - app name: `Gombit`
 - environment: `development`
 - HTTP address: `:8080`
+- HTTP request timeout: `60s`
 - API prefix: `/api/v1`
 - database driver: `sqlite`
 - database DSN: `file:gombit.db?cache=shared&_fk=1`
@@ -25,6 +26,8 @@ configuration. The M1-1 boundary recognizes:
 | `GOMBIT_APP_NAME` | `Config.AppName` | `Gombit` |
 | `GOMBIT_ENV` | `Config.Environment` | `development` |
 | `GOMBIT_HTTP_ADDR` | `Config.HTTP.Addr` | `:8080` |
+| `GOMBIT_HTTP_TRUSTED_PROXIES` | `Config.HTTP.TrustedProxies` | unset |
+| `GOMBIT_HTTP_REQUEST_TIMEOUT` | `Config.HTTP.RequestTimeout` | `60s` |
 | `GOMBIT_API_PREFIX` | `Config.API.Prefix` | `/api/v1` |
 | `GOMBIT_DATABASE_DRIVER` | `Config.Database.Driver` | `sqlite` |
 | `GOMBIT_DATABASE_DSN` | `Config.Database.DSN` | `file:gombit.db?cache=shared&_fk=1` |
@@ -35,6 +38,12 @@ configuration. The M1-1 boundary recognizes:
 `GOMBIT_ENV` accepts the exact lowercase values `development`, `test`, and
 `production`.
 `GOMBIT_DATABASE_DRIVER` accepts `sqlite`, `postgres`, and `mysql`.
+`GOMBIT_HTTP_TRUSTED_PROXIES` is a comma-separated list of IPs or CIDRs passed
+to Gin's trusted-proxy configuration. When unset, forwarded-client IP headers
+are ignored. Production config rejects values that trust all proxies, such as
+`0.0.0.0/0`.
+`GOMBIT_HTTP_REQUEST_TIMEOUT` uses Go duration syntax such as `30s` or `2m`;
+`0` disables the per-request deadline.
 `GOMBIT_DATABASE_CONN_MAX_LIFETIME` uses Go duration syntax such as `30m` or
 `1h`.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -42,8 +42,9 @@ configuration. The M1-1 boundary recognizes:
 to Gin's trusted-proxy configuration. When unset, forwarded-client IP headers
 are ignored. Production config rejects values that trust all proxies, such as
 `0.0.0.0/0`.
-`GOMBIT_HTTP_REQUEST_TIMEOUT` uses Go duration syntax such as `30s` or `2m`;
-`0` disables the per-request deadline.
+`GOMBIT_HTTP_REQUEST_TIMEOUT` uses Go duration syntax such as `30s` or `2m`.
+The value sets the cooperative per-request context deadline and the
+`http.Server` write/idle timeouts; `0` disables all three.
 `GOMBIT_DATABASE_CONN_MAX_LIFETIME` uses Go duration syntax such as `30m` or
 `1h`.
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -52,9 +52,9 @@ steps that need their own runtime surfaces.
 | 4. migration state checks | Deferred to M2. |
 | 5. optional Redis/cache connection | Deferred to M1-5. |
 | 6. auth infrastructure | Deferred to M5. |
-| 7. tracing and metrics | Deferred to M1-7. |
+| 7. tracing and metrics | Basic trace-ID propagation and HTTP request metrics are owned in M1-7; full OpenTelemetry exporter wiring is future runtime work. |
 | 8. HTTP server construction | Owned in M1-2 through `framework.Run` and `RunContext`. |
-| 9. middleware installation | Recovery is owned in M1-2. Route-registration composition (independently-registered route groups, each with optional group-scoped middleware) is owned in M1-3 — see [`docs/router.md`](router.md). The concrete security/observability middleware set (CORS, security headers, rate limiting, request-id/timeout, trusted-proxy) is owned by M1-7. |
+| 9. middleware installation | Recovery is owned in M1-2. Route-registration composition (independently-registered route groups, each with optional group-scoped middleware) is owned in M1-3 — see [`docs/router.md`](router.md). Request ID, trace context, metrics, security headers, request timeout, and trusted-proxy configuration are owned in M1-7. CORS, rate limiting, and auth remain separate issues. |
 | 10. module registration | Owned in M1-3 — applications register feature routes directly against `app.Router()`; see [`docs/router.md`](router.md). |
 | 11. readiness/liveness endpoints | Basic raw Gin probes are owned in M1-2; DB/cache-aware readiness is deferred to M1-4/M1-5. |
 | 12. frontend static asset mounting when embedded | Deferred to M5-5. |

--- a/docs/router.md
+++ b/docs/router.md
@@ -2,8 +2,8 @@
 
 M1-3 de-domains the router introduced in M1-2: `framework.New` builds a
 `*gin.Engine` with zero knowledge of any application domain and mounts only
-its own endpoints. Today that means `/livez` and `/readyz`; metrics and the
-OpenAPI document join later (M1-7, M3).
+its own endpoints. Today that means `/livez`, `/readyz`, and `/metrics`; the
+OpenAPI document joins later (M3).
 
 Applications register their own routes directly against the escape hatch:
 
@@ -40,15 +40,41 @@ two independently-registered groups compose without cross-module leakage.
 
 ## Middleware ordering
 
-Framework middleware installed before `New` returns — currently
-`gin.Recovery()` — wraps every route registered afterward, including
-application route groups and their own group-scoped middleware. Order is:
+Framework middleware installed before `New` returns wraps every route
+registered afterward, including application route groups and their own
+group-scoped middleware. Order is:
 
 ```text
-framework middleware (e.g. Recovery)
+Recovery
+  -> request ID
+  -> trace context
+  -> request metrics
+  -> security headers
+  -> request timeout
   -> feature group middleware (if any)
     -> feature handler
 ```
+
+Request IDs use the `X-Request-Id` header. If the caller provides one, the
+runtime preserves it; otherwise it generates one and stores it on both Gin's
+context and `c.Request.Context()` for downstream code:
+
+```go
+requestID := framework.GetRequestID(c)
+requestIDFromContext := framework.GetRequestIDFromContext(c.Request.Context())
+```
+
+Trace context currently preserves the W3C `Traceparent` trace ID when present
+and exposes the active trace ID through `X-Trace-Id`,
+`framework.GetTraceID(c)`, and `framework.GetTraceIDFromContext(ctx)`. Full
+OpenTelemetry exporter wiring remains future runtime work; M1-7 preserves the
+runtime seam and parity tests.
+
+`/metrics` exposes Prometheus text-format request counters, active request
+gauge, and request-duration sums for the runtime router. Trusted proxies are
+configured through `config.Config.HTTP.TrustedProxies` or
+`GOMBIT_HTTP_TRUSTED_PROXIES`; when unset, Gin ignores forwarded-client IP
+headers and uses the direct TCP peer.
 
 `framework/router_test.go`'s `TestDefaultRouterMountsOnlyFrameworkEndpoints`
 and `TestApplicationOwnedRouteRegistrationComposesIndependently` cover this;
@@ -57,14 +83,12 @@ Recovery still applying to an application-registered route.
 
 ## What is not here yet
 
-This surface does not include CORS, security/XSS headers, rate limiting,
-request-id/timeout, trusted-proxy configuration, or authentication
+This surface does not include CORS, rate limiting, or authentication
 middleware. Those are extracted with their own runtime dependencies in later
 issues:
 
 - rate limiting and the cache interface: M1-5
 - Mongo-backed access logging: M1-6
-- request-id/timeout, security headers, trusted-proxy parity: M1-7
 - auth middleware: M5
 
 Until then, an application that needs one of these can add it directly via

--- a/docs/router.md
+++ b/docs/router.md
@@ -71,10 +71,18 @@ OpenTelemetry exporter wiring remains future runtime work; M1-7 preserves the
 runtime seam and parity tests.
 
 `/metrics` exposes Prometheus text-format request counters, active request
-gauge, and request-duration sums for the runtime router. Trusted proxies are
-configured through `config.Config.HTTP.TrustedProxies` or
+gauge, and request-duration sums for the runtime router. The text renderer is
+intentionally minimal for M1 runtime parity; a later observability issue can
+swap in `prometheus/client_golang` or full OpenTelemetry exporter wiring
+without changing the route contract. Trusted proxies are configured through
+`config.Config.HTTP.TrustedProxies` or
 `GOMBIT_HTTP_TRUSTED_PROXIES`; when unset, Gin ignores forwarded-client IP
 headers and uses the direct TCP peer.
+
+`framework.WithRouter` is the custom-router escape hatch. When an application
+passes its own `*gin.Engine`, Gombit applies trusted-proxy configuration only;
+the application owns recovery, request ID, trace context, metrics, security
+headers, and timeout middleware for that router.
 
 `framework/router_test.go`'s `TestDefaultRouterMountsOnlyFrameworkEndpoints`
 and `TestApplicationOwnedRouteRegistrationComposesIndependently` cover this;

--- a/examples/router/main.go
+++ b/examples/router/main.go
@@ -13,7 +13,13 @@ import (
 func registerPingRoutes(router *gin.Engine) {
 	ping := router.Group("/ping")
 	ping.GET("", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "pong"}})
+		c.JSON(http.StatusOK, gin.H{
+			"data": gin.H{
+				"status":     "pong",
+				"request_id": framework.GetRequestID(c),
+				"trace_id":   framework.GetTraceID(c),
+			},
+		})
 	})
 }
 

--- a/framework/app.go
+++ b/framework/app.go
@@ -41,6 +41,11 @@ type App struct {
 	addr   string
 }
 
+type namedMiddleware struct {
+	name    string
+	handler gin.HandlerFunc
+}
+
 // New creates an application using process configuration and the default router.
 func New(options ...Option) (*App, error) {
 	app := &App{
@@ -215,6 +220,8 @@ func RunContext(ctx context.Context, app *App) error {
 	server := &http.Server{
 		Handler:           app.Router(),
 		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      app.Config().HTTP.RequestTimeout,
+		IdleTimeout:       app.Config().HTTP.RequestTimeout,
 	}
 	app.setServer(server, listener.Addr().String())
 
@@ -327,14 +334,7 @@ func newRouter(cfg config.Config) (*gin.Engine, error) {
 	}
 
 	metrics := newHTTPMetrics()
-	router.Use(
-		gin.Recovery(),
-		requestIDMiddleware(),
-		traceContextMiddleware(),
-		metricsMiddleware(metrics),
-		securityHeadersMiddleware(),
-		requestTimeoutMiddleware(cfg.HTTP.RequestTimeout),
-	)
+	router.Use(middlewareHandlers(runtimeMiddlewareStack(cfg, metrics))...)
 	router.GET("/livez", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"data": gin.H{
@@ -364,4 +364,26 @@ func configureTrustedProxies(engine *gin.Engine, proxies []string) error {
 		return fmt.Errorf("framework: trusted proxies: %w", err)
 	}
 	return nil
+}
+
+func runtimeMiddlewareStack(cfg config.Config, metrics *httpMetrics) []namedMiddleware {
+	return []namedMiddleware{
+		{name: "recovery", handler: gin.Recovery()},
+		{name: "request_id", handler: requestIDMiddleware()},
+		{name: "trace_context", handler: traceContextMiddleware()},
+		{name: "metrics", handler: metricsMiddleware(metrics)},
+		{
+			name:    "security_headers",
+			handler: securityHeadersMiddleware(cfg.Environment == config.EnvironmentProduction),
+		},
+		{name: "request_timeout", handler: requestTimeoutMiddleware(cfg.HTTP.RequestTimeout)},
+	}
+}
+
+func middlewareHandlers(stack []namedMiddleware) []gin.HandlerFunc {
+	handlers := make([]gin.HandlerFunc, 0, len(stack))
+	for _, middleware := range stack {
+		handlers = append(handlers, middleware.handler)
+	}
+	return handlers
 }

--- a/framework/app.go
+++ b/framework/app.go
@@ -73,7 +73,13 @@ func New(options ...Option) (*App, error) {
 	}
 	configureHTTPMode(app.cfg)
 	if app.router == nil {
-		app.router = newRouter()
+		router, err := newRouter(app.cfg)
+		if err != nil {
+			return nil, err
+		}
+		app.router = router
+	} else if err := configureTrustedProxies(app.router, app.cfg.HTTP.TrustedProxies); err != nil {
+		return nil, err
 	}
 
 	return app, nil
@@ -314,9 +320,21 @@ func (a *App) runStopHooksWithContext(ctx context.Context) error {
 	return joined
 }
 
-func newRouter() *gin.Engine {
+func newRouter(cfg config.Config) (*gin.Engine, error) {
 	router := gin.New()
-	router.Use(gin.Recovery())
+	if err := configureTrustedProxies(router, cfg.HTTP.TrustedProxies); err != nil {
+		return nil, err
+	}
+
+	metrics := newHTTPMetrics()
+	router.Use(
+		gin.Recovery(),
+		requestIDMiddleware(),
+		traceContextMiddleware(),
+		metricsMiddleware(metrics),
+		securityHeadersMiddleware(),
+		requestTimeoutMiddleware(cfg.HTTP.RequestTimeout),
+	)
 	router.GET("/livez", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"data": gin.H{
@@ -331,11 +349,19 @@ func newRouter() *gin.Engine {
 			},
 		})
 	})
-	return router
+	router.GET("/metrics", metrics.handler)
+	return router, nil
 }
 
 func configureHTTPMode(cfg config.Config) {
 	if cfg.Environment == config.EnvironmentProduction {
 		gin.SetMode(gin.ReleaseMode)
 	}
+}
+
+func configureTrustedProxies(engine *gin.Engine, proxies []string) error {
+	if err := engine.SetTrustedProxies(proxies); err != nil {
+		return fmt.Errorf("framework: trusted proxies: %w", err)
+	}
+	return nil
 }

--- a/framework/http_middleware.go
+++ b/framework/http_middleware.go
@@ -1,0 +1,237 @@
+package framework
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TraceparentHeader is the W3C trace context header.
+const TraceparentHeader = "Traceparent"
+
+// TraceIDHeader exposes the active trace ID for logs, diagnostics, and tests.
+const TraceIDHeader = "X-Trace-Id"
+
+const traceIDGinKey = "trace_id"
+
+type traceIDContextKey struct{}
+
+var traceparentPattern = regexp.MustCompile(`^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$`)
+
+func requestTimeoutMiddleware(timeout time.Duration) gin.HandlerFunc {
+	if timeout <= 0 {
+		return func(c *gin.Context) {
+			c.Next()
+		}
+	}
+
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
+		defer cancel()
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}
+
+func traceContextMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		traceID := traceIDFromTraceparent(c.GetHeader(TraceparentHeader))
+		if traceID == "" {
+			traceID = newTraceID()
+		}
+		if traceID == "" {
+			traceID = "unknown"
+		}
+
+		c.Set(traceIDGinKey, traceID)
+		c.Header(TraceIDHeader, traceID)
+		c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), traceIDContextKey{}, traceID))
+
+		c.Next()
+	}
+}
+
+// GetTraceID returns the trace ID stored in the Gin context.
+func GetTraceID(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	value, ok := c.Get(traceIDGinKey)
+	if !ok {
+		return ""
+	}
+	traceID, _ := value.(string)
+	return traceID
+}
+
+// GetTraceIDFromContext reads the trace ID from a request context.
+func GetTraceIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	traceID, _ := ctx.Value(traceIDContextKey{}).(string)
+	return traceID
+}
+
+func securityHeadersMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		header := c.Writer.Header()
+		header.Set("Content-Security-Policy", "default-src 'self'")
+		header.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		header.Set("Strict-Transport-Security", "max-age=315360000; includeSubDomains")
+		header.Set("X-Content-Type-Options", "nosniff")
+		header.Set("X-Download-Options", "noopen")
+		header.Set("X-Frame-Options", "DENY")
+		header.Set("X-XSS-Protection", "1; mode=block")
+		c.Next()
+	}
+}
+
+type httpMetrics struct {
+	mu       sync.Mutex
+	active   int64
+	requests map[metricsKey]int64
+	latency  map[metricsKey]time.Duration
+}
+
+type metricsKey struct {
+	method string
+	route  string
+	status int
+}
+
+func newHTTPMetrics() *httpMetrics {
+	return &httpMetrics{
+		requests: make(map[metricsKey]int64),
+		latency:  make(map[metricsKey]time.Duration),
+	}
+}
+
+func metricsMiddleware(metrics *httpMetrics) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		metrics.addActive(1)
+		defer metrics.addActive(-1)
+
+		c.Next()
+
+		route := c.FullPath()
+		if route == "" {
+			route = c.Request.URL.Path
+		}
+		metrics.observe(metricsKey{
+			method: c.Request.Method,
+			route:  route,
+			status: c.Writer.Status(),
+		}, time.Since(start))
+	}
+}
+
+func (m *httpMetrics) addActive(delta int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.active += delta
+}
+
+func (m *httpMetrics) observe(key metricsKey, duration time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requests[key]++
+	m.latency[key] += duration
+}
+
+func (m *httpMetrics) handler(c *gin.Context) {
+	c.Data(http.StatusOK, "text/plain; version=0.0.4; charset=utf-8", []byte(m.render()))
+}
+
+func (m *httpMetrics) render() string {
+	m.mu.Lock()
+	active := m.active
+	requests := make(map[metricsKey]int64, len(m.requests))
+	latency := make(map[metricsKey]time.Duration, len(m.latency))
+	for key, value := range m.requests {
+		requests[key] = value
+	}
+	for key, value := range m.latency {
+		latency[key] = value
+	}
+	m.mu.Unlock()
+
+	keys := make([]metricsKey, 0, len(requests))
+	for key := range requests {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].route != keys[j].route {
+			return keys[i].route < keys[j].route
+		}
+		if keys[i].method != keys[j].method {
+			return keys[i].method < keys[j].method
+		}
+		return keys[i].status < keys[j].status
+	})
+
+	var b strings.Builder
+	b.WriteString("# HELP gombit_http_active_requests Active HTTP requests currently in flight.\n")
+	b.WriteString("# TYPE gombit_http_active_requests gauge\n")
+	fmt.Fprintf(&b, "gombit_http_active_requests %d\n", active)
+	b.WriteString("# HELP gombit_http_requests_total Total HTTP requests handled by Gombit.\n")
+	b.WriteString("# TYPE gombit_http_requests_total counter\n")
+	for _, key := range keys {
+		fmt.Fprintf(
+			&b,
+			"gombit_http_requests_total{method=%q,route=%q,status=%q} %d\n",
+			key.method,
+			key.route,
+			strconv.Itoa(key.status),
+			requests[key],
+		)
+	}
+	b.WriteString("# HELP gombit_http_request_duration_seconds_sum Total request latency observed by Gombit.\n")
+	b.WriteString("# TYPE gombit_http_request_duration_seconds_sum counter\n")
+	for _, key := range keys {
+		fmt.Fprintf(
+			&b,
+			"gombit_http_request_duration_seconds_sum{method=%q,route=%q,status=%q} %.9f\n",
+			key.method,
+			key.route,
+			strconv.Itoa(key.status),
+			latency[key].Seconds(),
+		)
+	}
+	return b.String()
+}
+
+func traceIDFromTraceparent(value string) string {
+	match := traceparentPattern.FindStringSubmatch(strings.ToLower(strings.TrimSpace(value)))
+	if len(match) != 2 {
+		return ""
+	}
+	if match[1] == "00000000000000000000000000000000" {
+		return ""
+	}
+	return match[1]
+}
+
+func newTraceID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+	if b == [16]byte{} {
+		b[15] = 1
+	}
+	buf := make([]byte, 32)
+	hex.Encode(buf, b[:])
+	return string(buf)
+}

--- a/framework/http_middleware.go
+++ b/framework/http_middleware.go
@@ -83,16 +83,17 @@ func GetTraceIDFromContext(ctx context.Context) string {
 	return traceID
 }
 
-func securityHeadersMiddleware() gin.HandlerFunc {
+func securityHeadersMiddleware(includeHSTS bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		header := c.Writer.Header()
 		header.Set("Content-Security-Policy", "default-src 'self'")
 		header.Set("Referrer-Policy", "strict-origin-when-cross-origin")
-		header.Set("Strict-Transport-Security", "max-age=315360000; includeSubDomains")
+		if includeHSTS {
+			header.Set("Strict-Transport-Security", "max-age=315360000; includeSubDomains")
+		}
 		header.Set("X-Content-Type-Options", "nosniff")
 		header.Set("X-Download-Options", "noopen")
 		header.Set("X-Frame-Options", "DENY")
-		header.Set("X-XSS-Protection", "1; mode=block")
 		c.Next()
 	}
 }
@@ -127,7 +128,7 @@ func metricsMiddleware(metrics *httpMetrics) gin.HandlerFunc {
 
 		route := c.FullPath()
 		if route == "" {
-			route = c.Request.URL.Path
+			route = "unmatched"
 		}
 		metrics.observe(metricsKey{
 			method: c.Request.Method,

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -1,0 +1,294 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/gin-gonic/gin"
+)
+
+func TestDefaultRouterAddsRequestID(t *testing.T) {
+	app := newTestApp(t)
+	app.Router().GET("/request-id", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"gin":     GetRequestID(c),
+			"context": GetRequestIDFromContext(c.Request.Context()),
+		})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/request-id", nil)
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /request-id status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	requestID := rec.Header().Get(RequestIDHeader)
+	if requestID == "" {
+		t.Fatal("request ID response header is empty")
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response body: %v", err)
+	}
+	if body["gin"] != requestID || body["context"] != requestID {
+		t.Fatalf("request IDs = %#v, want both values to match response header %q", body, requestID)
+	}
+}
+
+func TestDefaultRouterPreservesRequestID(t *testing.T) {
+	app := newTestApp(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	req.Header.Set(RequestIDHeader, "req-123")
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /livez status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get(RequestIDHeader); got != "req-123" {
+		t.Fatalf("%s = %q, want req-123", RequestIDHeader, got)
+	}
+}
+
+func TestDefaultRouterCarriesTraceContext(t *testing.T) {
+	const traceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+	app := newTestApp(t)
+	app.Router().GET("/trace", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"gin":     GetTraceID(c),
+			"context": GetTraceIDFromContext(c.Request.Context()),
+		})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/trace", nil)
+	req.Header.Set(TraceparentHeader, "00-"+traceID+"-00f067aa0ba902b7-01")
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /trace status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get(TraceIDHeader); got != traceID {
+		t.Fatalf("%s = %q, want %q", TraceIDHeader, got, traceID)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response body: %v", err)
+	}
+	if body["gin"] != traceID || body["context"] != traceID {
+		t.Fatalf("trace IDs = %#v, want both values to match traceparent trace ID %q", body, traceID)
+	}
+}
+
+func TestDefaultRouterAddsSecurityHeaders(t *testing.T) {
+	app := newTestApp(t)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /livez status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	want := map[string]string{
+		"Content-Security-Policy": "default-src 'self'",
+		"Referrer-Policy":         "strict-origin-when-cross-origin",
+		"X-Content-Type-Options":  "nosniff",
+		"X-Download-Options":      "noopen",
+		"X-Frame-Options":         "DENY",
+		"X-XSS-Protection":        "1; mode=block",
+	}
+	for header, value := range want {
+		if got := rec.Header().Get(header); got != value {
+			t.Fatalf("%s = %q, want %q", header, got, value)
+		}
+	}
+	if got := rec.Header().Get("Strict-Transport-Security"); !strings.Contains(got, "max-age=315360000") {
+		t.Fatalf("Strict-Transport-Security = %q, want max-age=315360000", got)
+	}
+}
+
+func TestDefaultRouterRequestTimeoutSetsDeadline(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentTest
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.HTTP.RequestTimeout = 40 * time.Millisecond
+
+	app := newTestApp(t, WithConfig(cfg))
+	app.Router().GET("/slow", func(c *gin.Context) {
+		ctx := c.Request.Context()
+		select {
+		case <-time.After(500 * time.Millisecond):
+			c.Status(http.StatusOK)
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				c.AbortWithStatus(http.StatusGatewayTimeout)
+				return
+			}
+			c.AbortWithStatus(http.StatusInternalServerError)
+		}
+	})
+
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/slow", nil))
+
+	if elapsed := time.Since(start); elapsed >= 200*time.Millisecond {
+		t.Fatalf("GET /slow took %v, want handler to stop after request context deadline", elapsed)
+	}
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("GET /slow status = %d, want %d", rec.Code, http.StatusGatewayTimeout)
+	}
+}
+
+func TestDefaultRouterMetricsEndpointRecordsRequests(t *testing.T) {
+	app := newTestApp(t)
+
+	livez := httptest.NewRecorder()
+	app.Router().ServeHTTP(livez, httptest.NewRequest(http.MethodGet, "/livez", nil))
+	if livez.Code != http.StatusOK {
+		t.Fatalf("GET /livez status = %d, want %d", livez.Code, http.StatusOK)
+	}
+
+	metrics := httptest.NewRecorder()
+	app.Router().ServeHTTP(metrics, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if metrics.Code != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want %d", metrics.Code, http.StatusOK)
+	}
+
+	body := metrics.Body.String()
+	for _, want := range []string{
+		"gombit_http_active_requests",
+		`gombit_http_requests_total{method="GET",route="/livez",status="200"} 1`,
+		`gombit_http_request_duration_seconds_sum{method="GET",route="/livez",status="200"}`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("GET /metrics body = %q, want it to contain %q", body, want)
+		}
+	}
+}
+
+func TestReadyzAndLivezUseEnvelope(t *testing.T) {
+	app := newTestApp(t)
+
+	for _, path := range []string{"/livez", "/readyz"} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET %s status = %d, want %d", path, rec.Code, http.StatusOK)
+			}
+			var body struct {
+				Data struct {
+					Status string `json:"status"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal %s response body: %v", path, err)
+			}
+			if body.Data.Status != "ok" {
+				t.Fatalf("GET %s data.status = %q, want ok", path, body.Data.Status)
+			}
+		})
+	}
+}
+
+func TestTrustedProxiesNilIgnoresForwardedFor(t *testing.T) {
+	app := newTestApp(t)
+	app.Router().GET("/client-ip", func(c *gin.Context) {
+		c.String(http.StatusOK, c.ClientIP())
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/client-ip", nil)
+	req.RemoteAddr = "192.0.2.10:5555"
+	req.Header.Set("X-Forwarded-For", "203.0.113.7")
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /client-ip status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "192.0.2.10" {
+		t.Fatalf("client IP = %q, want direct peer IP", got)
+	}
+}
+
+func TestTrustedProxiesInvalidConfigReturnsError(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentTest
+	cfg.HTTP.TrustedProxies = []string{"not-a-valid-cidr!!!"}
+
+	_, err := New(WithConfig(cfg))
+	if err == nil {
+		t.Fatal("New() error = nil, want trusted proxy validation error")
+	}
+	if !strings.Contains(err.Error(), "trusted proxies") {
+		t.Fatalf("New() error = %q, want trusted proxies message", err)
+	}
+}
+
+func TestTrustedProxiesAllowsForwardedFromTrustedPeer(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentTest
+	cfg.HTTP.TrustedProxies = []string{"192.0.2.10/32"}
+	app := newTestApp(t, WithConfig(cfg))
+	app.Router().GET("/client-ip", func(c *gin.Context) {
+		c.String(http.StatusOK, c.ClientIP())
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/client-ip", nil)
+	req.RemoteAddr = "192.0.2.10:5555"
+	req.Header.Set("X-Forwarded-For", "198.51.100.22")
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /client-ip status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "198.51.100.22" {
+		t.Fatalf("client IP = %q, want forwarded IP", got)
+	}
+}
+
+func TestRunContextServesMetricsWithRuntimeMiddleware(t *testing.T) {
+	app := newTestApp(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunContext(ctx, app)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		if err := waitRun(done); err != nil {
+			t.Fatalf("RunContext() error = %v, want nil", err)
+		}
+	})
+
+	waitForHTTP(t, app, "/livez")
+	resp := getHTTP(t, app, "/metrics")
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read /metrics body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if !strings.Contains(string(body), "gombit_http_requests_total") {
+		t.Fatalf("GET /metrics body = %q, want request metrics", string(body))
+	}
+}

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,26 @@ import (
 	"github.com/LAA-Software-Engineering/gombit/config"
 	"github.com/gin-gonic/gin"
 )
+
+func TestDefaultRuntimeMiddlewareOrder(t *testing.T) {
+	stack := runtimeMiddlewareStack(config.Default(), newHTTPMetrics())
+	got := make([]string, 0, len(stack))
+	for _, middleware := range stack {
+		got = append(got, middleware.name)
+	}
+
+	want := []string{
+		"recovery",
+		"request_id",
+		"trace_context",
+		"metrics",
+		"security_headers",
+		"request_timeout",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("runtime middleware order = %v, want %v", got, want)
+	}
+}
 
 func TestDefaultRouterAddsRequestID(t *testing.T) {
 	app := newTestApp(t)
@@ -109,15 +130,40 @@ func TestDefaultRouterAddsSecurityHeaders(t *testing.T) {
 		"X-Content-Type-Options":  "nosniff",
 		"X-Download-Options":      "noopen",
 		"X-Frame-Options":         "DENY",
-		"X-XSS-Protection":        "1; mode=block",
 	}
 	for header, value := range want {
 		if got := rec.Header().Get(header); got != value {
 			t.Fatalf("%s = %q, want %q", header, got, value)
 		}
 	}
+	if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Fatalf("Strict-Transport-Security = %q, want empty outside production", got)
+	}
+	if got := rec.Header().Get("X-XSS-Protection"); got != "" {
+		t.Fatalf("X-XSS-Protection = %q, want empty deprecated header", got)
+	}
+}
+
+func TestProductionRouterAddsHSTS(t *testing.T) {
+	previousMode := gin.Mode()
+	t.Cleanup(func() {
+		gin.SetMode(previousMode)
+	})
+
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentProduction
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	app := newTestApp(t, WithConfig(cfg))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /livez status = %d, want %d", rec.Code, http.StatusOK)
+	}
 	if got := rec.Header().Get("Strict-Transport-Security"); !strings.Contains(got, "max-age=315360000") {
-		t.Fatalf("Strict-Transport-Security = %q, want max-age=315360000", got)
+		t.Fatalf("Strict-Transport-Security = %q, want max-age=315360000 in production", got)
 	}
 }
 
@@ -154,6 +200,41 @@ func TestDefaultRouterRequestTimeoutSetsDeadline(t *testing.T) {
 	}
 }
 
+func TestRunContextConfiguresServerTimeouts(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentTest
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.HTTP.RequestTimeout = 2 * time.Second
+	app := newTestApp(t, WithConfig(cfg))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunContext(ctx, app)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		if err := waitRun(done); err != nil {
+			t.Fatalf("RunContext() error = %v, want nil", err)
+		}
+	})
+
+	waitForHTTP(t, app, "/livez")
+
+	app.mu.RLock()
+	server := app.server
+	app.mu.RUnlock()
+	if server == nil {
+		t.Fatal("server = nil, want configured HTTP server")
+	}
+	if server.WriteTimeout != cfg.HTTP.RequestTimeout {
+		t.Fatalf("server.WriteTimeout = %v, want %v", server.WriteTimeout, cfg.HTTP.RequestTimeout)
+	}
+	if server.IdleTimeout != cfg.HTTP.RequestTimeout {
+		t.Fatalf("server.IdleTimeout = %v, want %v", server.IdleTimeout, cfg.HTTP.RequestTimeout)
+	}
+}
+
 func TestDefaultRouterMetricsEndpointRecordsRequests(t *testing.T) {
 	app := newTestApp(t)
 
@@ -177,6 +258,34 @@ func TestDefaultRouterMetricsEndpointRecordsRequests(t *testing.T) {
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("GET /metrics body = %q, want it to contain %q", body, want)
+		}
+	}
+}
+
+func TestDefaultRouterMetricsUsesBoundedLabelForUnmatchedRoutes(t *testing.T) {
+	app := newTestApp(t)
+
+	for _, path := range []string{"/missing/one", "/missing/two"} {
+		rec := httptest.NewRecorder()
+		app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("GET %s status = %d, want %d", path, rec.Code, http.StatusNotFound)
+		}
+	}
+
+	metrics := httptest.NewRecorder()
+	app.Router().ServeHTTP(metrics, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if metrics.Code != http.StatusOK {
+		t.Fatalf("GET /metrics status = %d, want %d", metrics.Code, http.StatusOK)
+	}
+
+	body := metrics.Body.String()
+	if !strings.Contains(body, `gombit_http_requests_total{method="GET",route="unmatched",status="404"} 2`) {
+		t.Fatalf("GET /metrics body = %q, want bounded unmatched route label", body)
+	}
+	for _, rawPath := range []string{"/missing/one", "/missing/two"} {
+		if strings.Contains(body, rawPath) {
+			t.Fatalf("GET /metrics body = %q, want no raw unmatched path %q", body, rawPath)
 		}
 	}
 }

--- a/framework/request_id.go
+++ b/framework/request_id.go
@@ -1,0 +1,79 @@
+package framework
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequestIDHeader is the HTTP header carrying a stable per-request ID.
+const RequestIDHeader = "X-Request-Id"
+
+const requestIDGinKey = "request_id"
+
+type requestIDContextKey struct{}
+
+func requestIDMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestID := strings.TrimSpace(c.GetHeader(RequestIDHeader))
+		if requestID == "" {
+			requestID = newRequestID()
+		}
+		if requestID == "" {
+			requestID = "unknown"
+		}
+
+		c.Set(requestIDGinKey, requestID)
+		c.Header(RequestIDHeader, requestID)
+		c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), requestIDContextKey{}, requestID))
+
+		c.Next()
+	}
+}
+
+// GetRequestID returns the request ID stored in the Gin context.
+func GetRequestID(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	value, ok := c.Get(requestIDGinKey)
+	if !ok {
+		return ""
+	}
+	requestID, _ := value.(string)
+	return requestID
+}
+
+// GetRequestIDFromContext reads the request ID from a request context.
+func GetRequestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	requestID, _ := ctx.Value(requestIDContextKey{}).(string)
+	return requestID
+}
+
+func newRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	buf := make([]byte, 36)
+	hex.Encode(buf[0:8], b[0:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], b[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], b[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], b[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:36], b[10:16])
+	return string(buf)
+}

--- a/framework/router_test.go
+++ b/framework/router_test.go
@@ -22,7 +22,7 @@ func TestDefaultRouterMountsOnlyFrameworkEndpoints(t *testing.T) {
 	}
 	sort.Strings(got)
 
-	want := []string{"GET /livez", "GET /readyz"}
+	want := []string{"GET /livez", "GET /metrics", "GET /readyz"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Router().Routes() = %v, want %v", got, want)
 	}


### PR DESCRIPTION
## Summary

Adds the M1-7 runtime observability/security parity surface:

- installs request ID, trace context, request metrics, security headers, request timeout, and trusted-proxy configuration on the default framework router
- exposes `/metrics` alongside `/livez` and `/readyz`
- documents the new HTTP config, runtime middleware order, and example route context helpers

Closes #10

## Acceptance criteria

- [x] parity test suite green

## Scope notes

Full OpenTelemetry exporter wiring remains future runtime work; M1-7 preserves trace-ID propagation and the runtime seam. CORS, rate limiting, auth, DB/cache-aware readiness, and Mongo-backed access logging remain with their existing backlog issues/milestones.

## Validation

- [x] `GOCACHE=/tmp/gombit-go-cache go test ./...`
- [x] `GOCACHE=/tmp/gombit-go-cache go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [x] Project `code-review` skill run against this diff
- [x] `GOCACHE=/tmp/gombit-go-cache go vet ./...`

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix
- [x] Stable features ship docs and appear in an example app
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (N/A: this PR does not touch generators)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR (N/A: no public Huma API contract or generated TS client change)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies
