### PR TITLE
[M2-2] gombit db migrate / rollback / status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12.2
 
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -52,10 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -104,10 +104,10 @@ jobs:
           --health-retries 12
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -171,10 +171,10 @@ jobs:
           --health-retries 12
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,17 +63,27 @@ jobs:
       - name: Run tests
         run: go test ./...
 
-  database:
-    name: Database (${{ matrix.driver }})
+  database-sqlite:
+    name: Database (sqlite)
     needs: test
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        driver:
-          - sqlite
-          - postgres
-          - mysql
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run SQLite database tests
+        run: go test ./database
+
+  database-postgres:
+    name: Database (postgres)
+    needs: test
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:16-alpine
@@ -88,6 +98,27 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run Postgres database tests
+        run: >-
+          go test -tags integration ./database
+          -database.postgres-dsn
+          'postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable'
+
+  database-mysql:
+    name: Database (mysql)
+    needs: test
+    runs-on: ubuntu-latest
+    services:
       mysql:
         image: mysql:8.4
         env:
@@ -112,63 +143,16 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Run SQLite database tests
-        if: matrix.driver == 'sqlite'
-        run: go test ./database
-
-      - name: Run Postgres database tests
-        if: matrix.driver == 'postgres'
-        run: >-
-          go test -tags integration ./database
-          -database.postgres-dsn
-          'postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable'
-
       - name: Run MySQL database tests
-        if: matrix.driver == 'mysql'
         run: >-
           go test -tags integration ./database
           -database.mysql-dsn
           'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
 
-  migrations:
-    name: Migrations (${{ matrix.driver }})
+  migrations-sqlite:
+    name: Migrations (sqlite)
     needs: test
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        driver:
-          - sqlite
-          - postgres
-          - mysql
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: gombit
-          POSTGRES_PASSWORD: gombit
-          POSTGRES_DB: gombit
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U gombit -d gombit"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 12
-      mysql:
-        image: mysql:8.4
-        env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: gombit
-          MYSQL_USER: gombit
-          MYSQL_PASSWORD: gombit
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd "mysqladmin ping -ugombit -pgombit"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 12
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -182,21 +166,75 @@ jobs:
       - name: Install Atlas Community Edition
         run: curl -sSf https://atlasgo.sh | sh -s -- --community
 
-      - name: Run migration unit tests
-        if: matrix.driver == 'sqlite'
+      - name: Run migration unit and Atlas smoke tests
         env:
           ATLAS_BINARY: atlas
         run: go test ./migrations ./cmd/gombit
 
+  migrations-postgres:
+    name: Migrations (postgres)
+    needs: test
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: gombit
+          POSTGRES_PASSWORD: gombit
+          POSTGRES_DB: gombit
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U gombit -d gombit"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Run Postgres migration integration tests
-        if: matrix.driver == 'postgres'
         run: >-
           go test -tags integration ./migrations
           -migrations.postgres-dsn
           'postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable'
 
+  migrations-mysql:
+    name: Migrations (mysql)
+    needs: test
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: gombit
+          MYSQL_USER: gombit
+          MYSQL_PASSWORD: gombit
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -ugombit -pgombit"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Run MySQL migration integration tests
-        if: matrix.driver == 'mysql'
         run: >-
           go test -tags integration ./migrations
           -migrations.mysql-dsn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,41 @@ jobs:
   migrations:
     name: Migrations
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        driver:
+          - sqlite
+          - postgres
+          - mysql
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: gombit
+          POSTGRES_PASSWORD: gombit
+          POSTGRES_DB: gombit
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U gombit -d gombit"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: gombit
+          MYSQL_USER: gombit
+          MYSQL_PASSWORD: gombit
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -ugombit -pgombit"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -108,10 +143,25 @@ jobs:
       - name: Install Atlas Community Edition
         run: curl -sSf https://atlasgo.sh | sh -s -- --community
 
-      - name: Run migration tests
+      - name: Run migration unit tests
+        if: matrix.driver == 'sqlite'
         env:
           ATLAS_BINARY: atlas
-        run: go test ./migrations
+        run: go test ./migrations ./cmd/gombit
+
+      - name: Run Postgres migration integration tests
+        if: matrix.driver == 'postgres'
+        run: >-
+          go test -tags integration ./migrations
+          -migrations.postgres-dsn
+          'postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable'
+
+      - name: Run MySQL migration integration tests
+        if: matrix.driver == 'mysql'
+        run: >-
+          go test -tags integration ./migrations
+          -migrations.mysql-dsn
+          'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,46 @@ on:
 permissions:
   contents: read
 
+# Pipeline: lint → build → test → (database ∥ migrations)
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.12.2
+
+  build:
+    name: Build
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build packages
+        run: go build ./...
+
   test:
     name: Test
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,6 +65,7 @@ jobs:
 
   database:
     name: Database (${{ matrix.driver }})
+    needs: test
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -93,7 +131,8 @@ jobs:
           'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
 
   migrations:
-    name: Migrations
+    name: Migrations (${{ matrix.driver }})
+    needs: test
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -162,21 +201,3 @@ jobs:
           go test -tags integration ./migrations
           -migrations.mysql-dsn
           'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
-        with:
-          version: v2.12.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,70 @@
-# Local Go tooling caches (never commit)
+# Binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+/bin/
+/dist/
+/build/
+
+# Go workspace / module tooling
+vendor/
 .gocache/
 .gomodcache/
 .tmp/
+*.coverprofile
+coverage.out
+coverage.html
+profile.out
+cpu.prof
+mem.prof
+
+# Secrets and local env (keep *.example tracked)
+.env
+.env.*
+!.env.example
+!.env.*.example
+
+# Local databases and runtime data
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+*.sqlite
+*.sqlite3
 
 # Atlas / makemigrations scratch
 .gombit/
+
+# Node / frontend (future Vite apps)
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.pnpm-store/
+.next/
+.vite/
+*.tsbuildinfo
+
+# IDE / editors
+.idea/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json.example
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# Logs and temp
+*.log
+tmp/
+temp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Local Go tooling caches (never commit)
+.gocache/
+.gomodcache/
+.tmp/
+
+# Atlas / makemigrations scratch
+.gombit/

--- a/cmd/gombit/main.go
+++ b/cmd/gombit/main.go
@@ -37,6 +37,12 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 	switch args[1] {
 	case "makemigrations":
 		return runMakeMigrations(ctx, args[2:], stdout, stderr)
+	case "migrate":
+		return runMigrate(ctx, args[2:], stdout, stderr)
+	case "rollback":
+		return runRollback(ctx, args[2:], stdout, stderr)
+	case "status":
+		return runStatus(ctx, args[2:], stdout, stderr)
 	default:
 		dbUsage(stderr)
 		return fmt.Errorf("gombit db: unknown subcommand %q", args[1])
@@ -89,6 +95,66 @@ func runMakeMigrations(ctx context.Context, args []string, stdout io.Writer, std
 	})
 }
 
+func runMigrate(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	opts, err := parseApplyFlags("gombit db migrate", args, stderr)
+	if err != nil {
+		return err
+	}
+	return migrations.Migrate(ctx, opts.withWriters(stdout, stderr))
+}
+
+func runRollback(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	opts, err := parseApplyFlags("gombit db rollback", args, stderr)
+	if err != nil {
+		return err
+	}
+	return migrations.Rollback(ctx, opts.withWriters(stdout, stderr))
+}
+
+func runStatus(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	opts, err := parseApplyFlags("gombit db status", args, stderr)
+	if err != nil {
+		return err
+	}
+	return migrations.Status(ctx, opts.withWriters(stdout, stderr))
+}
+
+type applyFlagValues struct {
+	opts migrations.ApplyOptions
+}
+
+func (v applyFlagValues) withWriters(stdout io.Writer, stderr io.Writer) migrations.ApplyOptions {
+	v.opts.Stdout = stdout
+	v.opts.Stderr = stderr
+	return v.opts
+}
+
+func parseApplyFlags(name string, args []string, stderr io.Writer) (applyFlagValues, error) {
+	cfg, err := loadConfig()
+	if err != nil {
+		return applyFlagValues{}, err
+	}
+
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	migrationDir := flags.String("dir", "database/migrations", "migration directory")
+	atlasBin := flags.String("atlas-bin", "atlas", "Atlas CLI binary path")
+	if err := flags.Parse(args); err != nil {
+		return applyFlagValues{}, err
+	}
+	if flags.NArg() != 0 {
+		flags.Usage()
+		return applyFlagValues{}, fmt.Errorf("%s: unexpected argument %q", name, flags.Arg(0))
+	}
+
+	return applyFlagValues{opts: migrations.ApplyOptions{
+		WorkDir:      ".",
+		MigrationDir: *migrationDir,
+		AtlasBinary:  *atlasBin,
+		Database:     cfg.Database,
+	}}, nil
+}
+
 type modelFlags []string
 
 func (m *modelFlags) String() string {
@@ -108,4 +174,7 @@ func usage(w io.Writer) {
 func dbUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "available db subcommands:")
 	_, _ = fmt.Fprintln(w, "  makemigrations <name> --model <import.Type> [--driver sqlite|postgres|mysql]")
+	_, _ = fmt.Fprintln(w, "  migrate [--dir database/migrations] [--atlas-bin atlas]")
+	_, _ = fmt.Fprintln(w, "  rollback [--dir database/migrations]")
+	_, _ = fmt.Fprintln(w, "  status [--dir database/migrations] [--atlas-bin atlas]")
 }

--- a/cmd/gombit/main_test.go
+++ b/cmd/gombit/main_test.go
@@ -263,15 +263,73 @@ func fakeAtlasApplyStatus(t *testing.T) string {
 	script := `#!/bin/sh
 set -eu
 cmd=""
+url=""
+dir=""
 prev=""
 for arg in "$@"; do
   if [ "$prev" = "migrate" ]; then
     cmd="$arg"
   fi
+  if [ "$prev" = "--url" ]; then
+    url="$arg"
+  fi
+  if [ "$prev" = "--dir" ]; then
+    dir="$arg"
+  fi
   prev="$arg"
 done
 case "$cmd" in
   apply)
+    python3 - "$url" "$dir" <<'PY'
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+
+url, dir_url = sys.argv[1], sys.argv[2]
+if not url.startswith("sqlite://"):
+    raise SystemExit(f"unsupported url: {url}")
+rest = url[len("sqlite://"):]
+db_path = rest.split("?", 1)[0]
+mig_dir = dir_url.removeprefix("file://")
+
+conn = sqlite3.connect(db_path)
+try:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS atlas_schema_revisions (
+          version TEXT PRIMARY KEY,
+          description TEXT,
+          type TEXT,
+          applied_at TEXT
+        )
+        """
+    )
+    existing = {
+        row[0]
+        for row in conn.execute("SELECT version FROM atlas_schema_revisions")
+    }
+    for name in sorted(os.listdir(mig_dir)):
+        if (
+            not name.endswith(".sql")
+            or name.endswith(".down.sql")
+            or name == "atlas.sum"
+        ):
+            continue
+        version = name.split("_", 1)[0]
+        if version in existing:
+            continue
+        with open(os.path.join(mig_dir, name), encoding="utf-8") as f:
+            sql = f.read()
+        conn.executescript(sql)
+        conn.execute(
+            "INSERT INTO atlas_schema_revisions (version, description, type, applied_at) VALUES (?, ?, ?, ?)",
+            (version, name, "sql", datetime.now(timezone.utc).isoformat()),
+        )
+    conn.commit()
+finally:
+    conn.close()
+PY
     printf '%s\n' 'fake atlas apply ok'
     ;;
   status)

--- a/cmd/gombit/main_test.go
+++ b/cmd/gombit/main_test.go
@@ -131,7 +131,7 @@ func TestRunMigrateRollbackStatus(t *testing.T) {
 	}
 	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
 		"CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL);")
-	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"),
+	writeFile(t, filepath.Join(migrationDir, "downs", "20260101000000_create_widgets.down.sql"),
 		"DROP TABLE IF EXISTS widgets;")
 
 	dbPath := filepath.Join(workDir, "app.db")
@@ -213,6 +213,9 @@ func stubConfig(t *testing.T, cfg config.Config) {
 
 func writeFile(t *testing.T, path string, content string) {
 	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}

--- a/cmd/gombit/main_test.go
+++ b/cmd/gombit/main_test.go
@@ -119,6 +119,80 @@ func TestRunRejectsUnknownCommand(t *testing.T) {
 	}
 }
 
+func TestRunMigrateRollbackStatus(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake atlas shell script uses POSIX sh")
+	}
+
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "migrations")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
+		"CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL);")
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"),
+		"DROP TABLE IF EXISTS widgets;")
+
+	dbPath := filepath.Join(workDir, "app.db")
+	cfg := config.Default()
+	cfg.Database.Driver = config.DatabaseDriverSQLite
+	cfg.Database.DSN = "file:" + dbPath + "?cache=shared&_fk=1"
+	stubConfig(t, cfg)
+
+	atlas := fakeAtlasApplyStatus(t)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	err := run(context.Background(), []string{
+		"db", "status",
+		"--dir", migrationDir,
+		"--atlas-bin", atlas,
+	}, stdout, stderr)
+	if err != nil {
+		t.Fatalf("status before migrate error = %v; stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "pending") {
+		t.Fatalf("status stdout = %q, want pending", stdout.String())
+	}
+	stdout.Reset()
+
+	err = run(context.Background(), []string{
+		"db", "migrate",
+		"--dir", migrationDir,
+		"--atlas-bin", atlas,
+	}, stdout, stderr)
+	if err != nil {
+		t.Fatalf("migrate error = %v; stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Applied 1 migration(s) in batch 1") {
+		t.Fatalf("migrate stdout = %q", stdout.String())
+	}
+	stdout.Reset()
+
+	err = run(context.Background(), []string{
+		"db", "rollback",
+		"--dir", migrationDir,
+		"--atlas-bin", atlas,
+	}, stdout, stderr)
+	if err != nil {
+		t.Fatalf("rollback error = %v; stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Rolled back batch 1") {
+		t.Fatalf("rollback stdout = %q", stdout.String())
+	}
+}
+
+func TestRunRejectsUnknownDBSubcommand(t *testing.T) {
+	err := run(context.Background(), []string{"db", "seed"}, ioDiscard{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("run() error = nil, want unknown subcommand error")
+	}
+	if !strings.Contains(err.Error(), "unknown subcommand") {
+		t.Fatalf("run() error = %q", err)
+	}
+}
+
 type ioDiscard struct{}
 
 func (ioDiscard) Write(p []byte) (int, error) {
@@ -135,6 +209,13 @@ func stubConfig(t *testing.T, cfg config.Config) {
 	t.Cleanup(func() {
 		loadConfig = previous
 	})
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
 }
 
 func fakeAtlas(t *testing.T) string {
@@ -164,6 +245,43 @@ mkdir -p "$dir"
   printf '%s\n' "-- dev ${dev}"
 } > "$dir/20260101000000_${name}.sql"
 printf '%s\n' 'created migration'
+`
+	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
+		t.Fatalf("write fake atlas: %v", err)
+	}
+	// #nosec G302 -- the fake Atlas script must be executable by this test process.
+	if err := os.Chmod(path, 0o700); err != nil {
+		t.Fatalf("chmod fake atlas: %v", err)
+	}
+	return path
+}
+
+func fakeAtlasApplyStatus(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "atlas")
+	script := `#!/bin/sh
+set -eu
+cmd=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "migrate" ]; then
+    cmd="$arg"
+  fi
+  prev="$arg"
+done
+case "$cmd" in
+  apply)
+    printf '%s\n' 'fake atlas apply ok'
+    ;;
+  status)
+    printf '%s\n' 'fake atlas status'
+    ;;
+  *)
+    printf 'unexpected atlas command: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
 `
 	if err := os.WriteFile(path, []byte(script), 0o600); err != nil {
 		t.Fatalf("write fake atlas: %v", err)

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -72,11 +72,16 @@ gombit db rollback [--dir database/migrations]
 
 1. Ensures the Gombit revision table `framework_migrations` exists.
 2. Runs Atlas Community Edition `atlas migrate apply --url ... --dir file://...`.
-3. Mirrors newly applied versions into `framework_migrations` as one batch:
-   `version`, `name`, `batch`, `applied_at` (no checksum; D4).
+3. Records into `framework_migrations` only the pending versions that appear in
+   `atlas_schema_revisions` after apply (`version`, `name`, `batch`,
+   `applied_at`; no checksum; D4). This keeps the Gombit ledger aligned with
+   Atlas when the two previously diverged.
 
 If nothing is pending relative to `framework_migrations`, migrate prints
 `No pending migrations.` and does not invoke Atlas apply.
+
+Unrecognized `*.sql` filenames in the migration directory are skipped with a
+warning on stderr.
 
 ### Status
 
@@ -92,10 +97,17 @@ command is outside Atlas Community Edition).
 `gombit db rollback` rolls back the **latest batch** only:
 
 1. Loads the highest `batch` from `framework_migrations`.
-2. Requires a companion down file for every version in that batch.
+2. Requires a companion down file for every version in that batch (missing
+   downs fail before any SQL runs; migrate does not require downs).
 3. Executes those down files in reverse version order.
 4. Deletes matching rows from `framework_migrations` and
    `atlas_schema_revisions` so a later `gombit db migrate` can re-apply.
+
+On SQLite and PostgreSQL, downs and revision deletes run in one transaction:
+a mid-batch failure aborts the transaction and leaves revision rows unchanged.
+MySQL DDL often auto-commits, so a mid-batch failure can leave the schema
+partially rolled back while revision rows remain; the error lists completed
+downs and revision rows are only removed after every down succeeds.
 
 ### Down files
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,6 +1,6 @@
 # Migrations
 
-M2-1 introduces `gombit db makemigrations`, a thin wrapper around Atlas
+M2 introduces `gombit db` migration commands as a thin wrapper around Atlas
 versioned migrations and `ariga.io/atlas-provider-gorm` Program Mode. Gombit
 does not define its own migration DSL.
 
@@ -54,9 +54,82 @@ exits without writing a new migration.
 Migration names may contain letters, numbers, underscores, and hyphens, and
 must not start with a hyphen.
 
+## Apply / Status / Rollback
+
+M2-2 adds apply, status, and rollback. These commands read the configured
+database from `config.Load()` (`GOMBIT_DATABASE_DRIVER` / `GOMBIT_DATABASE_DSN`)
+and the migration directory (default `database/migrations`).
+
+```sh
+gombit db migrate [--dir database/migrations] [--atlas-bin atlas]
+gombit db status  [--dir database/migrations] [--atlas-bin atlas]
+gombit db rollback [--dir database/migrations]
+```
+
+### Apply
+
+`gombit db migrate`:
+
+1. Ensures the Gombit revision table `framework_migrations` exists.
+2. Runs Atlas Community Edition `atlas migrate apply --url ... --dir file://...`.
+3. Mirrors newly applied versions into `framework_migrations` as one batch:
+   `version`, `name`, `batch`, `applied_at` (no checksum; D4).
+
+If nothing is pending relative to `framework_migrations`, migrate prints
+`No pending migrations.` and does not invoke Atlas apply.
+
+### Status
+
+`gombit db status` prints Gombit applied/pending rows from the migration
+directory plus `framework_migrations`, then runs `atlas migrate status` for
+Atlas bookkeeping.
+
+### Rollback
+
+Rollback is Gombit-owned and does **not** wrap `atlas migrate down` (that
+command is outside Atlas Community Edition).
+
+`gombit db rollback` rolls back the **latest batch** only:
+
+1. Loads the highest `batch` from `framework_migrations`.
+2. Requires a companion down file for every version in that batch.
+3. Executes those down files in reverse version order.
+4. Deletes matching rows from `framework_migrations` and
+   `atlas_schema_revisions` so a later `gombit db migrate` can re-apply.
+
+### Down files
+
+Atlas writes up migrations such as:
+
+```text
+20260101000000_create_products.sql
+```
+
+Gombit expects an application-owned companion for rollback:
+
+```text
+20260101000000_create_products.down.sql
+```
+
+If any down file in the latest batch is missing, rollback fails before
+executing any down SQL.
+
+## Revision metadata
+
+| Column | Notes |
+| --- | --- |
+| `version` | Atlas migration version prefix |
+| `name` | Migration name suffix |
+| `batch` | Incremented once per successful migrate that applies files |
+| `applied_at` | UTC timestamp when the batch was recorded |
+
+Atlas may still maintain `atlas.sum` and `atlas_schema_revisions` for apply
+integrity. That is separate from D4: Gombit does not store checksums in
+`framework_migrations`.
+
 ## Drivers
 
-`--driver` accepts the supported v0.1 database drivers:
+`--driver` (makemigrations) accepts the supported v0.1 database drivers:
 
 | Driver | Atlas dev database |
 | --- | --- |
@@ -66,6 +139,9 @@ must not start with a hyphen.
 
 SQLite runs without Docker. PostgreSQL and MySQL use Atlas dev-database Docker
 URLs, so Docker must be available when generating those migrations.
+
+Apply/status convert the configured GORM DSN into an Atlas `--url` for the
+same three drivers.
 
 ## Model Registration
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -71,7 +71,10 @@ gombit db rollback [--dir database/migrations]
 `gombit db migrate`:
 
 1. Ensures the Gombit revision table `framework_migrations` exists.
-2. Runs Atlas Community Edition `atlas migrate apply --url ... --dir file://...`.
+2. Runs Atlas Community Edition
+   `atlas migrate apply --url ... --dir file://... --allow-dirty`.
+   `--allow-dirty` is required because Gombit creates `framework_migrations`
+   before apply, and real apps already have schema tables.
 3. Records into `framework_migrations` only the pending versions that appear in
    `atlas_schema_revisions` after apply (`version`, `name`, `batch`,
    `applied_at`; no checksum; D4). This keeps the Gombit ledger aligned with

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -117,17 +117,18 @@ downs and revision rows are only removed after every down succeeds.
 Atlas writes up migrations such as:
 
 ```text
-20260101000000_create_products.sql
+database/migrations/20260101000000_create_products.sql
 ```
 
-Gombit expects an application-owned companion for rollback:
+Gombit-owned down SQL lives in a subdirectory so Atlas never scans it (Atlas
+panics if `.down.sql` files sit beside versioned up migrations):
 
 ```text
-20260101000000_create_products.down.sql
+database/migrations/downs/20260101000000_create_products.down.sql
 ```
 
 If any down file in the latest batch is missing, rollback fails before
-executing any down SQL.
+executing any down SQL. Migrate does not require downs.
 
 ## Revision metadata
 

--- a/examples/migrations/README.md
+++ b/examples/migrations/README.md
@@ -1,6 +1,9 @@
 # Migration Example
 
-Run the example command from the repository root:
+Run these commands from the repository root. Install Atlas Community Edition
+first (`curl -sSf https://atlasgo.sh | sh -s -- --community`).
+
+## Generate
 
 ```sh
 gombit db makemigrations create_products \
@@ -11,3 +14,30 @@ gombit db makemigrations create_products \
 This demonstrates the feature-package model path used by the temporary Atlas
 Program Mode loader. The generated migration files are written to
 `database/migrations` unless `--dir` is provided.
+
+## Apply, status, and rollback
+
+After generating an up migration, add a companion down file with the same
+version/name prefix, for example:
+
+```text
+database/migrations/20260101000000_create_products.sql
+database/migrations/20260101000000_create_products.down.sql
+```
+
+Configure the database (defaults are SQLite) and run:
+
+```sh
+export GOMBIT_DATABASE_DRIVER=sqlite
+export GOMBIT_DATABASE_DSN='file:gombit.db?cache=shared&_fk=1'
+
+gombit db status
+gombit db migrate
+gombit db status
+gombit db rollback
+```
+
+`migrate` wraps `atlas migrate apply` and records the applied versions in
+`framework_migrations` as one batch. `rollback` executes the latest batch's
+`.down.sql` files and clears both Gombit and Atlas revision rows for those
+versions. Seed/reset commands are tracked separately in M2-3.

--- a/examples/migrations/README.md
+++ b/examples/migrations/README.md
@@ -22,7 +22,7 @@ version/name prefix, for example:
 
 ```text
 database/migrations/20260101000000_create_products.sql
-database/migrations/20260101000000_create_products.down.sql
+database/migrations/downs/20260101000000_create_products.down.sql
 ```
 
 Configure the database (defaults are SQLite) and run:
@@ -39,5 +39,5 @@ gombit db rollback
 
 `migrate` wraps `atlas migrate apply` and records the applied versions in
 `framework_migrations` as one batch. `rollback` executes the latest batch's
-`.down.sql` files and clears both Gombit and Atlas revision rows for those
+`downs/*.down.sql` files and clears both Gombit and Atlas revision rows for those
 versions. Seed/reset commands are tracked separately in M2-3.

--- a/migrations/apply_test.go
+++ b/migrations/apply_test.go
@@ -1,0 +1,318 @@
+package migrations
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+)
+
+func TestMigrateRollbackStatusSQLiteRoundTrip(t *testing.T) {
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
+		"CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL);")
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"),
+		"DROP TABLE widgets;")
+	writeFile(t, filepath.Join(migrationDir, "20260102000000_add_widget_note.sql"),
+		"ALTER TABLE widgets ADD COLUMN note TEXT;")
+	writeFile(t, filepath.Join(migrationDir, "20260102000000_add_widget_note.down.sql"),
+		"ALTER TABLE widgets DROP COLUMN note;")
+
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	runner := &applyFakeAtlas{t: t}
+	fixedNow := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+	stdout := new(bytes.Buffer)
+
+	opts := ApplyOptions{
+		WorkDir:      workDir,
+		MigrationDir: "database/migrations",
+		AtlasBinary:  "atlas",
+		Database:     cfg,
+		Stdout:       stdout,
+		Stderr:       io.Discard,
+		runner:       runner,
+		now:          func() time.Time { return fixedNow },
+	}
+
+	if err := Status(context.Background(), opts); err != nil {
+		t.Fatalf("Status() before migrate error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "pending") || !strings.Contains(stdout.String(), "20260101000000") {
+		t.Fatalf("status before migrate = %q, want pending migrations", stdout.String())
+	}
+	stdout.Reset()
+
+	if err := Migrate(context.Background(), opts); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Applied 2 migration(s) in batch 1") {
+		t.Fatalf("migrate stdout = %q", stdout.String())
+	}
+	if len(runner.applyCalls) != 1 {
+		t.Fatalf("atlas apply calls = %d, want 1", len(runner.applyCalls))
+	}
+	stdout.Reset()
+
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !db.Migrator().HasTable("widgets") {
+		t.Fatal("expected widgets table after migrate")
+	}
+	revisions, err := listRevisions(db.DB)
+	if err != nil {
+		t.Fatalf("listRevisions() error = %v", err)
+	}
+	if len(revisions) != 2 || revisions[0].Batch != 1 || revisions[0].AppliedAt.UTC() != fixedNow {
+		t.Fatalf("revisions = %#v", revisions)
+	}
+	if !db.Migrator().HasTable(atlasRevisionsTable) {
+		t.Fatal("expected atlas_schema_revisions after fake apply")
+	}
+
+	if err := Status(context.Background(), opts); err != nil {
+		t.Fatalf("Status() after migrate error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "applied") || strings.Contains(stdout.String(), "pending\t") {
+		t.Fatalf("status after migrate = %q", stdout.String())
+	}
+	stdout.Reset()
+
+	if err := Rollback(context.Background(), opts); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Rolled back batch 1 (2 migration(s))") {
+		t.Fatalf("rollback stdout = %q", stdout.String())
+	}
+	if db.Migrator().HasTable("widgets") {
+		t.Fatal("widgets table should be gone after rollback")
+	}
+	revisions, err = listRevisions(db.DB)
+	if err != nil {
+		t.Fatalf("listRevisions() after rollback error = %v", err)
+	}
+	if len(revisions) != 0 {
+		t.Fatalf("revisions after rollback = %#v", revisions)
+	}
+	var atlasCount int64
+	if err := db.Table(atlasRevisionsTable).Count(&atlasCount).Error; err != nil {
+		t.Fatalf("count atlas revisions: %v", err)
+	}
+	if atlasCount != 0 {
+		t.Fatalf("atlas revisions after rollback = %d, want 0", atlasCount)
+	}
+	stdout.Reset()
+
+	if err := Migrate(context.Background(), opts); err != nil {
+		t.Fatalf("Migrate() after rollback error = %v", err)
+	}
+	if !db.Migrator().HasTable("widgets") {
+		t.Fatal("expected widgets table after re-migrate")
+	}
+}
+
+func TestMigrateNoPending(t *testing.T) {
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	stdout := new(bytes.Buffer)
+	runner := &applyFakeAtlas{t: t}
+
+	opts := ApplyOptions{
+		WorkDir:      workDir,
+		MigrationDir: migrationDir,
+		Database:     cfg,
+		Stdout:       stdout,
+		runner:       runner,
+	}
+	if err := Migrate(context.Background(), opts); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "No pending migrations") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if len(runner.applyCalls) != 0 {
+		t.Fatalf("unexpected atlas apply calls: %d", len(runner.applyCalls))
+	}
+}
+
+func TestRollbackMissingDownFails(t *testing.T) {
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
+		"CREATE TABLE widgets (id INTEGER PRIMARY KEY);")
+
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	opts := ApplyOptions{
+		WorkDir:      workDir,
+		MigrationDir: migrationDir,
+		Database:     cfg,
+		Stdout:       io.Discard,
+		runner:       &applyFakeAtlas{t: t},
+	}
+	if err := Migrate(context.Background(), opts); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+	err := Rollback(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Rollback() error = nil, want missing down error")
+	}
+	if !strings.Contains(err.Error(), "missing down migration") {
+		t.Fatalf("Rollback() error = %q", err)
+	}
+}
+
+func TestRollbackNothingToDo(t *testing.T) {
+	workDir := t.TempDir()
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	stdout := new(bytes.Buffer)
+	err := Rollback(context.Background(), ApplyOptions{
+		WorkDir:      workDir,
+		MigrationDir: filepath.Join(workDir, "database", "migrations"),
+		Database:     config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn},
+		Stdout:       stdout,
+	})
+	if err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Nothing to roll back") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+type applyFakeAtlas struct {
+	t          *testing.T
+	applyCalls [][]string
+}
+
+func (r *applyFakeAtlas) Run(ctx context.Context, dir string, name string, args []string, stdout io.Writer, stderr io.Writer) error {
+	r.t.Helper()
+	if len(args) < 2 || args[0] != "migrate" {
+		return fmt.Errorf("unexpected args: %v", args)
+	}
+	switch args[1] {
+	case "apply":
+		r.applyCalls = append(r.applyCalls, append([]string{}, args...))
+		return r.apply(dir, args, stdout)
+	case "status":
+		_, _ = io.WriteString(stdout, "fake atlas status\n")
+		return nil
+	default:
+		return fmt.Errorf("unexpected atlas subcommand: %v", args)
+	}
+}
+
+func (r *applyFakeAtlas) apply(workDir string, args []string, stdout io.Writer) error {
+	r.t.Helper()
+	urlValue, dirURL, err := parseAtlasURLAndDir(args)
+	if err != nil {
+		return err
+	}
+	migrationDir := strings.TrimPrefix(dirURL, "file://")
+	if !filepath.IsAbs(migrationDir) {
+		migrationDir = filepath.Join(workDir, migrationDir)
+	}
+
+	dsn := strings.TrimPrefix(urlValue, "sqlite://")
+	db, err := database.Open(config.DatabaseConfig{
+		Driver: config.DatabaseDriverSQLite,
+		DSN:    "file:" + dsn,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.Exec(fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+  version varchar(255) PRIMARY KEY,
+  description text,
+  type varchar(255),
+  applied_at datetime
+)`, atlasRevisionsTable)).Error; err != nil {
+		return err
+	}
+
+	files, err := ListMigrationFiles(migrationDir)
+	if err != nil {
+		return err
+	}
+	var existing []string
+	if err := db.Table(atlasRevisionsTable).Select("version").Find(&existing).Error; err != nil {
+		return err
+	}
+	applied := make(map[string]struct{}, len(existing))
+	for _, version := range existing {
+		applied[version] = struct{}{}
+	}
+
+	for _, file := range files {
+		if _, ok := applied[file.Version]; ok {
+			continue
+		}
+		sqlBytes, err := os.ReadFile(file.UpPath)
+		if err != nil {
+			return err
+		}
+		if err := db.Exec(string(sqlBytes)).Error; err != nil {
+			return err
+		}
+		if err := db.Exec(
+			fmt.Sprintf("INSERT INTO %s (version, description, type, applied_at) VALUES (?, ?, ?, ?)", atlasRevisionsTable),
+			file.Version,
+			file.Name,
+			"sql",
+			time.Now().UTC(),
+		).Error; err != nil {
+			return err
+		}
+	}
+	_, _ = io.WriteString(stdout, "fake atlas apply ok\n")
+	return nil
+}
+
+func parseAtlasURLAndDir(args []string) (atlasURL string, dirURL string, err error) {
+	for i := 0; i < len(args)-1; i++ {
+		switch args[i] {
+		case "--url":
+			atlasURL = args[i+1]
+		case "--dir":
+			dirURL = args[i+1]
+		}
+	}
+	if atlasURL == "" || dirURL == "" {
+		return "", "", fmt.Errorf("missing --url/--dir in %v", args)
+	}
+	return atlasURL, dirURL, nil
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/migrations/apply_test.go
+++ b/migrations/apply_test.go
@@ -204,9 +204,109 @@ func TestRollbackNothingToDo(t *testing.T) {
 	}
 }
 
+func TestMigrateRecordsOnlyVersionsPresentInAtlas(t *testing.T) {
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
+		"CREATE TABLE widgets (id INTEGER PRIMARY KEY);")
+	writeFile(t, filepath.Join(migrationDir, "20260102000000_create_gadgets.sql"),
+		"CREATE TABLE gadgets (id INTEGER PRIMARY KEY);")
+
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	stderr := new(bytes.Buffer)
+	opts := ApplyOptions{
+		WorkDir:      workDir,
+		MigrationDir: migrationDir,
+		Database:     cfg,
+		Stdout:       io.Discard,
+		Stderr:       stderr,
+		runner: &applyFakeAtlas{
+			t:            t,
+			applyVersions: map[string]bool{"20260101000000": true},
+		},
+	}
+	if err := Migrate(context.Background(), opts); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	revisions, err := listRevisions(db.DB)
+	if err != nil {
+		t.Fatalf("listRevisions() error = %v", err)
+	}
+	if len(revisions) != 1 || revisions[0].Version != "20260101000000" {
+		t.Fatalf("revisions = %#v, want only 20260101000000", revisions)
+	}
+	if !strings.Contains(stderr.String(), "recording 1 of 2 pending") {
+		t.Fatalf("stderr = %q, want partial-record warning", stderr.String())
+	}
+}
+
+func TestRollbackMidBatchFailureAbortsTransaction(t *testing.T) {
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
+		"CREATE TABLE widgets (id INTEGER PRIMARY KEY);")
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"),
+		"THIS IS NOT VALID SQL;")
+	writeFile(t, filepath.Join(migrationDir, "20260102000000_create_gadgets.sql"),
+		"CREATE TABLE gadgets (id INTEGER PRIMARY KEY);")
+	writeFile(t, filepath.Join(migrationDir, "20260102000000_create_gadgets.down.sql"),
+		"DROP TABLE gadgets;")
+
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	opts := ApplyOptions{
+		WorkDir:      workDir,
+		MigrationDir: migrationDir,
+		Database:     cfg,
+		Stdout:       io.Discard,
+		runner:       &applyFakeAtlas{t: t},
+	}
+	if err := Migrate(context.Background(), opts); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	err := Rollback(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Rollback() error = nil, want mid-batch failure")
+	}
+	if !strings.Contains(err.Error(), "framework_migrations unchanged") {
+		t.Fatalf("Rollback() error = %q, want unchanged revisions guidance", err)
+	}
+
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !db.Migrator().HasTable("widgets") || !db.Migrator().HasTable("gadgets") {
+		t.Fatal("expected both tables to remain after aborted transactional rollback")
+	}
+	revisions, err := listRevisions(db.DB)
+	if err != nil {
+		t.Fatalf("listRevisions() error = %v", err)
+	}
+	if len(revisions) != 2 {
+		t.Fatalf("revisions len = %d, want 2 after aborted rollback", len(revisions))
+	}
+}
+
 type applyFakeAtlas struct {
-	t          *testing.T
-	applyCalls [][]string
+	t             *testing.T
+	applyCalls    [][]string
+	applyVersions map[string]bool
 }
 
 func (r *applyFakeAtlas) Run(ctx context.Context, dir string, name string, args []string, stdout io.Writer, stderr io.Writer) error {
@@ -272,6 +372,9 @@ CREATE TABLE IF NOT EXISTS %s (
 
 	for _, file := range files {
 		if _, ok := applied[file.Version]; ok {
+			continue
+		}
+		if r.applyVersions != nil && !r.applyVersions[file.Version] {
 			continue
 		}
 		sqlBytes, err := os.ReadFile(file.UpPath)

--- a/migrations/apply_test.go
+++ b/migrations/apply_test.go
@@ -24,11 +24,11 @@ func TestMigrateRollbackStatusSQLiteRoundTrip(t *testing.T) {
 
 	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
 		"CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL);")
-	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"),
+	writeFile(t, filepath.Join(migrationDir, "downs", "20260101000000_create_widgets.down.sql"),
 		"DROP TABLE widgets;")
 	writeFile(t, filepath.Join(migrationDir, "20260102000000_add_widget_note.sql"),
 		"ALTER TABLE widgets ADD COLUMN note TEXT;")
-	writeFile(t, filepath.Join(migrationDir, "20260102000000_add_widget_note.down.sql"),
+	writeFile(t, filepath.Join(migrationDir, "downs", "20260102000000_add_widget_note.down.sql"),
 		"ALTER TABLE widgets DROP COLUMN note;")
 
 	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
@@ -258,11 +258,11 @@ func TestRollbackMidBatchFailureAbortsTransaction(t *testing.T) {
 	}
 	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
 		"CREATE TABLE widgets (id INTEGER PRIMARY KEY);")
-	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"),
+	writeFile(t, filepath.Join(migrationDir, "downs", "20260101000000_create_widgets.down.sql"),
 		"THIS IS NOT VALID SQL;")
 	writeFile(t, filepath.Join(migrationDir, "20260102000000_create_gadgets.sql"),
 		"CREATE TABLE gadgets (id INTEGER PRIMARY KEY);")
-	writeFile(t, filepath.Join(migrationDir, "20260102000000_create_gadgets.down.sql"),
+	writeFile(t, filepath.Join(migrationDir, "downs", "20260102000000_create_gadgets.down.sql"),
 		"DROP TABLE gadgets;")
 
 	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
@@ -415,6 +415,9 @@ func parseAtlasURLAndDir(args []string) (atlasURL string, dirURL string, err err
 
 func writeFile(t *testing.T, path string, content string) {
 	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}

--- a/migrations/atlas_smoke_test.go
+++ b/migrations/atlas_smoke_test.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,12 +34,15 @@ func TestMigrateStatusRollbackAtlasCLISQLiteWhenAvailable(t *testing.T) {
 	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"),
 		"DROP TABLE IF EXISTS `widgets`;\n")
 
-	// #nosec G204 -- smoke test runs the Atlas CLI from ATLAS_BINARY or PATH.
-	// #nosec G204 -- smoke test intentionally runs the configured Atlas CLI binary.
-	hash := exec.Command(atlasBin, "migrate", "hash", "--dir", "file://"+filepath.ToSlash(migrationDir))
-	hash.Dir = workDir
-	if out, err := hash.CombinedOutput(); err != nil {
-		t.Fatalf("atlas migrate hash: %v\n%s", err, out)
+	hashArgs := []string{
+		"migrate",
+		"hash",
+		"--dir",
+		"file://" + filepath.ToSlash(migrationDir),
+	}
+	var hashErr bytes.Buffer
+	if err := (execRunner{}).Run(context.Background(), workDir, atlasBin, hashArgs, io.Discard, &hashErr); err != nil {
+		t.Fatalf("atlas migrate hash: %v\n%s", err, hashErr.String())
 	}
 
 	dbPath := filepath.Join(workDir, "app.db")

--- a/migrations/atlas_smoke_test.go
+++ b/migrations/atlas_smoke_test.go
@@ -1,0 +1,126 @@
+package migrations
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+)
+
+func TestMigrateStatusRollbackAtlasCLISQLiteWhenAvailable(t *testing.T) {
+	atlasBin := os.Getenv("ATLAS_BINARY")
+	if atlasBin == "" {
+		var err error
+		atlasBin, err = exec.LookPath("atlas")
+		if err != nil {
+			t.Skip("Atlas CLI not found; set ATLAS_BINARY to run the real SQLite migrate smoke test")
+		}
+	}
+
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
+		"-- Create \"widgets\" table\nCREATE TABLE `widgets` (`id` integer NULL PRIMARY KEY AUTOINCREMENT, `name` text NOT NULL);\n")
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"),
+		"DROP TABLE IF EXISTS `widgets`;\n")
+
+	hash := exec.Command(atlasBin, "migrate", "hash", "--dir", "file://"+filepath.ToSlash(migrationDir))
+	hash.Dir = workDir
+	if out, err := hash.CombinedOutput(); err != nil {
+		t.Fatalf("atlas migrate hash: %v\n%s", err, out)
+	}
+
+	dbPath := filepath.Join(workDir, "app.db")
+	cfg := config.DatabaseConfig{
+		Driver: config.DatabaseDriverSQLite,
+		DSN:    "file:" + dbPath + "?cache=shared&_fk=1",
+	}
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	opts := ApplyOptions{
+		WorkDir:      workDir,
+		MigrationDir: "database/migrations",
+		AtlasBinary:  atlasBin,
+		Database:     cfg,
+		Stdout:       stdout,
+		Stderr:       stderr,
+	}
+
+	if err := Migrate(context.Background(), opts); err != nil {
+		t.Fatalf("Migrate() error = %v; stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Applied 1 migration(s) in batch 1") {
+		t.Fatalf("migrate stdout = %q", stdout.String())
+	}
+
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !db.Migrator().HasTable("widgets") {
+		t.Fatal("expected widgets table after real atlas apply")
+	}
+	if !db.Migrator().HasTable(atlasRevisionsTable) {
+		t.Fatal("expected atlas_schema_revisions after real atlas apply")
+	}
+	revisions, err := listRevisions(db.DB)
+	if err != nil {
+		t.Fatalf("listRevisions() error = %v", err)
+	}
+	if len(revisions) != 1 || revisions[0].Version != "20260101000000" {
+		t.Fatalf("revisions = %#v", revisions)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := Status(context.Background(), opts); err != nil {
+		t.Fatalf("Status() error = %v; stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "applied") || !strings.Contains(stdout.String(), "20260101000000") {
+		t.Fatalf("status stdout = %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Atlas migration status") {
+		t.Fatalf("status stdout = %q, want atlas status section", stdout.String())
+	}
+
+	stdout.Reset()
+	if err := Rollback(context.Background(), opts); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	if db.Migrator().HasTable("widgets") {
+		t.Fatal("widgets table should be gone after rollback")
+	}
+	revisions, err = listRevisions(db.DB)
+	if err != nil {
+		t.Fatalf("listRevisions() after rollback error = %v", err)
+	}
+	if len(revisions) != 0 {
+		t.Fatalf("revisions after rollback = %#v", revisions)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := Migrate(context.Background(), ApplyOptions{
+		WorkDir:      workDir,
+		MigrationDir: "database/migrations",
+		AtlasBinary:  atlasBin,
+		Database:     cfg,
+		Stdout:       stdout,
+		Stderr:       stderr,
+	}); err != nil {
+		t.Fatalf("Migrate() after rollback error = %v; stderr=%q", err, stderr.String())
+	}
+	if !db.Migrator().HasTable("widgets") {
+		t.Fatal("expected widgets table after re-migrate")
+	}
+}

--- a/migrations/atlas_smoke_test.go
+++ b/migrations/atlas_smoke_test.go
@@ -31,7 +31,7 @@ func TestMigrateStatusRollbackAtlasCLISQLiteWhenAvailable(t *testing.T) {
 	}
 	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
 		"-- Create \"widgets\" table\nCREATE TABLE `widgets` (`id` integer NULL PRIMARY KEY AUTOINCREMENT, `name` text NOT NULL);\n")
-	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"),
+	writeFile(t, filepath.Join(migrationDir, "downs", "20260101000000_create_widgets.down.sql"),
 		"DROP TABLE IF EXISTS `widgets`;\n")
 
 	hashArgs := []string{

--- a/migrations/atlas_smoke_test.go
+++ b/migrations/atlas_smoke_test.go
@@ -33,6 +33,8 @@ func TestMigrateStatusRollbackAtlasCLISQLiteWhenAvailable(t *testing.T) {
 	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"),
 		"DROP TABLE IF EXISTS `widgets`;\n")
 
+	// #nosec G204 -- smoke test runs the Atlas CLI from ATLAS_BINARY or PATH.
+	// #nosec G204 -- smoke test intentionally runs the configured Atlas CLI binary.
 	hash := exec.Command(atlasBin, "migrate", "hash", "--dir", "file://"+filepath.ToSlash(migrationDir))
 	hash.Dir = workDir
 	if out, err := hash.CombinedOutput(); err != nil {

--- a/migrations/atlasurl.go
+++ b/migrations/atlasurl.go
@@ -1,0 +1,132 @@
+package migrations
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+)
+
+var mysqlTCPPattern = regexp.MustCompile(`^(?:([^:@]+)?(?::([^@]*))?@)?tcp\(([^)]+)\)/([^?]*)(\?.*)?$`)
+
+// AtlasURL converts a Gombit database config into an Atlas --url value.
+func AtlasURL(cfg config.DatabaseConfig) (string, error) {
+	if err := config.ValidateDatabase(cfg); err != nil {
+		return "", err
+	}
+	dsn := strings.TrimSpace(cfg.DSN)
+	switch cfg.Driver {
+	case config.DatabaseDriverSQLite:
+		return sqliteAtlasURL(dsn)
+	case config.DatabaseDriverPostgres:
+		return postgresAtlasURL(dsn)
+	case config.DatabaseDriverMySQL:
+		return mysqlAtlasURL(dsn)
+	default:
+		return "", fmt.Errorf("migrations: unsupported driver %q", cfg.Driver)
+	}
+}
+
+func sqliteAtlasURL(dsn string) (string, error) {
+	switch {
+	case strings.HasPrefix(dsn, "sqlite://"):
+		return dsn, nil
+	case strings.HasPrefix(dsn, "file:"):
+		rest := strings.TrimPrefix(dsn, "file:")
+		return "sqlite://" + rest, nil
+	default:
+		return "sqlite://" + dsn, nil
+	}
+}
+
+func postgresAtlasURL(dsn string) (string, error) {
+	switch {
+	case strings.HasPrefix(dsn, "postgres://"), strings.HasPrefix(dsn, "postgresql://"):
+		return dsn, nil
+	case strings.Contains(dsn, "="):
+		return postgresKeyValueURL(dsn)
+	default:
+		return "", fmt.Errorf("migrations: unsupported postgres DSN %q", dsn)
+	}
+}
+
+func postgresKeyValueURL(dsn string) (string, error) {
+	values := make(map[string]string)
+	for _, part := range strings.Fields(dsn) {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			return "", fmt.Errorf("migrations: invalid postgres DSN fragment %q", part)
+		}
+		values[key] = value
+	}
+	host := values["host"]
+	if host == "" {
+		host = "localhost"
+	}
+	port := values["port"]
+	if port == "" {
+		port = "5432"
+	}
+	user := values["user"]
+	password := values["password"]
+	dbname := values["dbname"]
+	if dbname == "" {
+		return "", fmt.Errorf("migrations: postgres DSN missing dbname")
+	}
+
+	u := &url.URL{
+		Scheme: "postgres",
+		Host:   host + ":" + port,
+		Path:   "/" + dbname,
+	}
+	if user != "" {
+		if password != "" {
+			u.User = url.UserPassword(user, password)
+		} else {
+			u.User = url.User(user)
+		}
+	}
+	query := url.Values{}
+	for key, value := range values {
+		switch key {
+		case "host", "port", "user", "password", "dbname":
+			continue
+		default:
+			query.Set(key, value)
+		}
+	}
+	u.RawQuery = query.Encode()
+	return u.String(), nil
+}
+
+func mysqlAtlasURL(dsn string) (string, error) {
+	if strings.HasPrefix(dsn, "mysql://") {
+		return dsn, nil
+	}
+	matches := mysqlTCPPattern.FindStringSubmatch(dsn)
+	if matches == nil {
+		return "", fmt.Errorf("migrations: unsupported mysql DSN %q", dsn)
+	}
+	user := matches[1]
+	password := matches[2]
+	host := matches[3]
+	dbname := matches[4]
+	rawQuery := strings.TrimPrefix(matches[5], "?")
+
+	u := &url.URL{
+		Scheme:   "mysql",
+		Host:     host,
+		Path:     "/" + dbname,
+		RawQuery: rawQuery,
+	}
+	if user != "" {
+		if password != "" {
+			u.User = url.UserPassword(user, password)
+		} else {
+			u.User = url.User(user)
+		}
+	}
+	return u.String(), nil
+}

--- a/migrations/atlasurl_test.go
+++ b/migrations/atlasurl_test.go
@@ -33,33 +33,33 @@ func TestAtlasURL(t *testing.T) {
 			name: "postgres url",
 			cfg: config.DatabaseConfig{
 				Driver: config.DatabaseDriverPostgres,
-				DSN:    "postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable",
+				DSN:    "postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable", // #nosec G101 -- fake local test DSN.
 			},
-			want: "postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable",
+			want: "postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable", // #nosec G101 -- fake local test DSN.
 		},
 		{
 			name: "postgres key value",
 			cfg: config.DatabaseConfig{
 				Driver: config.DatabaseDriverPostgres,
-				DSN:    "host=localhost user=gombit password=secret dbname=app sslmode=disable",
+				DSN:    "host=localhost user=gombit password=secret dbname=app sslmode=disable", // #nosec G101 -- fake local test DSN.
 			},
-			want: "postgres://gombit:secret@localhost:5432/app?sslmode=disable",
+			want: "postgres://gombit:secret@localhost:5432/app?sslmode=disable", // #nosec G101 -- fake local test DSN.
 		},
 		{
 			name: "mysql tcp",
 			cfg: config.DatabaseConfig{
 				Driver: config.DatabaseDriverMySQL,
-				DSN:    "gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true",
+				DSN:    "gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true", // #nosec G101 -- fake local test DSN.
 			},
-			want: "mysql://gombit:gombit@127.0.0.1:3306/gombit?parseTime=true",
+			want: "mysql://gombit:gombit@127.0.0.1:3306/gombit?parseTime=true", // #nosec G101 -- fake local test DSN.
 		},
 		{
 			name: "mysql already atlas",
 			cfg: config.DatabaseConfig{
 				Driver: config.DatabaseDriverMySQL,
-				DSN:    "mysql://gombit:gombit@127.0.0.1:3306/gombit",
+				DSN:    "mysql://gombit:gombit@127.0.0.1:3306/gombit", // #nosec G101 -- fake local test DSN.
 			},
-			want: "mysql://gombit:gombit@127.0.0.1:3306/gombit",
+			want: "mysql://gombit:gombit@127.0.0.1:3306/gombit", // #nosec G101 -- fake local test DSN.
 		},
 		{
 			name: "mysql unsupported",

--- a/migrations/atlasurl_test.go
+++ b/migrations/atlasurl_test.go
@@ -1,0 +1,99 @@
+package migrations
+
+import (
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+)
+
+func TestAtlasURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.DatabaseConfig
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "sqlite file",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverSQLite,
+				DSN:    "file:gombit.db?cache=shared&_fk=1",
+			},
+			want: "sqlite://gombit.db?cache=shared&_fk=1",
+		},
+		{
+			name: "sqlite already atlas",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverSQLite,
+				DSN:    "sqlite://file?mode=memory&_fk=1",
+			},
+			want: "sqlite://file?mode=memory&_fk=1",
+		},
+		{
+			name: "postgres url",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverPostgres,
+				DSN:    "postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable",
+			},
+			want: "postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable",
+		},
+		{
+			name: "postgres key value",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverPostgres,
+				DSN:    "host=localhost user=gombit password=secret dbname=app sslmode=disable",
+			},
+			want: "postgres://gombit:secret@localhost:5432/app?sslmode=disable",
+		},
+		{
+			name: "mysql tcp",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverMySQL,
+				DSN:    "gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true",
+			},
+			want: "mysql://gombit:gombit@127.0.0.1:3306/gombit?parseTime=true",
+		},
+		{
+			name: "mysql already atlas",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverMySQL,
+				DSN:    "mysql://gombit:gombit@127.0.0.1:3306/gombit",
+			},
+			want: "mysql://gombit:gombit@127.0.0.1:3306/gombit",
+		},
+		{
+			name: "mysql unsupported",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverMySQL,
+				DSN:    "unix(/tmp/mysql.sock)/gombit",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty dsn",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverSQLite,
+				DSN:    "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := AtlasURL(tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("AtlasURL() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AtlasURL() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("AtlasURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/migrations/doc.go
+++ b/migrations/doc.go
@@ -1,0 +1,6 @@
+// Package migrations wraps Atlas versioned migrations for Gombit apps.
+//
+// MakeMigrations generates SQL via Atlas Program Mode. Migrate, Status, and
+// Rollback apply and report those migrations while recording D4 metadata in
+// framework_migrations.
+package migrations

--- a/migrations/integration_test.go
+++ b/migrations/integration_test.go
@@ -1,0 +1,203 @@
+//go:build integration
+
+package migrations
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+)
+
+var (
+	postgresDSN = flag.String("migrations.postgres-dsn", "", "PostgreSQL DSN for migration integration tests")
+	mysqlDSN    = flag.String("migrations.mysql-dsn", "", "MySQL DSN for migration integration tests")
+)
+
+func TestMigrateRollbackStatusPostgres(t *testing.T) {
+	if *postgresDSN == "" {
+		t.Skip("set -migrations.postgres-dsn to run Postgres migration integration tests")
+	}
+	runDriverRoundTrip(t, config.DatabaseConfig{
+		Driver: config.DatabaseDriverPostgres,
+		DSN:    *postgresDSN,
+	}, `
+CREATE TABLE IF NOT EXISTS widgets (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL
+);`, `DROP TABLE IF EXISTS widgets;`)
+}
+
+func TestMigrateRollbackStatusMySQL(t *testing.T) {
+	if *mysqlDSN == "" {
+		t.Skip("set -migrations.mysql-dsn to run MySQL migration integration tests")
+	}
+	runDriverRoundTrip(t, config.DatabaseConfig{
+		Driver: config.DatabaseDriverMySQL,
+		DSN:    *mysqlDSN,
+	}, `
+CREATE TABLE IF NOT EXISTS widgets (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL
+);`, `DROP TABLE IF EXISTS widgets;`)
+}
+
+func runDriverRoundTrip(t *testing.T, cfg config.DatabaseConfig, upSQL string, downSQL string) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"), upSQL)
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"), downSQL)
+
+	cleanupDriverDB(t, cfg)
+	t.Cleanup(func() { cleanupDriverDB(t, cfg) })
+
+	runner := &sqlApplyRunner{t: t, cfg: cfg}
+	stdout := new(bytes.Buffer)
+	opts := ApplyOptions{
+		WorkDir:      workDir,
+		MigrationDir: "database/migrations",
+		Database:     cfg,
+		Stdout:       stdout,
+		Stderr:       io.Discard,
+		runner:       runner,
+		now:          func() time.Time { return time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC) },
+	}
+
+	if err := Migrate(context.Background(), opts); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !db.Migrator().HasTable("widgets") {
+		t.Fatal("expected widgets table after migrate")
+	}
+
+	stdout.Reset()
+	if err := Status(context.Background(), opts); err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "applied") {
+		t.Fatalf("status = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	if err := Rollback(context.Background(), opts); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	if db.Migrator().HasTable("widgets") {
+		t.Fatal("widgets table should be gone after rollback")
+	}
+}
+
+func cleanupDriverDB(t *testing.T, cfg config.DatabaseConfig) {
+	t.Helper()
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("cleanup open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	_ = db.Migrator().DropTable("widgets")
+	_ = db.Migrator().DropTable(revisionsTable)
+	_ = db.Migrator().DropTable(atlasRevisionsTable)
+}
+
+type sqlApplyRunner struct {
+	t   *testing.T
+	cfg config.DatabaseConfig
+}
+
+func (r *sqlApplyRunner) Run(ctx context.Context, dir string, name string, args []string, stdout io.Writer, stderr io.Writer) error {
+	r.t.Helper()
+	if len(args) < 2 || args[0] != "migrate" {
+		return fmt.Errorf("unexpected atlas args: %v", args)
+	}
+	switch args[1] {
+	case "status":
+		_, _ = io.WriteString(stdout, "fake atlas status\n")
+		return nil
+	case "apply":
+		return r.apply(dir, args, stdout)
+	default:
+		return fmt.Errorf("unexpected atlas args: %v", args)
+	}
+}
+
+func (r *sqlApplyRunner) apply(workDir string, args []string, stdout io.Writer) error {
+	_, dirURL, err := parseAtlasURLAndDir(args)
+	if err != nil {
+		return err
+	}
+	migrationDir := strings.TrimPrefix(dirURL, "file://")
+	if !filepath.IsAbs(migrationDir) {
+		migrationDir = filepath.Join(workDir, migrationDir)
+	}
+
+	db, err := database.Open(r.cfg)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.Exec(`
+CREATE TABLE IF NOT EXISTS atlas_schema_revisions (
+  version varchar(255) PRIMARY KEY,
+  description text,
+  type varchar(255),
+  applied_at timestamp NULL
+)`).Error; err != nil {
+		return err
+	}
+
+	files, err := ListMigrationFiles(migrationDir)
+	if err != nil {
+		return err
+	}
+	var existing []string
+	if err := db.Table(atlasRevisionsTable).Select("version").Find(&existing).Error; err != nil {
+		return err
+	}
+	applied := make(map[string]struct{}, len(existing))
+	for _, version := range existing {
+		applied[version] = struct{}{}
+	}
+	for _, file := range files {
+		if _, ok := applied[file.Version]; ok {
+			continue
+		}
+		sqlBytes, err := os.ReadFile(file.UpPath)
+		if err != nil {
+			return err
+		}
+		if err := db.Exec(string(sqlBytes)).Error; err != nil {
+			return err
+		}
+		if err := db.Exec(
+			"INSERT INTO atlas_schema_revisions (version, description, type, applied_at) VALUES (?, ?, ?, ?)",
+			file.Version,
+			file.Name,
+			"sql",
+			time.Now().UTC(),
+		).Error; err != nil {
+			return err
+		}
+	}
+	_, _ = io.WriteString(stdout, "fake atlas apply ok\n")
+	return nil
+}

--- a/migrations/integration_test.go
+++ b/migrations/integration_test.go
@@ -60,7 +60,7 @@ func runDriverRoundTrip(t *testing.T, cfg config.DatabaseConfig, upSQL string, d
 		t.Fatalf("mkdir: %v", err)
 	}
 	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"), upSQL)
-	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.down.sql"), downSQL)
+	writeFile(t, filepath.Join(migrationDir, "downs", "20260101000000_create_widgets.down.sql"), downSQL)
 
 	cleanupDriverDB(t, cfg)
 	t.Cleanup(func() { cleanupDriverDB(t, cfg) })

--- a/migrations/makemigrations.go
+++ b/migrations/makemigrations.go
@@ -207,7 +207,7 @@ func validateOptions(opts Options) error {
 }
 
 func (execRunner) Run(ctx context.Context, dir string, name string, args []string, stdout io.Writer, stderr io.Writer) error {
-	// #nosec G204 -- makemigrations intentionally executes the configured Atlas CLI binary.
+	// #nosec G204,G702 -- migrations intentionally executes the configured Atlas CLI binary.
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	cmd.Stdout = stdout

--- a/migrations/migrate.go
+++ b/migrations/migrate.go
@@ -134,6 +134,8 @@ func Migrate(ctx context.Context, opts ApplyOptions) error {
 		atlasURL,
 		"--dir",
 		"file://" + filepath.ToSlash(migrationDir),
+		// framework_migrations (and later app tables) make the DB non-empty before Atlas runs.
+		"--allow-dirty",
 	}
 	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
 		return fmt.Errorf("migrations: atlas migrate apply: %w", err)

--- a/migrations/migrate.go
+++ b/migrations/migrate.go
@@ -1,0 +1,145 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+)
+
+// ApplyOptions configures migrate, rollback, and status commands.
+type ApplyOptions struct {
+	WorkDir      string
+	MigrationDir string
+	AtlasBinary  string
+	Database     config.DatabaseConfig
+	Stdout       io.Writer
+	Stderr       io.Writer
+
+	runner commandRunner
+	openDB func(config.DatabaseConfig) (*database.DB, error)
+	now    func() time.Time
+}
+
+func withApplyDefaults(opts ApplyOptions) ApplyOptions {
+	if opts.WorkDir == "" {
+		opts.WorkDir = "."
+	}
+	if opts.MigrationDir == "" {
+		opts.MigrationDir = defaultMigrationDir
+	}
+	if opts.AtlasBinary == "" {
+		opts.AtlasBinary = defaultAtlasBinary
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = io.Discard
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = io.Discard
+	}
+	if opts.runner == nil {
+		opts.runner = execRunner{}
+	}
+	if opts.openDB == nil {
+		opts.openDB = database.Open
+	}
+	if opts.now == nil {
+		opts.now = time.Now
+	}
+	return opts
+}
+
+func resolveMigrationDir(opts ApplyOptions) (string, error) {
+	absWorkDir, err := filepath.Abs(opts.WorkDir)
+	if err != nil {
+		return "", fmt.Errorf("migrations: resolve work dir: %w", err)
+	}
+	migrationDir := opts.MigrationDir
+	if !filepath.IsAbs(migrationDir) {
+		migrationDir = filepath.Join(absWorkDir, migrationDir)
+	}
+	return migrationDir, nil
+}
+
+func openConfiguredDB(opts ApplyOptions) (*database.DB, error) {
+	db, err := opts.openDB(opts.Database)
+	if err != nil {
+		return nil, fmt.Errorf("migrations: open database: %w", err)
+	}
+	return db, nil
+}
+
+// Migrate applies pending Atlas migrations and mirrors them into framework_migrations.
+func Migrate(ctx context.Context, opts ApplyOptions) error {
+	if ctx == nil {
+		return errors.New("migrations: nil context")
+	}
+	opts = withApplyDefaults(opts)
+	if err := config.ValidateDatabase(opts.Database); err != nil {
+		return err
+	}
+
+	migrationDir, err := resolveMigrationDir(opts)
+	if err != nil {
+		return err
+	}
+	atlasURL, err := AtlasURL(opts.Database)
+	if err != nil {
+		return err
+	}
+
+	db, err := openConfiguredDB(opts)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := ensureRevisionsTable(db.DB); err != nil {
+		return err
+	}
+
+	files, err := ListMigrationFiles(migrationDir)
+	if err != nil {
+		return err
+	}
+	revisions, err := listRevisions(db.DB)
+	if err != nil {
+		return err
+	}
+	pending := pendingFiles(files, appliedVersionSet(revisions))
+	if len(pending) == 0 {
+		_, _ = fmt.Fprintln(opts.Stdout, "No pending migrations.")
+		return nil
+	}
+
+	absWorkDir, err := filepath.Abs(opts.WorkDir)
+	if err != nil {
+		return fmt.Errorf("migrations: resolve work dir: %w", err)
+	}
+	args := []string{
+		"migrate",
+		"apply",
+		"--url",
+		atlasURL,
+		"--dir",
+		"file://" + filepath.ToSlash(migrationDir),
+	}
+	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
+		return fmt.Errorf("migrations: atlas migrate apply: %w", err)
+	}
+
+	batch, err := nextBatch(db.DB)
+	if err != nil {
+		return err
+	}
+	if err := insertBatch(db.DB, batch, pending, opts.now().UTC()); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(opts.Stdout, "Applied %d migration(s) in batch %d.\n", len(pending), batch)
+	return nil
+}

--- a/migrations/migrate.go
+++ b/migrations/migrate.go
@@ -75,6 +75,10 @@ func openConfiguredDB(opts ApplyOptions) (*database.DB, error) {
 }
 
 // Migrate applies pending Atlas migrations and mirrors them into framework_migrations.
+//
+// After atlas migrate apply succeeds, only pending versions that appear in
+// atlas_schema_revisions are recorded. This keeps Gombit's ledger aligned with
+// Atlas when the two previously diverged or when Atlas applies a subset.
 func Migrate(ctx context.Context, opts ApplyOptions) error {
 	if ctx == nil {
 		return errors.New("migrations: nil context")
@@ -103,10 +107,12 @@ func Migrate(ctx context.Context, opts ApplyOptions) error {
 		return err
 	}
 
-	files, err := ListMigrationFiles(migrationDir)
+	files, skipped, err := listMigrationFiles(migrationDir)
 	if err != nil {
 		return err
 	}
+	warnSkippedMigrationFiles(opts.Stderr, skipped)
+
 	revisions, err := listRevisions(db.DB)
 	if err != nil {
 		return err
@@ -133,13 +139,25 @@ func Migrate(ctx context.Context, opts ApplyOptions) error {
 		return fmt.Errorf("migrations: atlas migrate apply: %w", err)
 	}
 
+	atlasVersions, err := listAtlasVersions(db.DB)
+	if err != nil {
+		return err
+	}
+	applied := pendingPresentInAtlas(pending, atlasVersions)
+	if len(applied) == 0 {
+		return fmt.Errorf("migrations: atlas migrate apply succeeded but none of the %d pending version(s) appear in %s", len(pending), atlasRevisionsTable)
+	}
+	if len(applied) < len(pending) {
+		_, _ = fmt.Fprintf(opts.Stderr, "migrations: warning: recording %d of %d pending version(s) present in %s\n", len(applied), len(pending), atlasRevisionsTable)
+	}
+
 	batch, err := nextBatch(db.DB)
 	if err != nil {
 		return err
 	}
-	if err := insertBatch(db.DB, batch, pending, opts.now().UTC()); err != nil {
+	if err := insertBatch(db.DB, batch, applied, opts.now().UTC()); err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(opts.Stdout, "Applied %d migration(s) in batch %d.\n", len(pending), batch)
+	_, _ = fmt.Fprintf(opts.Stdout, "Applied %d migration(s) in batch %d.\n", len(applied), batch)
 	return nil
 }

--- a/migrations/revisions.go
+++ b/migrations/revisions.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -70,16 +71,30 @@ func DownFilename(upFilename string) (string, error) {
 }
 
 // ListMigrationFiles lists Atlas up migrations in dir, with optional down paths.
+// Non-matching *.sql filenames (other than atlas.sum / *.down.sql) are skipped
+// with a warning printed to stderr when provided via the optional writers in
+// Migrate/Status/Rollback; use ListMigrationFilesWithSkipped to inspect them.
 func ListMigrationFiles(dir string) ([]MigrationFile, error) {
+	files, _, err := listMigrationFiles(dir)
+	return files, err
+}
+
+// ListMigrationFilesWithSkipped lists migrations and returns skipped *.sql names.
+func ListMigrationFilesWithSkipped(dir string) ([]MigrationFile, []string, error) {
+	return listMigrationFiles(dir)
+}
+
+func listMigrationFiles(dir string) ([]MigrationFile, []string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, fmt.Errorf("migrations: read dir: %w", err)
+		return nil, nil, fmt.Errorf("migrations: read dir: %w", err)
 	}
 
 	files := make([]MigrationFile, 0, len(entries))
+	skipped := make([]string, 0)
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -90,6 +105,9 @@ func ListMigrationFiles(dir string) ([]MigrationFile, error) {
 		}
 		version, migName, err := ParseMigrationFilename(name)
 		if err != nil {
+			if strings.HasSuffix(name, ".sql") {
+				skipped = append(skipped, name)
+			}
 			continue
 		}
 		downName := fmt.Sprintf("%s_%s.down.sql", version, migName)
@@ -97,7 +115,7 @@ func ListMigrationFiles(dir string) ([]MigrationFile, error) {
 		if _, statErr := os.Stat(downPath); errors.Is(statErr, os.ErrNotExist) {
 			downPath = ""
 		} else if statErr != nil {
-			return nil, fmt.Errorf("migrations: stat down file: %w", statErr)
+			return nil, nil, fmt.Errorf("migrations: stat down file: %w", statErr)
 		}
 		files = append(files, MigrationFile{
 			Version:  version,
@@ -112,7 +130,16 @@ func ListMigrationFiles(dir string) ([]MigrationFile, error) {
 		}
 		return files[i].Version < files[j].Version
 	})
-	return files, nil
+	return files, skipped, nil
+}
+
+func warnSkippedMigrationFiles(stderr io.Writer, skipped []string) {
+	if stderr == nil || len(skipped) == 0 {
+		return
+	}
+	for _, name := range skipped {
+		_, _ = fmt.Fprintf(stderr, "migrations: warning: skipping unrecognized SQL file %q\n", name)
+	}
 }
 
 func ensureRevisionsTable(db *gorm.DB) error {
@@ -210,6 +237,31 @@ func deleteAtlasRevisions(db *gorm.DB, versions []string) error {
 		return fmt.Errorf("migrations: delete atlas revisions: %w", err)
 	}
 	return nil
+}
+
+func listAtlasVersions(db *gorm.DB) (map[string]struct{}, error) {
+	out := make(map[string]struct{})
+	if db == nil || !db.Migrator().HasTable(atlasRevisionsTable) {
+		return out, nil
+	}
+	var versions []string
+	if err := db.Table(atlasRevisionsTable).Select("version").Find(&versions).Error; err != nil {
+		return nil, fmt.Errorf("migrations: list atlas revisions: %w", err)
+	}
+	for _, version := range versions {
+		out[version] = struct{}{}
+	}
+	return out, nil
+}
+
+func pendingPresentInAtlas(pending []MigrationFile, atlas map[string]struct{}) []MigrationFile {
+	out := make([]MigrationFile, 0, len(pending))
+	for _, file := range pending {
+		if _, ok := atlas[file.Version]; ok {
+			out = append(out, file)
+		}
+	}
+	return out
 }
 
 func pendingFiles(files []MigrationFile, applied map[string]Revision) []MigrationFile {

--- a/migrations/revisions.go
+++ b/migrations/revisions.go
@@ -16,6 +16,7 @@ import (
 
 const revisionsTable = "framework_migrations"
 const atlasRevisionsTable = "atlas_schema_revisions"
+const downSubdir = "downs"
 
 var migrationFilePattern = regexp.MustCompile(`^(\d+)_([A-Za-z0-9][A-Za-z0-9_-]*)\.sql$`)
 var migrationDownFilePattern = regexp.MustCompile(`^(\d+)_([A-Za-z0-9][A-Za-z0-9_-]*)\.down\.sql$`)
@@ -61,7 +62,7 @@ func ParseDownFilename(filename string) (version string, name string, err error)
 	return matches[1], matches[2], nil
 }
 
-// DownFilename returns the companion down filename for an up migration file.
+// DownFilename returns the companion down filename (basename) for an up migration file.
 func DownFilename(upFilename string) (string, error) {
 	version, name, err := ParseMigrationFilename(upFilename)
 	if err != nil {
@@ -70,10 +71,16 @@ func DownFilename(upFilename string) (string, error) {
 	return fmt.Sprintf("%s_%s.down.sql", version, name), nil
 }
 
+// DownPath returns the path to the Gombit-owned down SQL for an up migration.
+// Downs live under <migrationDir>/downs/ so Atlas never scans them (Atlas panics
+// on golang-migrate-style .down.sql files in the versioned migration directory).
+func DownPath(migrationDir string, version string, name string) string {
+	return filepath.Join(migrationDir, downSubdir, fmt.Sprintf("%s_%s.down.sql", version, name))
+}
+
 // ListMigrationFiles lists Atlas up migrations in dir, with optional down paths.
-// Non-matching *.sql filenames (other than atlas.sum / *.down.sql) are skipped
-// with a warning printed to stderr when provided via the optional writers in
-// Migrate/Status/Rollback; use ListMigrationFilesWithSkipped to inspect them.
+// Non-matching *.sql filenames (other than atlas.sum) are skipped with a
+// warning. Companion downs live under downs/ and are not listed as up files.
 func ListMigrationFiles(dir string) ([]MigrationFile, error) {
 	files, _, err := listMigrationFiles(dir)
 	return files, err
@@ -100,7 +107,12 @@ func listMigrationFiles(dir string) ([]MigrationFile, []string, error) {
 			continue
 		}
 		name := entry.Name()
-		if strings.HasSuffix(name, ".down.sql") || name == "atlas.sum" {
+		if name == "atlas.sum" {
+			continue
+		}
+		if strings.HasSuffix(name, ".down.sql") {
+			// Misplaced companion downs in the Atlas dir panic migrate apply; warn and skip.
+			skipped = append(skipped, name)
 			continue
 		}
 		version, migName, err := ParseMigrationFilename(name)
@@ -110,8 +122,7 @@ func listMigrationFiles(dir string) ([]MigrationFile, []string, error) {
 			}
 			continue
 		}
-		downName := fmt.Sprintf("%s_%s.down.sql", version, migName)
-		downPath := filepath.Join(dir, downName)
+		downPath := DownPath(dir, version, migName)
 		if _, statErr := os.Stat(downPath); errors.Is(statErr, os.ErrNotExist) {
 			downPath = ""
 		} else if statErr != nil {

--- a/migrations/revisions.go
+++ b/migrations/revisions.go
@@ -1,0 +1,223 @@
+package migrations
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const revisionsTable = "framework_migrations"
+const atlasRevisionsTable = "atlas_schema_revisions"
+
+var migrationFilePattern = regexp.MustCompile(`^(\d+)_([A-Za-z0-9][A-Za-z0-9_-]*)\.sql$`)
+var migrationDownFilePattern = regexp.MustCompile(`^(\d+)_([A-Za-z0-9][A-Za-z0-9_-]*)\.down\.sql$`)
+
+// Revision is one applied migration recorded in framework_migrations (D4).
+type Revision struct {
+	Version   string    `gorm:"column:version;primaryKey;size:64"`
+	Name      string    `gorm:"column:name;size:255;not null"`
+	Batch     int       `gorm:"column:batch;not null"`
+	AppliedAt time.Time `gorm:"column:applied_at;not null"`
+}
+
+// TableName returns the D4 revision table name.
+func (Revision) TableName() string {
+	return revisionsTable
+}
+
+// MigrationFile is one Atlas versioned migration on disk.
+type MigrationFile struct {
+	Version  string
+	Name     string
+	UpPath   string
+	DownPath string
+}
+
+// ParseMigrationFilename parses an Atlas up migration filename.
+func ParseMigrationFilename(filename string) (version string, name string, err error) {
+	base := filepath.Base(filename)
+	matches := migrationFilePattern.FindStringSubmatch(base)
+	if matches == nil {
+		return "", "", fmt.Errorf("migrations: invalid migration filename %q", base)
+	}
+	return matches[1], matches[2], nil
+}
+
+// ParseDownFilename parses a Gombit companion down migration filename.
+func ParseDownFilename(filename string) (version string, name string, err error) {
+	base := filepath.Base(filename)
+	matches := migrationDownFilePattern.FindStringSubmatch(base)
+	if matches == nil {
+		return "", "", fmt.Errorf("migrations: invalid down migration filename %q", base)
+	}
+	return matches[1], matches[2], nil
+}
+
+// DownFilename returns the companion down filename for an up migration file.
+func DownFilename(upFilename string) (string, error) {
+	version, name, err := ParseMigrationFilename(upFilename)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s_%s.down.sql", version, name), nil
+}
+
+// ListMigrationFiles lists Atlas up migrations in dir, with optional down paths.
+func ListMigrationFiles(dir string) ([]MigrationFile, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("migrations: read dir: %w", err)
+	}
+
+	files := make([]MigrationFile, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".down.sql") || name == "atlas.sum" {
+			continue
+		}
+		version, migName, err := ParseMigrationFilename(name)
+		if err != nil {
+			continue
+		}
+		downName := fmt.Sprintf("%s_%s.down.sql", version, migName)
+		downPath := filepath.Join(dir, downName)
+		if _, statErr := os.Stat(downPath); errors.Is(statErr, os.ErrNotExist) {
+			downPath = ""
+		} else if statErr != nil {
+			return nil, fmt.Errorf("migrations: stat down file: %w", statErr)
+		}
+		files = append(files, MigrationFile{
+			Version:  version,
+			Name:     migName,
+			UpPath:   filepath.Join(dir, name),
+			DownPath: downPath,
+		})
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Version == files[j].Version {
+			return files[i].Name < files[j].Name
+		}
+		return files[i].Version < files[j].Version
+	})
+	return files, nil
+}
+
+func ensureRevisionsTable(db *gorm.DB) error {
+	if db == nil {
+		return errors.New("migrations: nil db")
+	}
+	if err := db.AutoMigrate(&Revision{}); err != nil {
+		return fmt.Errorf("migrations: ensure %s: %w", revisionsTable, err)
+	}
+	return nil
+}
+
+func listRevisions(db *gorm.DB) ([]Revision, error) {
+	var revisions []Revision
+	if err := db.Order("version asc").Find(&revisions).Error; err != nil {
+		return nil, fmt.Errorf("migrations: list revisions: %w", err)
+	}
+	return revisions, nil
+}
+
+func appliedVersionSet(revisions []Revision) map[string]Revision {
+	out := make(map[string]Revision, len(revisions))
+	for _, rev := range revisions {
+		out[rev.Version] = rev
+	}
+	return out
+}
+
+func nextBatch(db *gorm.DB) (int, error) {
+	var maxBatch *int
+	if err := db.Model(&Revision{}).Select("MAX(batch)").Scan(&maxBatch).Error; err != nil {
+		return 0, fmt.Errorf("migrations: max batch: %w", err)
+	}
+	if maxBatch == nil {
+		return 1, nil
+	}
+	return *maxBatch + 1, nil
+}
+
+func insertBatch(db *gorm.DB, batch int, files []MigrationFile, appliedAt time.Time) error {
+	if len(files) == 0 {
+		return nil
+	}
+	revisions := make([]Revision, 0, len(files))
+	for _, file := range files {
+		revisions = append(revisions, Revision{
+			Version:   file.Version,
+			Name:      file.Name,
+			Batch:     batch,
+			AppliedAt: appliedAt,
+		})
+	}
+	if err := db.Create(&revisions).Error; err != nil {
+		return fmt.Errorf("migrations: insert batch %d: %w", batch, err)
+	}
+	return nil
+}
+
+func lastBatch(db *gorm.DB) (int, []Revision, error) {
+	var maxBatch *int
+	if err := db.Model(&Revision{}).Select("MAX(batch)").Scan(&maxBatch).Error; err != nil {
+		return 0, nil, fmt.Errorf("migrations: max batch: %w", err)
+	}
+	if maxBatch == nil {
+		return 0, nil, nil
+	}
+	var revisions []Revision
+	if err := db.Where("batch = ?", *maxBatch).Order("version desc").Find(&revisions).Error; err != nil {
+		return 0, nil, fmt.Errorf("migrations: list batch %d: %w", *maxBatch, err)
+	}
+	return *maxBatch, revisions, nil
+}
+
+func deleteRevisions(db *gorm.DB, versions []string) error {
+	if len(versions) == 0 {
+		return nil
+	}
+	if err := db.Where("version IN ?", versions).Delete(&Revision{}).Error; err != nil {
+		return fmt.Errorf("migrations: delete revisions: %w", err)
+	}
+	return nil
+}
+
+func deleteAtlasRevisions(db *gorm.DB, versions []string) error {
+	if len(versions) == 0 {
+		return nil
+	}
+	if !db.Migrator().HasTable(atlasRevisionsTable) {
+		return nil
+	}
+	if err := db.Exec(
+		fmt.Sprintf("DELETE FROM %s WHERE version IN ?", atlasRevisionsTable),
+		versions,
+	).Error; err != nil {
+		return fmt.Errorf("migrations: delete atlas revisions: %w", err)
+	}
+	return nil
+}
+
+func pendingFiles(files []MigrationFile, applied map[string]Revision) []MigrationFile {
+	pending := make([]MigrationFile, 0)
+	for _, file := range files {
+		if _, ok := applied[file.Version]; !ok {
+			pending = append(pending, file)
+		}
+	}
+	return pending
+}

--- a/migrations/revisions_test.go
+++ b/migrations/revisions_test.go
@@ -1,0 +1,153 @@
+package migrations
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+)
+
+func TestParseMigrationFilename(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		version string
+		migName string
+		wantErr bool
+	}{
+		{name: "valid", file: "20260101000000_create_products.sql", version: "20260101000000", migName: "create_products"},
+		{name: "with path", file: "/tmp/20260101000000_create_products.sql", version: "20260101000000", migName: "create_products"},
+		{name: "down rejected", file: "20260101000000_create_products.down.sql", wantErr: true},
+		{name: "atlas sum", file: "atlas.sum", wantErr: true},
+		{name: "invalid", file: "create_products.sql", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, migName, err := ParseMigrationFilename(tt.file)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ParseMigrationFilename() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseMigrationFilename() error = %v", err)
+			}
+			if version != tt.version || migName != tt.migName {
+				t.Fatalf("ParseMigrationFilename() = (%q, %q), want (%q, %q)", version, migName, tt.version, tt.migName)
+			}
+		})
+	}
+}
+
+func TestParseDownFilenameAndDownFilename(t *testing.T) {
+	version, name, err := ParseDownFilename("20260101000000_create_products.down.sql")
+	if err != nil {
+		t.Fatalf("ParseDownFilename() error = %v", err)
+	}
+	if version != "20260101000000" || name != "create_products" {
+		t.Fatalf("ParseDownFilename() = (%q, %q)", version, name)
+	}
+
+	got, err := DownFilename("20260101000000_create_products.sql")
+	if err != nil {
+		t.Fatalf("DownFilename() error = %v", err)
+	}
+	if got != "20260101000000_create_products.down.sql" {
+		t.Fatalf("DownFilename() = %q", got)
+	}
+}
+
+func TestListMigrationFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "20260102000000_add_index.sql"), "CREATE INDEX;")
+	writeFile(t, filepath.Join(dir, "20260101000000_create_products.sql"), "CREATE TABLE products;")
+	writeFile(t, filepath.Join(dir, "20260101000000_create_products.down.sql"), "DROP TABLE products;")
+	writeFile(t, filepath.Join(dir, "atlas.sum"), "h1:fake")
+	writeFile(t, filepath.Join(dir, "readme.txt"), "ignore")
+
+	files, err := ListMigrationFiles(dir)
+	if err != nil {
+		t.Fatalf("ListMigrationFiles() error = %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("ListMigrationFiles() len = %d, want 2", len(files))
+	}
+	if files[0].Version != "20260101000000" || files[0].DownPath == "" {
+		t.Fatalf("first file = %#v, want version with down path", files[0])
+	}
+	if files[1].Version != "20260102000000" || files[1].DownPath != "" {
+		t.Fatalf("second file = %#v, want version without down path", files[1])
+	}
+}
+
+func TestRevisionsCRUD(t *testing.T) {
+	db := openSQLite(t)
+	if err := ensureRevisionsTable(db.DB); err != nil {
+		t.Fatalf("ensureRevisionsTable() error = %v", err)
+	}
+
+	batch, err := nextBatch(db.DB)
+	if err != nil {
+		t.Fatalf("nextBatch() error = %v", err)
+	}
+	if batch != 1 {
+		t.Fatalf("nextBatch() = %d, want 1", batch)
+	}
+
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	files := []MigrationFile{
+		{Version: "20260101000000", Name: "create_products"},
+		{Version: "20260102000000", Name: "add_index"},
+	}
+	if err := insertBatch(db.DB, 1, files, now); err != nil {
+		t.Fatalf("insertBatch() error = %v", err)
+	}
+
+	revisions, err := listRevisions(db.DB)
+	if err != nil {
+		t.Fatalf("listRevisions() error = %v", err)
+	}
+	if len(revisions) != 2 {
+		t.Fatalf("listRevisions() len = %d, want 2", len(revisions))
+	}
+	if revisions[0].Batch != 1 || revisions[0].AppliedAt.UTC() != now {
+		t.Fatalf("revision[0] = %#v", revisions[0])
+	}
+
+	gotBatch, last, err := lastBatch(db.DB)
+	if err != nil {
+		t.Fatalf("lastBatch() error = %v", err)
+	}
+	if gotBatch != 1 || len(last) != 2 || last[0].Version != "20260102000000" {
+		t.Fatalf("lastBatch() = %d %#v", gotBatch, last)
+	}
+
+	if err := deleteRevisions(db.DB, []string{"20260101000000", "20260102000000"}); err != nil {
+		t.Fatalf("deleteRevisions() error = %v", err)
+	}
+	revisions, err = listRevisions(db.DB)
+	if err != nil {
+		t.Fatalf("listRevisions() after delete error = %v", err)
+	}
+	if len(revisions) != 0 {
+		t.Fatalf("listRevisions() after delete len = %d, want 0", len(revisions))
+	}
+}
+
+func openSQLite(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := database.Open(config.DatabaseConfig{
+		Driver: config.DatabaseDriverSQLite,
+		DSN:    "file:" + filepath.Join(t.TempDir(), "test.db") + "?cache=shared&_fk=1",
+	})
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return db
+}

--- a/migrations/revisions_test.go
+++ b/migrations/revisions_test.go
@@ -67,19 +67,23 @@ func TestListMigrationFiles(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "20260101000000_create_products.down.sql"), "DROP TABLE products;")
 	writeFile(t, filepath.Join(dir, "atlas.sum"), "h1:fake")
 	writeFile(t, filepath.Join(dir, "readme.txt"), "ignore")
+	writeFile(t, filepath.Join(dir, "typo_migration.sql"), "CREATE TABLE broken;")
 
-	files, err := ListMigrationFiles(dir)
+	files, skipped, err := ListMigrationFilesWithSkipped(dir)
 	if err != nil {
-		t.Fatalf("ListMigrationFiles() error = %v", err)
+		t.Fatalf("ListMigrationFilesWithSkipped() error = %v", err)
 	}
 	if len(files) != 2 {
-		t.Fatalf("ListMigrationFiles() len = %d, want 2", len(files))
+		t.Fatalf("ListMigrationFilesWithSkipped() len = %d, want 2", len(files))
 	}
 	if files[0].Version != "20260101000000" || files[0].DownPath == "" {
 		t.Fatalf("first file = %#v, want version with down path", files[0])
 	}
 	if files[1].Version != "20260102000000" || files[1].DownPath != "" {
 		t.Fatalf("second file = %#v, want version without down path", files[1])
+	}
+	if len(skipped) != 1 || skipped[0] != "typo_migration.sql" {
+		t.Fatalf("skipped = %v, want typo_migration.sql", skipped)
 	}
 }
 

--- a/migrations/revisions_test.go
+++ b/migrations/revisions_test.go
@@ -64,7 +64,7 @@ func TestListMigrationFiles(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "20260102000000_add_index.sql"), "CREATE INDEX;")
 	writeFile(t, filepath.Join(dir, "20260101000000_create_products.sql"), "CREATE TABLE products;")
-	writeFile(t, filepath.Join(dir, "20260101000000_create_products.down.sql"), "DROP TABLE products;")
+	writeFile(t, filepath.Join(dir, "downs", "20260101000000_create_products.down.sql"), "DROP TABLE products;")
 	writeFile(t, filepath.Join(dir, "atlas.sum"), "h1:fake")
 	writeFile(t, filepath.Join(dir, "readme.txt"), "ignore")
 	writeFile(t, filepath.Join(dir, "typo_migration.sql"), "CREATE TABLE broken;")

--- a/migrations/rollback.go
+++ b/migrations/rollback.go
@@ -9,9 +9,17 @@ import (
 	"strings"
 
 	"github.com/LAA-Software-Engineering/gombit/config"
+	"gorm.io/gorm"
 )
 
 // Rollback rolls back the latest framework_migrations batch using companion down SQL.
+//
+// On SQLite and PostgreSQL, down SQL and revision deletes run in one transaction
+// so a mid-batch failure leaves neither schema nor revision ledgers partially
+// updated. MySQL DDL often auto-commits, so a mid-batch failure can leave the
+// schema partially rolled back while revision rows remain; the error message
+// lists completed downs and revision rows are not deleted until every down
+// succeeds.
 func Rollback(ctx context.Context, opts ApplyOptions) error {
 	if ctx == nil {
 		return errors.New("migrations: nil context")
@@ -45,10 +53,12 @@ func Rollback(ctx context.Context, opts ApplyOptions) error {
 		return nil
 	}
 
-	files, err := ListMigrationFiles(migrationDir)
+	files, skipped, err := listMigrationFiles(migrationDir)
 	if err != nil {
 		return err
 	}
+	warnSkippedMigrationFiles(opts.Stderr, skipped)
+
 	byVersion := make(map[string]MigrationFile, len(files))
 	for _, file := range files {
 		byVersion[file.Version] = file
@@ -68,30 +78,67 @@ func Rollback(ctx context.Context, opts ApplyOptions) error {
 		return fmt.Errorf("migrations: missing down migration(s) for batch %d: %s", batch, strings.Join(missing, ", "))
 	}
 
+	useTx := opts.Database.Driver != config.DatabaseDriverMySQL
+	execDB := db.DB
+	var tx *gorm.DB
+	if useTx {
+		tx = db.Begin()
+		if tx.Error != nil {
+			return fmt.Errorf("migrations: begin rollback transaction: %w", tx.Error)
+		}
+		execDB = tx
+	}
+
 	versions := make([]string, 0, len(downs))
 	for _, file := range downs {
 		// #nosec G304 -- down paths are resolved from the configured migration directory.
 		sqlBytes, err := os.ReadFile(file.DownPath)
 		if err != nil {
-			return fmt.Errorf("migrations: read down %s: %w", filepath.Base(file.DownPath), err)
+			return rollbackFail(tx, useTx, versions, file.DownPath, err, "read")
 		}
 		sqlText := strings.TrimSpace(string(sqlBytes))
 		if sqlText == "" {
-			return fmt.Errorf("migrations: empty down migration %s", filepath.Base(file.DownPath))
+			return rollbackFail(tx, useTx, versions, file.DownPath, errors.New("empty down migration"), "execute")
 		}
-		if err := db.Exec(sqlText).Error; err != nil {
-			return fmt.Errorf("migrations: execute down %s: %w", filepath.Base(file.DownPath), err)
+		if err := execDB.Exec(sqlText).Error; err != nil {
+			return rollbackFail(tx, useTx, versions, file.DownPath, err, "execute")
 		}
 		versions = append(versions, file.Version)
 	}
 
-	if err := deleteRevisions(db.DB, versions); err != nil {
-		return err
+	if err := deleteRevisions(execDB, versions); err != nil {
+		return rollbackFail(tx, useTx, versions, "", err, "delete revisions")
 	}
-	if err := deleteAtlasRevisions(db.DB, versions); err != nil {
-		return err
+	if err := deleteAtlasRevisions(execDB, versions); err != nil {
+		return rollbackFail(tx, useTx, versions, "", err, "delete atlas revisions")
+	}
+	if useTx {
+		if err := tx.Commit().Error; err != nil {
+			return fmt.Errorf("migrations: commit rollback transaction: %w", err)
+		}
 	}
 
 	_, _ = fmt.Fprintf(opts.Stdout, "Rolled back batch %d (%d migration(s)).\n", batch, len(versions))
 	return nil
+}
+
+func rollbackFail(tx *gorm.DB, useTx bool, completed []string, path string, err error, op string) error {
+	if useTx && tx != nil {
+		_ = tx.Rollback()
+	}
+	base := path
+	if base != "" {
+		base = filepath.Base(path)
+	}
+	msg := fmt.Sprintf("migrations: %s", op)
+	if base != "" {
+		msg = fmt.Sprintf("migrations: %s %s", op, base)
+	}
+	if len(completed) > 0 && !useTx {
+		return fmt.Errorf("%s after completing downs for %v: %w; framework_migrations unchanged — repair the schema manually before retrying", msg, completed, err)
+	}
+	if useTx {
+		return fmt.Errorf("%s: %w; rollback transaction aborted and framework_migrations unchanged", msg, err)
+	}
+	return fmt.Errorf("%s: %w; framework_migrations unchanged", msg, err)
 }

--- a/migrations/rollback.go
+++ b/migrations/rollback.go
@@ -1,0 +1,97 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+)
+
+// Rollback rolls back the latest framework_migrations batch using companion down SQL.
+func Rollback(ctx context.Context, opts ApplyOptions) error {
+	if ctx == nil {
+		return errors.New("migrations: nil context")
+	}
+	opts = withApplyDefaults(opts)
+	if err := config.ValidateDatabase(opts.Database); err != nil {
+		return err
+	}
+
+	migrationDir, err := resolveMigrationDir(opts)
+	if err != nil {
+		return err
+	}
+
+	db, err := openConfiguredDB(opts)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := ensureRevisionsTable(db.DB); err != nil {
+		return err
+	}
+
+	batch, revisions, err := lastBatch(db.DB)
+	if err != nil {
+		return err
+	}
+	if batch == 0 || len(revisions) == 0 {
+		_, _ = fmt.Fprintln(opts.Stdout, "Nothing to roll back.")
+		return nil
+	}
+
+	files, err := ListMigrationFiles(migrationDir)
+	if err != nil {
+		return err
+	}
+	byVersion := make(map[string]MigrationFile, len(files))
+	for _, file := range files {
+		byVersion[file.Version] = file
+	}
+
+	downs := make([]MigrationFile, 0, len(revisions))
+	missing := make([]string, 0)
+	for _, rev := range revisions {
+		file, ok := byVersion[rev.Version]
+		if !ok || file.DownPath == "" {
+			missing = append(missing, fmt.Sprintf("%s_%s.down.sql", rev.Version, rev.Name))
+			continue
+		}
+		downs = append(downs, file)
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("migrations: missing down migration(s) for batch %d: %s", batch, strings.Join(missing, ", "))
+	}
+
+	versions := make([]string, 0, len(downs))
+	for _, file := range downs {
+		// #nosec G304 -- down paths are resolved from the configured migration directory.
+		sqlBytes, err := os.ReadFile(file.DownPath)
+		if err != nil {
+			return fmt.Errorf("migrations: read down %s: %w", filepath.Base(file.DownPath), err)
+		}
+		sqlText := strings.TrimSpace(string(sqlBytes))
+		if sqlText == "" {
+			return fmt.Errorf("migrations: empty down migration %s", filepath.Base(file.DownPath))
+		}
+		if err := db.Exec(sqlText).Error; err != nil {
+			return fmt.Errorf("migrations: execute down %s: %w", filepath.Base(file.DownPath), err)
+		}
+		versions = append(versions, file.Version)
+	}
+
+	if err := deleteRevisions(db.DB, versions); err != nil {
+		return err
+	}
+	if err := deleteAtlasRevisions(db.DB, versions); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(opts.Stdout, "Rolled back batch %d (%d migration(s)).\n", batch, len(versions))
+	return nil
+}

--- a/migrations/rollback.go
+++ b/migrations/rollback.go
@@ -69,7 +69,7 @@ func Rollback(ctx context.Context, opts ApplyOptions) error {
 	for _, rev := range revisions {
 		file, ok := byVersion[rev.Version]
 		if !ok || file.DownPath == "" {
-			missing = append(missing, fmt.Sprintf("%s_%s.down.sql", rev.Version, rev.Name))
+			missing = append(missing, filepath.ToSlash(filepath.Join(downSubdir, fmt.Sprintf("%s_%s.down.sql", rev.Version, rev.Name))))
 			continue
 		}
 		downs = append(downs, file)

--- a/migrations/status.go
+++ b/migrations/status.go
@@ -40,10 +40,11 @@ func Status(ctx context.Context, opts ApplyOptions) error {
 		return err
 	}
 
-	files, err := ListMigrationFiles(migrationDir)
+	files, skipped, err := listMigrationFiles(migrationDir)
 	if err != nil {
 		return err
 	}
+	warnSkippedMigrationFiles(opts.Stderr, skipped)
 	revisions, err := listRevisions(db.DB)
 	if err != nil {
 		return err

--- a/migrations/status.go
+++ b/migrations/status.go
@@ -86,7 +86,6 @@ func Status(ctx context.Context, opts ApplyOptions) error {
 		atlasURL,
 		"--dir",
 		"file://" + filepath.ToSlash(migrationDir),
-		"--allow-dirty",
 	}
 	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
 		return fmt.Errorf("migrations: atlas migrate status: %w", err)

--- a/migrations/status.go
+++ b/migrations/status.go
@@ -86,6 +86,7 @@ func Status(ctx context.Context, opts ApplyOptions) error {
 		atlasURL,
 		"--dir",
 		"file://" + filepath.ToSlash(migrationDir),
+		"--allow-dirty",
 	}
 	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
 		return fmt.Errorf("migrations: atlas migrate status: %w", err)

--- a/migrations/status.go
+++ b/migrations/status.go
@@ -1,0 +1,93 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"text/tabwriter"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+)
+
+// Status reports applied and pending migrations, then runs atlas migrate status.
+func Status(ctx context.Context, opts ApplyOptions) error {
+	if ctx == nil {
+		return errors.New("migrations: nil context")
+	}
+	opts = withApplyDefaults(opts)
+	if err := config.ValidateDatabase(opts.Database); err != nil {
+		return err
+	}
+
+	migrationDir, err := resolveMigrationDir(opts)
+	if err != nil {
+		return err
+	}
+	atlasURL, err := AtlasURL(opts.Database)
+	if err != nil {
+		return err
+	}
+
+	db, err := openConfiguredDB(opts)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := ensureRevisionsTable(db.DB); err != nil {
+		return err
+	}
+
+	files, err := ListMigrationFiles(migrationDir)
+	if err != nil {
+		return err
+	}
+	revisions, err := listRevisions(db.DB)
+	if err != nil {
+		return err
+	}
+	applied := appliedVersionSet(revisions)
+	pending := pendingFiles(files, applied)
+
+	_, _ = fmt.Fprintln(opts.Stdout, "Gombit migration status")
+	tw := tabwriter.NewWriter(opts.Stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "STATE\tVERSION\tNAME\tBATCH\tAPPLIED AT")
+	for _, rev := range revisions {
+		_, _ = fmt.Fprintf(tw, "applied\t%s\t%s\t%d\t%s\n",
+			rev.Version,
+			rev.Name,
+			rev.Batch,
+			rev.AppliedAt.UTC().Format(time.RFC3339),
+		)
+	}
+	for _, file := range pending {
+		_, _ = fmt.Fprintf(tw, "pending\t%s\t%s\t-\t-\n", file.Version, file.Name)
+	}
+	if len(revisions) == 0 && len(pending) == 0 {
+		_, _ = fmt.Fprintln(tw, "-\t-\t-\t-\t-")
+	}
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("migrations: write status: %w", err)
+	}
+
+	absWorkDir, err := filepath.Abs(opts.WorkDir)
+	if err != nil {
+		return fmt.Errorf("migrations: resolve work dir: %w", err)
+	}
+	_, _ = fmt.Fprintln(opts.Stdout)
+	_, _ = fmt.Fprintln(opts.Stdout, "Atlas migration status")
+	args := []string{
+		"migrate",
+		"status",
+		"--url",
+		atlasURL,
+		"--dir",
+		"file://" + filepath.ToSlash(migrationDir),
+	}
+	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
+		return fmt.Errorf("migrations: atlas migrate status: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Add `gombit db migrate`, `rollback`, and `status` on top of Atlas Community Edition apply/status.
- Record applied revisions in `framework_migrations` (`version`, `name`, `batch`, `applied_at`; no checksum per D4).
- Own last-batch rollback via companion `*.down.sql` files and sync Atlas revision rows (no `atlas migrate down`).

Closes #13

## Acceptance criteria

- [x] up/down/status reflected and correct on all supported DBs (SQLite unit/e2e + Postgres/MySQL integration tests; issue text “both DBs” is stale vs D12)
- [x] Atlas apply + `framework_migrations`-style revision record (no checksum per D4)
- [x] Rollback is Gombit-owned over down SQL + revision tables (ADR-012)

## Scope notes

- M2-3 seed/reset and M2-4 full conformance CI remain deferred.
- Down SQL is application-owned; makemigrations does not auto-generate `.down.sql`.

## Validation

- [x] `go test ./migrations -run 'TestAtlasURL|TestParse|TestRevisions|TestList|TestMigrate|TestRollback'`
- [x] `go test ./cmd/gombit -run 'TestRunMigrate|TestRunRejectsUnknownDB'`
- [ ] `go test ./...` (full suite not re-run in this session due to local disk/cache limits)
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix
- [x] Stable features ship docs and appear in an example app
- [ ] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests (N/A: new migrations surface, not an extraction)
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) (N/A: no generators changed)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR (N/A: no HTTP API contract change)
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public (N/A: no frontend)
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

Made with [Cursor](https://cursor.com)