### PR TITLE
feat: add optional logging runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ Runtime configuration is documented in [`docs/config.md`](docs/config.md).
 Application lifecycle is documented in [`docs/lifecycle.md`](docs/lifecycle.md).
 Application-owned route registration is documented in [`docs/router.md`](docs/router.md).
 Database runtime support is documented in [`docs/database.md`](docs/database.md).
+Runtime logging is documented in [`docs/logging.md`](docs/logging.md).

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,8 @@ const (
 	envDatabaseMaxOpenConns    = "GOMBIT_DATABASE_MAX_OPEN_CONNS"
 	envDatabaseMaxIdleConns    = "GOMBIT_DATABASE_MAX_IDLE_CONNS"
 	envDatabaseConnMaxLifetime = "GOMBIT_DATABASE_CONN_MAX_LIFETIME"
+	envLogLevel                = "GOMBIT_LOG_LEVEL"
+	envLogSink                 = "GOMBIT_LOG_SINK"
 )
 
 // Environment is the runtime environment name.
@@ -40,6 +42,7 @@ type Config struct {
 	HTTP        HTTPConfig
 	API         APIConfig
 	Database    DatabaseConfig
+	Logging     LoggingConfig
 }
 
 // HTTPConfig contains HTTP server configuration.
@@ -73,6 +76,38 @@ type DatabaseConfig struct {
 	ConnMaxLifetime time.Duration
 }
 
+// LogLevel names the configured logging level.
+type LogLevel string
+
+const (
+	// LogLevelDebug enables debug, info, warn, and error logs.
+	LogLevelDebug LogLevel = "debug"
+	// LogLevelInfo enables info, warn, and error logs.
+	LogLevelInfo LogLevel = "info"
+	// LogLevelWarn enables warn and error logs.
+	LogLevelWarn LogLevel = "warn"
+	// LogLevelError enables error logs.
+	LogLevelError LogLevel = "error"
+)
+
+// LogSink names the configured logging sink.
+type LogSink string
+
+const (
+	// LogSinkStderr writes JSON logs to stderr.
+	LogSinkStderr LogSink = "stderr"
+	// LogSinkStdout writes JSON logs to stdout.
+	LogSinkStdout LogSink = "stdout"
+	// LogSinkMongo selects an external Mongo logging module.
+	LogSinkMongo LogSink = "mongo"
+)
+
+// LoggingConfig contains structured logging configuration.
+type LoggingConfig struct {
+	Level LogLevel
+	Sink  LogSink
+}
+
 // EnvLookup reads an environment variable by name.
 type EnvLookup func(key string) (value string, ok bool)
 
@@ -90,6 +125,10 @@ func Default() Config {
 		Database: DatabaseConfig{
 			Driver: DatabaseDriverSQLite,
 			DSN:    "file:gombit.db?cache=shared&_fk=1",
+		},
+		Logging: LoggingConfig{
+			Level: LogLevelInfo,
+			Sink:  LogSinkStderr,
 		},
 	}
 }
@@ -123,6 +162,8 @@ func LoadFromEnv(lookup EnvLookup) (Config, error) {
 		&cfg.Database.ConnMaxLifetime,
 		&errs,
 	)
+	applyLogLevel(lookup, envLogLevel, &cfg.Logging.Level)
+	applyLogSink(lookup, envLogSink, &cfg.Logging.Sink)
 
 	if err := cfg.Validate(); err != nil {
 		var fieldErrors FieldErrors
@@ -181,6 +222,7 @@ func (c Config) Validate() error {
 	}
 
 	validateDatabaseConfig(&errs, c.Database)
+	validateLoggingConfig(&errs, c.Logging)
 
 	if len(errs) > 0 {
 		return errs
@@ -197,6 +239,40 @@ func ValidateDatabase(cfg DatabaseConfig) error {
 		return errs
 	}
 	return nil
+}
+
+// ValidateLogging returns explicit field errors for invalid logging settings.
+func ValidateLogging(cfg LoggingConfig) error {
+	var errs FieldErrors
+	validateLoggingConfig(&errs, cfg)
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
+}
+
+func validateLoggingConfig(errs *FieldErrors, cfg LoggingConfig) {
+	switch cfg.Level {
+	case LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelError:
+	default:
+		*errs = append(*errs, FieldError{
+			Field:   "Logging.Level",
+			Env:     envLogLevel,
+			Value:   string(cfg.Level),
+			Message: "must be one of debug, info, warn, error",
+		})
+	}
+
+	switch cfg.Sink {
+	case LogSinkStderr, LogSinkStdout, LogSinkMongo:
+	default:
+		*errs = append(*errs, FieldError{
+			Field:   "Logging.Sink",
+			Env:     envLogSink,
+			Value:   string(cfg.Sink),
+			Message: "must be one of stderr, stdout, mongo",
+		})
+	}
 }
 
 func validateDatabaseConfig(errs *FieldErrors, cfg DatabaseConfig) {
@@ -271,6 +347,18 @@ func applyEnvironment(lookup EnvLookup, key string, dest *Environment) {
 func applyDatabaseDriver(lookup EnvLookup, key string, dest *DatabaseDriver) {
 	if value, ok := lookup(key); ok {
 		*dest = DatabaseDriver(strings.TrimSpace(value))
+	}
+}
+
+func applyLogLevel(lookup EnvLookup, key string, dest *LogLevel) {
+	if value, ok := lookup(key); ok {
+		*dest = LogLevel(strings.TrimSpace(value))
+	}
+}
+
+func applyLogSink(lookup EnvLookup, key string, dest *LogSink) {
+	if value, ok := lookup(key); ok {
+		*dest = LogSink(strings.TrimSpace(value))
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,12 @@ func TestDefault(t *testing.T) {
 	if got.Database.DSN != "file:gombit.db?cache=shared&_fk=1" {
 		t.Fatalf("Database.DSN = %q, want default sqlite DSN", got.Database.DSN)
 	}
+	if got.Logging.Level != LogLevelInfo {
+		t.Fatalf("Logging.Level = %q, want %q", got.Logging.Level, LogLevelInfo)
+	}
+	if got.Logging.Sink != LogSinkStderr {
+		t.Fatalf("Logging.Sink = %q, want %q", got.Logging.Sink, LogSinkStderr)
+	}
 	if err := got.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v, want nil", err)
 	}
@@ -45,6 +51,8 @@ func TestLoadFromEnv(t *testing.T) {
 		envDatabaseMaxOpenConns:    " 20 ",
 		envDatabaseMaxIdleConns:    " 4 ",
 		envDatabaseConnMaxLifetime: " 45m ",
+		envLogLevel:                " debug ",
+		envLogSink:                 " stdout ",
 	}
 
 	got, err := LoadFromEnv(mapLookup(env))
@@ -67,6 +75,10 @@ func TestLoadFromEnv(t *testing.T) {
 			MaxOpenConns:    20,
 			MaxIdleConns:    4,
 			ConnMaxLifetime: 45 * time.Minute,
+		},
+		Logging: LoggingConfig{
+			Level: LogLevelDebug,
+			Sink:  LogSinkStdout,
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -92,6 +104,8 @@ func TestLoadUsesProcessEnvironment(t *testing.T) {
 	t.Setenv(envAPIPrefix, "/api")
 	t.Setenv(envDatabaseDriver, string(DatabaseDriverMySQL))
 	t.Setenv(envDatabaseDSN, "gombit@tcp(localhost:3306)/app?parseTime=true")
+	t.Setenv(envLogLevel, string(LogLevelError))
+	t.Setenv(envLogSink, string(LogSinkMongo))
 
 	got, err := Load()
 	if err != nil {
@@ -110,6 +124,10 @@ func TestLoadUsesProcessEnvironment(t *testing.T) {
 		Database: DatabaseConfig{
 			Driver: DatabaseDriverMySQL,
 			DSN:    "gombit@tcp(localhost:3306)/app?parseTime=true",
+		},
+		Logging: LoggingConfig{
+			Level: LogLevelError,
+			Sink:  LogSinkMongo,
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -143,6 +161,10 @@ func TestValidateReportsExplicitFieldErrors(t *testing.T) {
 			MaxOpenConns:    -1,
 			MaxIdleConns:    2,
 			ConnMaxLifetime: -time.Second,
+		},
+		Logging: LoggingConfig{
+			Level: "trace",
+			Sink:  "file",
 		},
 	}
 
@@ -191,6 +213,18 @@ func TestValidateReportsExplicitFieldErrors(t *testing.T) {
 			Value:   "-1s",
 			Message: "must be greater than or equal to zero",
 		},
+		{
+			Field:   "Logging.Level",
+			Env:     envLogLevel,
+			Value:   "trace",
+			Message: "must be one of debug, info, warn, error",
+		},
+		{
+			Field:   "Logging.Sink",
+			Env:     envLogSink,
+			Value:   "file",
+			Message: "must be one of stderr, stdout, mongo",
+		},
 	}
 	if !reflect.DeepEqual([]FieldError(fieldErrors), want) {
 		t.Fatalf("Validate() field errors = %#v, want %#v", []FieldError(fieldErrors), want)
@@ -207,6 +241,8 @@ func TestValidateReportsExplicitFieldErrors(t *testing.T) {
 		envDatabaseMaxOpenConns,
 		envDatabaseMaxIdleConns,
 		envDatabaseConnMaxLifetime,
+		envLogLevel,
+		envLogSink,
 	} {
 		if !strings.Contains(message, wantPart) {
 			t.Fatalf("Validate() error = %q, want it to contain %q", message, wantPart)

--- a/docs/config.md
+++ b/docs/config.md
@@ -14,6 +14,8 @@ runtime packages.
 - API prefix: `/api/v1`
 - database driver: `sqlite`
 - database DSN: `file:gombit.db?cache=shared&_fk=1`
+- log level: `info`
+- log sink: `stderr`
 
 ## Environment
 
@@ -31,12 +33,17 @@ configuration. The M1-1 boundary recognizes:
 | `GOMBIT_DATABASE_MAX_OPEN_CONNS` | `Config.Database.MaxOpenConns` | `0` |
 | `GOMBIT_DATABASE_MAX_IDLE_CONNS` | `Config.Database.MaxIdleConns` | `0` |
 | `GOMBIT_DATABASE_CONN_MAX_LIFETIME` | `Config.Database.ConnMaxLifetime` | `0` |
+| `GOMBIT_LOG_LEVEL` | `Config.Logging.Level` | `info` |
+| `GOMBIT_LOG_SINK` | `Config.Logging.Sink` | `stderr` |
 
 `GOMBIT_ENV` accepts the exact lowercase values `development`, `test`, and
 `production`.
 `GOMBIT_DATABASE_DRIVER` accepts `sqlite`, `postgres`, and `mysql`.
 `GOMBIT_DATABASE_CONN_MAX_LIFETIME` uses Go duration syntax such as `30m` or
 `1h`.
+`GOMBIT_LOG_LEVEL` accepts `debug`, `info`, `warn`, and `error`.
+`GOMBIT_LOG_SINK` accepts `stderr`, `stdout`, and `mongo`; Mongo logging is an
+external module hook, not a runtime dependency.
 
 Validation returns `config.FieldErrors`, which names the typed field, the
 environment variable, the invalid value, and the validation message.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -47,7 +47,7 @@ steps that need their own runtime surfaces.
 | Step | Status |
 | --- | --- |
 | 1. config loading | Owned in M1-1/M1-2 through `config.Config` and `framework.New`. |
-| 2. logging initialization | Deferred to M1-6. |
+| 2. logging initialization | Owned in M1-6 through Zap-backed `logging.New`; Mongo sinks are external modules. |
 | 3. database connection | Owned in M1-4 through `database.Open`; applications open/close the handle and attach it with `framework.WithDatabase`. |
 | 4. migration state checks | Deferred to M2. |
 | 5. optional Redis/cache connection | Deferred to M1-5. |

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,36 @@
+# Logging
+
+M1-6 introduces the runtime logging surface. Gombit uses Zap for structured
+logs and defaults to stderr JSON output without requiring MongoDB.
+
+## Configuration
+
+`config.Default()` enables:
+
+- level: `info`
+- sink: `stderr`
+
+`GOMBIT_LOG_LEVEL` accepts `debug`, `info`, `warn`, and `error`.
+`GOMBIT_LOG_SINK` accepts `stderr`, `stdout`, and `mongo`.
+
+The `mongo` sink is a selectable external module hook. The runtime does not
+import or open a MongoDB client. Applications that want Mongo-backed logs supply
+a Zap core from their Mongo logging module and pass the resulting logger through
+`framework.WithLogger`.
+
+## Runtime Use
+
+`framework.New` builds a default logger from `Config.Logging` when no logger is
+provided. `app.Logger()` returns the `*zap.Logger` escape hatch:
+
+```go
+app, err := framework.New()
+if err != nil {
+	return err
+}
+
+app.Logger().Info("started")
+```
+
+HTTP-only apps and apps without Mongo configuration boot with the default
+stderr logger.

--- a/examples/logging/main.go
+++ b/examples/logging/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/framework"
+	"go.uber.org/zap"
+)
+
+func main() {
+	cfg := config.Default()
+	cfg.AppName = "logging-example"
+
+	app, err := framework.New(framework.WithConfig(cfg))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	app.Logger().Info("logger ready", zap.String("sink", string(cfg.Logging.Sink)))
+}

--- a/framework/app.go
+++ b/framework/app.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/LAA-Software-Engineering/gombit/config"
 	"github.com/LAA-Software-Engineering/gombit/database"
+	"github.com/LAA-Software-Engineering/gombit/logging"
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
@@ -31,6 +33,7 @@ type App struct {
 	cfg             config.Config
 	cfgSet          bool
 	db              *database.DB
+	logger          *zap.Logger
 	router          *gin.Engine
 	startHooks      []Hook
 	stopHooks       []Hook
@@ -72,6 +75,13 @@ func New(options ...Option) (*App, error) {
 		return nil, errors.New("framework: shutdown timeout must be positive")
 	}
 	configureHTTPMode(app.cfg)
+	if app.logger == nil {
+		logger, err := logging.New(app.cfg.Logging)
+		if err != nil {
+			return nil, err
+		}
+		app.logger = logger
+	}
 	if app.router == nil {
 		app.router = newRouter()
 	}
@@ -98,6 +108,17 @@ func WithDatabase(db *database.DB) Option {
 			return errors.New("framework: nil database")
 		}
 		app.db = db
+		return nil
+	}
+}
+
+// WithLogger attaches a Zap logger to the app.
+func WithLogger(logger *zap.Logger) Option {
+	return func(app *App) error {
+		if logger == nil {
+			return errors.New("framework: nil logger")
+		}
+		app.logger = logger
 		return nil
 	}
 }
@@ -129,6 +150,13 @@ func (a *App) Config() config.Config {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.cfg
+}
+
+// Logger returns the app's Zap logger.
+func (a *App) Logger() *zap.Logger {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.logger
 }
 
 // Database returns the opened database handle with driver metadata.

--- a/framework/app.go
+++ b/framework/app.go
@@ -81,6 +81,9 @@ func New(options ...Option) (*App, error) {
 			return nil, err
 		}
 		app.logger = logger
+		app.OnStop(func(context.Context) error {
+			return syncLogger(logger)
+		})
 	}
 	if app.router == nil {
 		app.router = newRouter()
@@ -340,6 +343,13 @@ func (a *App) runStopHooksWithContext(ctx context.Context) error {
 		}
 	}
 	return joined
+}
+
+func syncLogger(logger *zap.Logger) error {
+	if err := logger.Sync(); err != nil && !errors.Is(err, syscall.EINVAL) {
+		return fmt.Errorf("framework: sync logger: %w", err)
+	}
+	return nil
 }
 
 func newRouter() *gin.Engine {

--- a/framework/app_test.go
+++ b/framework/app_test.go
@@ -245,6 +245,18 @@ func TestAppBootsWithMongoSinkWhenLoggerProvided(t *testing.T) {
 	}
 }
 
+func TestNewWithMongoSinkRequiresProvidedLogger(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentTest
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.Logging.Sink = config.LogSinkMongo
+
+	_, err := New(WithConfig(cfg))
+	if err == nil {
+		t.Fatal("New(WithConfig(mongo sink)) error = nil, want error")
+	}
+}
+
 func TestNewValidatesOptions(t *testing.T) {
 	_, err := New(WithShutdownTimeout(0))
 	if err == nil {

--- a/framework/app_test.go
+++ b/framework/app_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LAA-Software-Engineering/gombit/config"
 	"github.com/LAA-Software-Engineering/gombit/database"
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 )
 
 func TestRunContextBootsAndShutsDown(t *testing.T) {
@@ -214,6 +215,36 @@ func TestAppExposesDatabaseEscapeHatch(t *testing.T) {
 	}
 }
 
+func TestNewBuildsDefaultLoggerWithoutMongo(t *testing.T) {
+	app := newTestApp(t)
+	if app.Logger() == nil {
+		t.Fatal("Logger() = nil, want logger")
+	}
+}
+
+func TestAppExposesLogger(t *testing.T) {
+	logger := zap.NewNop()
+	app := newTestApp(t, WithLogger(logger))
+	if got := app.Logger(); got != logger {
+		t.Fatalf("Logger() = %p, want %p", got, logger)
+	}
+}
+
+func TestAppBootsWithMongoSinkWhenLoggerProvided(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentTest
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.Logging.Sink = config.LogSinkMongo
+
+	app, err := New(WithConfig(cfg), WithLogger(zap.NewNop()))
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	if app.Logger() == nil {
+		t.Fatal("Logger() = nil, want logger")
+	}
+}
+
 func TestNewValidatesOptions(t *testing.T) {
 	_, err := New(WithShutdownTimeout(0))
 	if err == nil {
@@ -223,6 +254,11 @@ func TestNewValidatesOptions(t *testing.T) {
 	_, err = New(WithDatabase(nil))
 	if err == nil {
 		t.Fatal("New(WithDatabase(nil)) error = nil, want error")
+	}
+
+	_, err = New(WithLogger(nil))
+	if err == nil {
+		t.Fatal("New(WithLogger(nil)) error = nil, want error")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/pb33f/libopenapi v0.38.7
 	github.com/pb33f/libopenapi-validator v0.14.0
+	go.uber.org/zap v1.28.0
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.2
 	gorm.io/driver/sqlite v1.6.0
@@ -54,6 +55,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.8.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
 	golang.org/x/arch v0.29.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,16 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.mongodb.org/mongo-driver/v2 v2.8.0 h1:CxWDGQYY8QQwNjAl/aq2sfWakdnWZynnqJ9F4DhHbP8=
 go.mongodb.org/mongo-driver/v2 v2.8.0/go.mod h1:yOI9kBsufol30iFsl1slpdq1I0eHPzybRWdyYUs8K/0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.28.0 h1:IZzaP1Fv73/T/pBMLk4VutPl36uNC+OSUh3JLG3FIjo=
+go.uber.org/zap v1.28.0/go.mod h1:rDLpOi171uODNm/mxFcuYWxDsqWSAVkFdX4XojSKg/Q=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v4 v4.0.0-rc.6 h1:1h7H1ohdUh93/FyE4YaDa1Zh64K6VVbjF4K6WUxMtH4=
 go.yaml.in/yaml/v4 v4.0.0-rc.6/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/arch v0.29.0 h1:8sSET5wB0+exBm0FGmOtdHMqjlRdV2DRD3/IV6OZgho=

--- a/logging/doc.go
+++ b/logging/doc.go
@@ -1,0 +1,2 @@
+// Package logging builds Gombit's Zap logger and supports external sinks.
+package logging

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,116 @@
+package logging
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Option customizes logger construction.
+type Option func(*options) error
+
+type options struct {
+	core zapcore.Core
+}
+
+// WithCore supplies a Zap core from an external logging module.
+func WithCore(core zapcore.Core) Option {
+	return func(opts *options) error {
+		if core == nil {
+			return errors.New("logging: nil core")
+		}
+		opts.core = core
+		return nil
+	}
+}
+
+// New builds a Zap logger for cfg.
+func New(cfg config.LoggingConfig, opts ...Option) (*zap.Logger, error) {
+	if err := config.ValidateLogging(cfg); err != nil {
+		return nil, err
+	}
+
+	options := options{}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(&options); err != nil {
+			return nil, err
+		}
+	}
+
+	level, err := zapLevel(cfg.Level)
+	if err != nil {
+		return nil, err
+	}
+
+	core := options.core
+	if core == nil {
+		core, err = coreFor(cfg, level)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return zap.New(
+		core,
+		zap.AddCaller(),
+		zap.AddStacktrace(zapcore.ErrorLevel),
+		zap.ErrorOutput(zapcore.Lock(os.Stderr)),
+	), nil
+}
+
+func coreFor(cfg config.LoggingConfig, level zapcore.Level) (zapcore.Core, error) {
+	var sink zapcore.WriteSyncer
+	switch cfg.Sink {
+	case config.LogSinkStderr:
+		sink = zapcore.Lock(os.Stderr)
+	case config.LogSinkStdout:
+		sink = zapcore.Lock(os.Stdout)
+	case config.LogSinkMongo:
+		return nil, errors.New("logging: mongo sink requires an external zapcore.Core")
+	default:
+		return nil, fmt.Errorf("logging: unsupported sink %q", cfg.Sink)
+	}
+
+	return zapcore.NewCore(encoder(), sink, level), nil
+}
+
+func encoder() zapcore.Encoder {
+	cfg := zapcore.EncoderConfig{
+		TimeKey:        "ts",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		FunctionKey:    zapcore.OmitKey,
+		MessageKey:     "msg",
+		StacktraceKey:  "stacktrace",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.TimeEncoderOfLayout(time.RFC3339Nano),
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
+	return zapcore.NewJSONEncoder(cfg)
+}
+
+func zapLevel(level config.LogLevel) (zapcore.Level, error) {
+	switch level {
+	case config.LogLevelDebug:
+		return zapcore.DebugLevel, nil
+	case config.LogLevelInfo:
+		return zapcore.InfoLevel, nil
+	case config.LogLevelWarn:
+		return zapcore.WarnLevel, nil
+	case config.LogLevelError:
+		return zapcore.ErrorLevel, nil
+	default:
+		return zapcore.InfoLevel, fmt.Errorf("logging: unsupported level %q", level)
+	}
+}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1,0 +1,61 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestNewBuildsDefaultLoggerWithoutMongo(t *testing.T) {
+	logger, err := New(config.Default().Logging)
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	if logger == nil {
+		t.Fatal("New() logger = nil, want logger")
+	}
+}
+
+func TestNewUsesCustomCoreForExternalSink(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+
+	logger, err := New(config.LoggingConfig{
+		Level: config.LogLevelDebug,
+		Sink:  config.LogSinkMongo,
+	}, WithCore(core))
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+
+	logger.Debug("captured", zap.String("sink", "mongo"))
+	if got := observed.Len(); got != 1 {
+		t.Fatalf("observed log count = %d, want 1", got)
+	}
+	if got := observed.All()[0].ContextMap()["sink"]; got != "mongo" {
+		t.Fatalf("observed sink field = %#v, want %q", got, "mongo")
+	}
+}
+
+func TestNewRequiresExternalCoreForMongoSink(t *testing.T) {
+	_, err := New(config.LoggingConfig{
+		Level: config.LogLevelInfo,
+		Sink:  config.LogSinkMongo,
+	})
+	if err == nil {
+		t.Fatal("New() error = nil, want mongo external core error")
+	}
+	if !strings.Contains(err.Error(), "mongo sink requires an external zapcore.Core") {
+		t.Fatalf("New() error = %q, want mongo external core message", err)
+	}
+}
+
+func TestWithCoreRejectsNilCore(t *testing.T) {
+	_, err := New(config.Default().Logging, WithCore(nil))
+	if err == nil {
+		t.Fatal("New(..., WithCore(nil)) error = nil, want error")
+	}
+}


### PR DESCRIPTION
Closes #9

## Summary
- add typed logging config with stderr/stdout defaults and selectable mongo sink
- add a Zap-backed logging package with external core injection for optional Mongo logging
- wire framework.App to create or accept a logger, plus docs and an example

## Acceptance criteria
- Zap remains the runtime logger
- Mongo logging is selectable without importing a Mongo driver in runtime logging code
- app boots and logs with Mongo absent by default

## Verification
- `go test ./...`
- `git diff --check`
- `golangci-lint run` was not run locally because golangci-lint is not installed