### PR TITLE
[M2-3] gombit db seed / reset

### DIFF
--- a/cmd/gombit/main.go
+++ b/cmd/gombit/main.go
@@ -43,6 +43,10 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		return runRollback(ctx, args[2:], stdout, stderr)
 	case "status":
 		return runStatus(ctx, args[2:], stdout, stderr)
+	case "seed":
+		return runSeed(ctx, args[2:], stdout, stderr)
+	case "reset":
+		return runReset(ctx, args[2:], stdout, stderr)
 	default:
 		dbUsage(stderr)
 		return fmt.Errorf("gombit db: unknown subcommand %q", args[1])
@@ -119,6 +123,67 @@ func runStatus(ctx context.Context, args []string, stdout io.Writer, stderr io.W
 	return migrations.Status(ctx, opts.withWriters(stdout, stderr))
 }
 
+func runSeed(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	flags := flag.NewFlagSet("gombit db seed", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	seedDir := flags.String("seeds", "database/seeds", "seed directory")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		flags.Usage()
+		return fmt.Errorf("gombit db seed: unexpected argument %q", flags.Arg(0))
+	}
+
+	return migrations.Seed(ctx, migrations.SeedOptions{
+		WorkDir:  ".",
+		SeedDir:  *seedDir,
+		Database: cfg.Database,
+		Stdout:   stdout,
+		Stderr:   stderr,
+	})
+}
+
+func runReset(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	flags := flag.NewFlagSet("gombit db reset", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	migrationDir := flags.String("dir", "database/migrations", "migration directory")
+	seedDir := flags.String("seeds", "database/seeds", "seed directory")
+	atlasBin := flags.String("atlas-bin", "atlas", "Atlas CLI binary path")
+	force := flags.Bool("force", false, "allow reset when GOMBIT_ENV=production")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		flags.Usage()
+		return fmt.Errorf("gombit db reset: unexpected argument %q", flags.Arg(0))
+	}
+
+	return migrations.Reset(ctx, migrations.ResetOptions{
+		ApplyOptions: migrations.ApplyOptions{
+			WorkDir:      ".",
+			MigrationDir: *migrationDir,
+			AtlasBinary:  *atlasBin,
+			Database:     cfg.Database,
+			Stdout:       stdout,
+			Stderr:       stderr,
+		},
+		SeedDir:     *seedDir,
+		Force:       *force,
+		Environment: cfg.Environment,
+	})
+}
+
 type applyFlagValues struct {
 	opts migrations.ApplyOptions
 }
@@ -177,4 +242,6 @@ func dbUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  migrate [--dir database/migrations] [--atlas-bin atlas]")
 	_, _ = fmt.Fprintln(w, "  rollback [--dir database/migrations]")
 	_, _ = fmt.Fprintln(w, "  status [--dir database/migrations] [--atlas-bin atlas]")
+	_, _ = fmt.Fprintln(w, "  seed [--seeds database/seeds]")
+	_, _ = fmt.Fprintln(w, "  reset [--dir database/migrations] [--seeds database/seeds] [--atlas-bin atlas] [--force]")
 }

--- a/cmd/gombit/main_test.go
+++ b/cmd/gombit/main_test.go
@@ -184,11 +184,87 @@ func TestRunMigrateRollbackStatus(t *testing.T) {
 }
 
 func TestRunRejectsUnknownDBSubcommand(t *testing.T) {
-	err := run(context.Background(), []string{"db", "seed"}, ioDiscard{}, ioDiscard{})
+	err := run(context.Background(), []string{"db", "unknown"}, ioDiscard{}, ioDiscard{})
 	if err == nil {
 		t.Fatal("run() error = nil, want unknown subcommand error")
 	}
 	if !strings.Contains(err.Error(), "unknown subcommand") {
+		t.Fatalf("run() error = %q", err)
+	}
+}
+
+func TestRunSeedAndReset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake atlas shell script uses POSIX sh")
+	}
+
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "migrations")
+	seedDir := filepath.Join(workDir, "seeds")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir migrations: %v", err)
+	}
+	if err := os.MkdirAll(seedDir, 0o750); err != nil {
+		t.Fatalf("mkdir seeds: %v", err)
+	}
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
+		"CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL);")
+	writeFile(t, filepath.Join(seedDir, "01_widgets.sql"),
+		"INSERT INTO widgets (id, name) VALUES (1, 'from-seed');")
+
+	dbPath := filepath.Join(workDir, "app.db")
+	cfg := config.Default()
+	cfg.Database.Driver = config.DatabaseDriverSQLite
+	cfg.Database.DSN = "file:" + dbPath + "?cache=shared&_fk=1"
+	stubConfig(t, cfg)
+
+	atlas := fakeAtlasApplyStatus(t)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	err := run(context.Background(), []string{
+		"db", "reset",
+		"--dir", migrationDir,
+		"--seeds", seedDir,
+		"--atlas-bin", atlas,
+	}, stdout, stderr)
+	if err != nil {
+		t.Fatalf("reset error = %v; stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Dropped database schema") {
+		t.Fatalf("reset stdout = %q, want drop message", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Applied 1 seed file(s)") {
+		t.Fatalf("reset stdout = %q, want seed message", stdout.String())
+	}
+	stdout.Reset()
+
+	emptySeeds := filepath.Join(workDir, "empty-seeds")
+	if err := os.MkdirAll(emptySeeds, 0o750); err != nil {
+		t.Fatalf("mkdir empty seeds: %v", err)
+	}
+	err = run(context.Background(), []string{
+		"db", "seed",
+		"--seeds", emptySeeds,
+	}, stdout, stderr)
+	if err != nil {
+		t.Fatalf("seed empty dir error = %v; stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No seed files") {
+		t.Fatalf("seed stdout = %q, want no seed files", stdout.String())
+	}
+}
+
+func TestRunResetRefusesProductionWithoutForce(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentProduction
+	stubConfig(t, cfg)
+
+	err := run(context.Background(), []string{"db", "reset"}, ioDiscard{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("run() error = nil, want production refusal")
+	}
+	if !strings.Contains(err.Error(), "refuse reset in production without --force") {
 		t.Fatalf("run() error = %q", err)
 	}
 }

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -143,15 +143,19 @@ gombit db reset [--dir database/migrations] [--seeds database/seeds] [--atlas-bi
 
 ### Seed
 
-`gombit db seed` executes every `*.sql` file in the seed directory in lexical
-order. Non-`.sql` files are skipped with a warning on stderr. A missing or empty
-seed directory prints `No seed files.` and exits successfully.
+`gombit db seed` executes every top-level `*.sql` file in the seed directory in
+lexical order. Nested subdirectories and non-`.sql` files are skipped with a
+warning on stderr. A missing or empty seed directory prints `No seed files.` and
+exits successfully.
 
-Seed files are application-owned SQL. Keep them idempotent if you plan to run
-`seed` more than once against the same database; Gombit does not wrap seeds in
-a cross-driver transaction.
+Each seed file may contain multiple SQL statements separated by `;`. Gombit
+splits on semicolons outside quotes and comments, then executes statements in
+order (so multi-`INSERT` files work without relying on driver multi-statement
+support). Seed files are application-owned SQL. Keep them idempotent if you plan
+to run `seed` more than once against the same database; Gombit does not wrap
+seeds in a cross-driver transaction.
 
-Example layout:
+Example layout (flat directory only):
 
 ```text
 database/seeds/01_demo.sql
@@ -162,8 +166,8 @@ database/seeds/02_more_data.sql
 
 `gombit db reset` is drop + migrate + seed:
 
-1. Drops the configured database schema (all user tables/views, including
-   `framework_migrations` and `atlas_schema_revisions`).
+1. Wipes the configured database using the driver strategy below (including
+   Gombit/Atlas revision tables when they live in the wiped scope).
 2. Runs `gombit db migrate`.
 3. Runs `gombit db seed`.
 
@@ -172,7 +176,7 @@ Driver wipe strategy:
 | Driver | Wipe |
 | --- | --- |
 | SQLite | `DROP` every non-`sqlite_*` table/view from `sqlite_master` (file is not deleted) |
-| PostgreSQL | `DROP SCHEMA public CASCADE` then recreate `public` and restore grants |
+| PostgreSQL | Resets schema `public` only (`DROP SCHEMA public CASCADE` then recreate + grants). Non-`public` schemas are left untouched. |
 | MySQL | Disable FK checks, drop every base table/view in the current database, re-enable checks |
 
 Reset refuses to run when `GOMBIT_ENV=production` unless `--force` is set.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -149,11 +149,17 @@ warning on stderr. A missing or empty seed directory prints `No seed files.` and
 exits successfully.
 
 Each seed file may contain multiple SQL statements separated by `;`. Gombit
-splits on semicolons outside quotes and comments, then executes statements in
-order (so multi-`INSERT` files work without relying on driver multi-statement
-support). Seed files are application-owned SQL. Keep them idempotent if you plan
-to run `seed` more than once against the same database; Gombit does not wrap
-seeds in a cross-driver transaction.
+splits on semicolons outside single/double quotes and `--` / `/* */` comments,
+then executes statements in order (so multi-`INSERT` files work without relying
+on driver multi-statement support). **Known limit (v0.1):** the splitter does
+not treat MySQL backtick identifiers (`` `ident` ``) or PostgreSQL dollar-quoted
+strings (`$tag$...$tag$`) as quoted regions — a `;` inside those forms can
+mis-split. Prefer one statement per file, or avoid semicolons inside backticks /
+dollar-quotes, until the splitter is extended.
+
+Seed files are application-owned SQL. Keep them idempotent if you plan to run
+`seed` more than once against the same database; Gombit does not wrap seeds in a
+cross-driver transaction.
 
 Example layout (flat directory only):
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -130,6 +130,54 @@ database/migrations/downs/20260101000000_create_products.down.sql
 If any down file in the latest batch is missing, rollback fails before
 executing any down SQL. Migrate does not require downs.
 
+## Seed / Reset
+
+M2-3 adds seeders and a destructive development reset. Both commands read the
+configured database from `config.Load()` (`GOMBIT_DATABASE_DRIVER` /
+`GOMBIT_DATABASE_DSN`).
+
+```sh
+gombit db seed  [--seeds database/seeds]
+gombit db reset [--dir database/migrations] [--seeds database/seeds] [--atlas-bin atlas] [--force]
+```
+
+### Seed
+
+`gombit db seed` executes every `*.sql` file in the seed directory in lexical
+order. Non-`.sql` files are skipped with a warning on stderr. A missing or empty
+seed directory prints `No seed files.` and exits successfully.
+
+Seed files are application-owned SQL. Keep them idempotent if you plan to run
+`seed` more than once against the same database; Gombit does not wrap seeds in
+a cross-driver transaction.
+
+Example layout:
+
+```text
+database/seeds/01_demo.sql
+database/seeds/02_more_data.sql
+```
+
+### Reset
+
+`gombit db reset` is drop + migrate + seed:
+
+1. Drops the configured database schema (all user tables/views, including
+   `framework_migrations` and `atlas_schema_revisions`).
+2. Runs `gombit db migrate`.
+3. Runs `gombit db seed`.
+
+Driver wipe strategy:
+
+| Driver | Wipe |
+| --- | --- |
+| SQLite | `DROP` every non-`sqlite_*` table/view from `sqlite_master` (file is not deleted) |
+| PostgreSQL | `DROP SCHEMA public CASCADE` then recreate `public` and restore grants |
+| MySQL | Disable FK checks, drop every base table/view in the current database, re-enable checks |
+
+Reset refuses to run when `GOMBIT_ENV=production` unless `--force` is set.
+Seed alone is allowed in production; apps own seed idempotency.
+
 ## Revision metadata
 
 | Column | Notes |

--- a/examples/migrations/README.md
+++ b/examples/migrations/README.md
@@ -48,7 +48,9 @@ Add SQL seed files under `database/seeds/` (lexical order). This example include
 [`database/seeds/01_demo.sql`](database/seeds/01_demo.sql):
 
 ```sh
-# from the repository root, after configuring GOMBIT_DATABASE_* as above
+# from the repository root, after configuring GOMBIT_DATABASE_* as above.
+# --dir points at the app migration directory (default/repo-root
+# database/migrations from makemigrations); --seeds can point at this example.
 gombit db seed --seeds examples/migrations/database/seeds
 gombit db reset --dir database/migrations --seeds examples/migrations/database/seeds
 ```

--- a/examples/migrations/README.md
+++ b/examples/migrations/README.md
@@ -40,4 +40,33 @@ gombit db rollback
 `migrate` wraps `atlas migrate apply` and records the applied versions in
 `framework_migrations` as one batch. `rollback` executes the latest batch's
 `downs/*.down.sql` files and clears both Gombit and Atlas revision rows for those
-versions. Seed/reset commands are tracked separately in M2-3.
+versions.
+
+## Seed and reset
+
+Add SQL seed files under `database/seeds/` (lexical order). This example includes
+[`database/seeds/01_demo.sql`](database/seeds/01_demo.sql):
+
+```sh
+# from the repository root, after configuring GOMBIT_DATABASE_* as above
+gombit db seed --seeds examples/migrations/database/seeds
+gombit db reset --dir database/migrations --seeds examples/migrations/database/seeds
+```
+
+Or create seeds next to your app migrations:
+
+```sh
+mkdir -p database/seeds
+cat > database/seeds/01_demo.sql <<'SQL'
+-- Example seed. Adjust to match your migrated schema.
+-- INSERT INTO products (name) VALUES ('demo');
+SELECT 1;
+SQL
+
+gombit db seed
+gombit db reset
+```
+
+`seed` runs every `*.sql` file in `--seeds` (default `database/seeds`).
+`reset` drops the schema, migrates, then seeds. In production, pass `--force`
+to allow reset.

--- a/examples/migrations/database/seeds/01_demo.sql
+++ b/examples/migrations/database/seeds/01_demo.sql
@@ -1,0 +1,4 @@
+-- Demo seed for the migrations example.
+-- After generating and applying a products migration, uncomment:
+-- INSERT INTO products (name) VALUES ('demo-product');
+SELECT 1;

--- a/migrations/doc.go
+++ b/migrations/doc.go
@@ -2,5 +2,6 @@
 //
 // MakeMigrations generates SQL via Atlas Program Mode. Migrate, Status, and
 // Rollback apply and report those migrations while recording D4 metadata in
-// framework_migrations.
+// framework_migrations. Seed runs ordered SQL files from database/seeds, and
+// Reset drops the schema then migrate + seed.
 package migrations

--- a/migrations/integration_test.go
+++ b/migrations/integration_test.go
@@ -51,6 +51,34 @@ CREATE TABLE IF NOT EXISTS widgets (
 );`, `DROP TABLE IF EXISTS widgets;`)
 }
 
+func TestSeedResetPostgres(t *testing.T) {
+	if *postgresDSN == "" {
+		t.Skip("set -migrations.postgres-dsn to run Postgres migration integration tests")
+	}
+	runSeedResetRoundTrip(t, config.DatabaseConfig{
+		Driver: config.DatabaseDriverPostgres,
+		DSN:    *postgresDSN,
+	}, `
+CREATE TABLE IF NOT EXISTS widgets (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL
+);`, `INSERT INTO widgets (id, name) VALUES (1, 'seeded');`)
+}
+
+func TestSeedResetMySQL(t *testing.T) {
+	if *mysqlDSN == "" {
+		t.Skip("set -migrations.mysql-dsn to run MySQL migration integration tests")
+	}
+	runSeedResetRoundTrip(t, config.DatabaseConfig{
+		Driver: config.DatabaseDriverMySQL,
+		DSN:    *mysqlDSN,
+	}, `
+CREATE TABLE IF NOT EXISTS widgets (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL
+);`, `INSERT INTO widgets (id, name) VALUES (1, 'seeded');`)
+}
+
 func runDriverRoundTrip(t *testing.T, cfg config.DatabaseConfig, upSQL string, downSQL string) {
 	t.Helper()
 
@@ -106,16 +134,81 @@ func runDriverRoundTrip(t *testing.T, cfg config.DatabaseConfig, upSQL string, d
 	}
 }
 
-func cleanupDriverDB(t *testing.T, cfg config.DatabaseConfig) {
+func runSeedResetRoundTrip(t *testing.T, cfg config.DatabaseConfig, upSQL string, seedSQL string) {
 	t.Helper()
+
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	seedDir := filepath.Join(workDir, "database", "seeds")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir migrations: %v", err)
+	}
+	if err := os.MkdirAll(seedDir, 0o750); err != nil {
+		t.Fatalf("mkdir seeds: %v", err)
+	}
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"), upSQL)
+	writeFile(t, filepath.Join(seedDir, "01_widgets.sql"), seedSQL)
+
+	cleanupDriverDB(t, cfg)
+	t.Cleanup(func() { cleanupDriverDB(t, cfg) })
+
+	runner := &sqlApplyRunner{t: t, cfg: cfg}
+	stdout := new(bytes.Buffer)
+	opts := ResetOptions{
+		ApplyOptions: ApplyOptions{
+			WorkDir:      workDir,
+			MigrationDir: "database/migrations",
+			Database:     cfg,
+			Stdout:       stdout,
+			Stderr:       io.Discard,
+			runner:       runner,
+			now:          func() time.Time { return time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC) },
+		},
+		SeedDir: "database/seeds",
+	}
+
+	if err := Reset(context.Background(), opts); err != nil {
+		t.Fatalf("Reset() error = %v", err)
+	}
+
 	db, err := database.Open(cfg)
 	if err != nil {
-		t.Fatalf("cleanup open: %v", err)
+		t.Fatalf("database.Open() error = %v", err)
 	}
 	defer func() { _ = db.Close() }()
-	_ = db.Migrator().DropTable("widgets")
-	_ = db.Migrator().DropTable(revisionsTable)
-	_ = db.Migrator().DropTable(atlasRevisionsTable)
+	if !db.Migrator().HasTable("widgets") {
+		t.Fatal("expected widgets after reset")
+	}
+	var name string
+	if err := db.Raw("SELECT name FROM widgets WHERE id = 1").Scan(&name).Error; err != nil {
+		t.Fatalf("select seeded row: %v", err)
+	}
+	if name != "seeded" {
+		t.Fatalf("name = %q, want seeded", name)
+	}
+
+	stdout.Reset()
+	if err := Reset(context.Background(), opts); err != nil {
+		t.Fatalf("Reset() second error = %v", err)
+	}
+	var count int64
+	if err := db.Table("widgets").Count(&count).Error; err != nil {
+		t.Fatalf("count widgets: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("widgets count = %d, want 1 after re-seed", count)
+	}
+}
+
+func cleanupDriverDB(t *testing.T, cfg config.DatabaseConfig) {
+	t.Helper()
+	if err := DropSchema(context.Background(), ApplyOptions{
+		Database: cfg,
+		Stdout:   io.Discard,
+		Stderr:   io.Discard,
+	}); err != nil {
+		t.Fatalf("cleanup DropSchema: %v", err)
+	}
 }
 
 type sqlApplyRunner struct {

--- a/migrations/reset.go
+++ b/migrations/reset.go
@@ -1,0 +1,179 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+)
+
+// ResetOptions configures gombit db reset (drop + migrate + seed).
+type ResetOptions struct {
+	ApplyOptions
+	SeedDir     string
+	Force       bool
+	Environment config.Environment
+}
+
+// DropSchema removes all user tables and views from the configured database.
+//
+// Driver wipe strategy:
+//   - SQLite: DROP every non-sqlite_* table/view from sqlite_master
+//   - Postgres: DROP SCHEMA public CASCADE; CREATE SCHEMA public; restore grants
+//   - MySQL: disable FK checks, DROP every base table and view, re-enable checks
+//
+// The SQLite database file is not deleted so in-memory and shared-cache DSNs work.
+func DropSchema(ctx context.Context, opts ApplyOptions) error {
+	if ctx == nil {
+		return errors.New("migrations: nil context")
+	}
+	opts = withApplyDefaults(opts)
+	if err := config.ValidateDatabase(opts.Database); err != nil {
+		return err
+	}
+
+	db, err := openConfiguredDB(opts)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	switch opts.Database.Driver {
+	case config.DatabaseDriverSQLite:
+		if err := dropSQLiteSchema(db); err != nil {
+			return err
+		}
+	case config.DatabaseDriverPostgres:
+		if err := dropPostgresSchema(db); err != nil {
+			return err
+		}
+	case config.DatabaseDriverMySQL:
+		if err := dropMySQLSchema(db); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("migrations: unsupported driver %q", opts.Database.Driver)
+	}
+	_, _ = fmt.Fprintln(opts.Stdout, "Dropped database schema.")
+	return nil
+}
+
+// Reset drops the database schema, applies migrations, then runs seeders.
+//
+// When Environment is production, Force must be true.
+func Reset(ctx context.Context, opts ResetOptions) error {
+	if ctx == nil {
+		return errors.New("migrations: nil context")
+	}
+	if opts.Environment == config.EnvironmentProduction && !opts.Force {
+		return errors.New("migrations: refuse reset in production without --force")
+	}
+
+	applyOpts := withApplyDefaults(opts.ApplyOptions)
+	if err := DropSchema(ctx, applyOpts); err != nil {
+		return err
+	}
+	if err := Migrate(ctx, applyOpts); err != nil {
+		return err
+	}
+	return Seed(ctx, SeedOptions{
+		WorkDir:  applyOpts.WorkDir,
+		SeedDir:  opts.SeedDir,
+		Database: applyOpts.Database,
+		Stdout:   applyOpts.Stdout,
+		Stderr:   applyOpts.Stderr,
+		openDB:   applyOpts.openDB,
+	})
+}
+
+func dropSQLiteSchema(db *database.DB) error {
+	if err := db.Exec("PRAGMA foreign_keys = OFF").Error; err != nil {
+		return fmt.Errorf("migrations: disable sqlite foreign keys: %w", err)
+	}
+	type object struct {
+		Type string
+		Name string
+	}
+	var objects []object
+	if err := db.Raw(`
+SELECT type, name FROM sqlite_master
+WHERE type IN ('table', 'view')
+  AND name NOT LIKE 'sqlite_%'
+ORDER BY type DESC, name`).Scan(&objects).Error; err != nil {
+		return fmt.Errorf("migrations: list sqlite objects: %w", err)
+	}
+	for _, obj := range objects {
+		stmt := fmt.Sprintf("DROP %s IF EXISTS %s", strings.ToUpper(obj.Type), quoteIdent(obj.Name))
+		if err := db.Exec(stmt).Error; err != nil {
+			return fmt.Errorf("migrations: drop sqlite %s %s: %w", obj.Type, obj.Name, err)
+		}
+	}
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		return fmt.Errorf("migrations: enable sqlite foreign keys: %w", err)
+	}
+	return nil
+}
+
+func dropPostgresSchema(db *database.DB) error {
+	stmts := []string{
+		"DROP SCHEMA IF EXISTS public CASCADE",
+		"CREATE SCHEMA public",
+		"GRANT ALL ON SCHEMA public TO public",
+		"GRANT ALL ON SCHEMA public TO CURRENT_USER",
+	}
+	for _, stmt := range stmts {
+		if err := db.Exec(stmt).Error; err != nil {
+			return fmt.Errorf("migrations: postgres schema wipe (%s): %w", stmt, err)
+		}
+	}
+	return nil
+}
+
+func dropMySQLSchema(db *database.DB) error {
+	if err := db.Exec("SET FOREIGN_KEY_CHECKS = 0").Error; err != nil {
+		return fmt.Errorf("migrations: disable mysql foreign keys: %w", err)
+	}
+
+	var dbName string
+	if err := db.Raw("SELECT DATABASE()").Scan(&dbName).Error; err != nil {
+		return fmt.Errorf("migrations: resolve mysql database: %w", err)
+	}
+	if dbName == "" {
+		return errors.New("migrations: mysql DATABASE() is empty")
+	}
+
+	type object struct {
+		Name string
+		Type string
+	}
+	var objects []object
+	if err := db.Raw(`
+SELECT table_name AS name, table_type AS type
+FROM information_schema.tables
+WHERE table_schema = ?
+ORDER BY table_type DESC, table_name`, dbName).Scan(&objects).Error; err != nil {
+		return fmt.Errorf("migrations: list mysql objects: %w", err)
+	}
+	for _, obj := range objects {
+		kind := "TABLE"
+		if strings.EqualFold(obj.Type, "VIEW") {
+			kind = "VIEW"
+		}
+		stmt := fmt.Sprintf("DROP %s IF EXISTS `%s`", kind, strings.ReplaceAll(obj.Name, "`", "``"))
+		if err := db.Exec(stmt).Error; err != nil {
+			return fmt.Errorf("migrations: drop mysql %s %s: %w", kind, obj.Name, err)
+		}
+	}
+
+	if err := db.Exec("SET FOREIGN_KEY_CHECKS = 1").Error; err != nil {
+		return fmt.Errorf("migrations: enable mysql foreign keys: %w", err)
+	}
+	return nil
+}
+
+func quoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}

--- a/migrations/seed.go
+++ b/migrations/seed.go
@@ -61,7 +61,9 @@ func resolveSeedDir(opts SeedOptions) (string, error) {
 // Seed executes SQL seed files from the configured seed directory in lexical order.
 //
 // Missing or empty seed directories succeed with "No seed files.". Non-.sql entries
-// are skipped with a warning on stderr. Execution stops on the first SQL error.
+// and nested subdirectories are skipped with a warning on stderr. Each file may
+// contain multiple statements separated by `;`; statements are executed in order
+// and execution stops on the first SQL error.
 func Seed(ctx context.Context, opts SeedOptions) error {
 	if ctx == nil {
 		return errors.New("migrations: nil context")
@@ -75,11 +77,12 @@ func Seed(ctx context.Context, opts SeedOptions) error {
 	if err != nil {
 		return err
 	}
-	files, skipped, err := listSeedFiles(seedDir)
+	files, skipped, skippedDirs, err := listSeedFiles(seedDir)
 	if err != nil {
 		return err
 	}
 	warnSkippedSeedFiles(opts.Stderr, skipped)
+	warnSkippedSeedDirs(opts.Stderr, skippedDirs)
 	if len(files) == 0 {
 		_, _ = fmt.Fprintln(opts.Stdout, "No seed files.")
 		return nil
@@ -101,27 +104,34 @@ func Seed(ctx context.Context, opts SeedOptions) error {
 		if sqlText == "" {
 			return fmt.Errorf("migrations: seed %s is empty", filepath.Base(path))
 		}
-		if err := db.Exec(sqlText).Error; err != nil {
-			return fmt.Errorf("migrations: execute seed %s: %w", filepath.Base(path), err)
+		stmts := splitSQLStatements(sqlText)
+		if len(stmts) == 0 {
+			return fmt.Errorf("migrations: seed %s has no executable statements", filepath.Base(path))
+		}
+		for i, stmt := range stmts {
+			if err := db.Exec(stmt).Error; err != nil {
+				return fmt.Errorf("migrations: execute seed %s statement %d: %w", filepath.Base(path), i+1, err)
+			}
 		}
 	}
 	_, _ = fmt.Fprintf(opts.Stdout, "Applied %d seed file(s).\n", len(files))
 	return nil
 }
 
-func listSeedFiles(dir string) (files []string, skipped []string, err error) {
+func listSeedFiles(dir string) (files []string, skipped []string, skippedDirs []string, err error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil, nil
+			return nil, nil, nil, nil
 		}
-		return nil, nil, fmt.Errorf("migrations: read seed dir: %w", err)
+		return nil, nil, nil, fmt.Errorf("migrations: read seed dir: %w", err)
 	}
 	for _, entry := range entries {
+		name := entry.Name()
 		if entry.IsDir() {
+			skippedDirs = append(skippedDirs, name)
 			continue
 		}
-		name := entry.Name()
 		if strings.HasSuffix(strings.ToLower(name), ".sql") {
 			files = append(files, filepath.Join(dir, name))
 			continue
@@ -129,7 +139,7 @@ func listSeedFiles(dir string) (files []string, skipped []string, err error) {
 		skipped = append(skipped, name)
 	}
 	sort.Strings(files)
-	return files, skipped, nil
+	return files, skipped, skippedDirs, nil
 }
 
 func warnSkippedSeedFiles(stderr io.Writer, skipped []string) {
@@ -139,4 +149,118 @@ func warnSkippedSeedFiles(stderr io.Writer, skipped []string) {
 	for _, name := range skipped {
 		_, _ = fmt.Fprintf(stderr, "migrations: warning: skipping non-SQL seed file %s\n", name)
 	}
+}
+
+func warnSkippedSeedDirs(stderr io.Writer, skippedDirs []string) {
+	if stderr == nil || len(skippedDirs) == 0 {
+		return
+	}
+	for _, name := range skippedDirs {
+		_, _ = fmt.Fprintf(stderr, "migrations: warning: skipping nested seed directory %s (flat directory only)\n", name)
+	}
+}
+
+// splitSQLStatements splits SQL on semicolons outside quotes and comments.
+// Empty / comment-only fragments are dropped.
+func splitSQLStatements(sql string) []string {
+	var (
+		stmts                                             []string
+		current                                           strings.Builder
+		inSingle, inDouble, inLineComment, inBlockComment bool
+	)
+
+	runes := []rune(sql)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		next := rune(0)
+		if i+1 < len(runes) {
+			next = runes[i+1]
+		}
+
+		switch {
+		case inLineComment:
+			current.WriteRune(r)
+			if r == '\n' {
+				inLineComment = false
+			}
+		case inBlockComment:
+			current.WriteRune(r)
+			if r == '*' && next == '/' {
+				current.WriteRune(next)
+				i++
+				inBlockComment = false
+			}
+		case inSingle:
+			current.WriteRune(r)
+			if r == '\'' {
+				// SQL escaped quote: ''
+				if next == '\'' {
+					current.WriteRune(next)
+					i++
+					continue
+				}
+				inSingle = false
+			}
+		case inDouble:
+			current.WriteRune(r)
+			if r == '"' {
+				if next == '"' {
+					current.WriteRune(next)
+					i++
+					continue
+				}
+				inDouble = false
+			}
+		case r == '-' && next == '-':
+			current.WriteRune(r)
+			current.WriteRune(next)
+			i++
+			inLineComment = true
+		case r == '/' && next == '*':
+			current.WriteRune(r)
+			current.WriteRune(next)
+			i++
+			inBlockComment = true
+		case r == '\'':
+			current.WriteRune(r)
+			inSingle = true
+		case r == '"':
+			current.WriteRune(r)
+			inDouble = true
+		case r == ';':
+			if stmt := strings.TrimSpace(current.String()); stmt != "" && !isSQLCommentOnly(stmt) {
+				stmts = append(stmts, stmt)
+			}
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if stmt := strings.TrimSpace(current.String()); stmt != "" && !isSQLCommentOnly(stmt) {
+		stmts = append(stmts, stmt)
+	}
+	return stmts
+}
+
+func isSQLCommentOnly(stmt string) bool {
+	remaining := strings.TrimSpace(stmt)
+	for remaining != "" {
+		if strings.HasPrefix(remaining, "--") {
+			if idx := strings.IndexByte(remaining, '\n'); idx >= 0 {
+				remaining = strings.TrimSpace(remaining[idx+1:])
+				continue
+			}
+			return true
+		}
+		if strings.HasPrefix(remaining, "/*") {
+			end := strings.Index(remaining, "*/")
+			if end < 0 {
+				return true
+			}
+			remaining = strings.TrimSpace(remaining[end+2:])
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/migrations/seed.go
+++ b/migrations/seed.go
@@ -162,6 +162,9 @@ func warnSkippedSeedDirs(stderr io.Writer, skippedDirs []string) {
 
 // splitSQLStatements splits SQL on semicolons outside quotes and comments.
 // Empty / comment-only fragments are dropped.
+//
+// v0.1 known limits: MySQL backtick identifiers and PostgreSQL dollar-quoted
+// strings are not treated as quoted regions, so a ';' inside them can mis-split.
 func splitSQLStatements(sql string) []string {
 	var (
 		stmts                                             []string

--- a/migrations/seed.go
+++ b/migrations/seed.go
@@ -1,0 +1,142 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+)
+
+const defaultSeedDir = "database/seeds"
+
+// SeedOptions configures gombit db seed.
+type SeedOptions struct {
+	WorkDir  string
+	SeedDir  string
+	Database config.DatabaseConfig
+	Stdout   io.Writer
+	Stderr   io.Writer
+
+	openDB func(config.DatabaseConfig) (*database.DB, error)
+}
+
+func withSeedDefaults(opts SeedOptions) SeedOptions {
+	if opts.WorkDir == "" {
+		opts.WorkDir = "."
+	}
+	if opts.SeedDir == "" {
+		opts.SeedDir = defaultSeedDir
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = io.Discard
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = io.Discard
+	}
+	if opts.openDB == nil {
+		opts.openDB = database.Open
+	}
+	return opts
+}
+
+func resolveSeedDir(opts SeedOptions) (string, error) {
+	absWorkDir, err := filepath.Abs(opts.WorkDir)
+	if err != nil {
+		return "", fmt.Errorf("migrations: resolve work dir: %w", err)
+	}
+	seedDir := opts.SeedDir
+	if !filepath.IsAbs(seedDir) {
+		seedDir = filepath.Join(absWorkDir, seedDir)
+	}
+	return seedDir, nil
+}
+
+// Seed executes SQL seed files from the configured seed directory in lexical order.
+//
+// Missing or empty seed directories succeed with "No seed files.". Non-.sql entries
+// are skipped with a warning on stderr. Execution stops on the first SQL error.
+func Seed(ctx context.Context, opts SeedOptions) error {
+	if ctx == nil {
+		return errors.New("migrations: nil context")
+	}
+	opts = withSeedDefaults(opts)
+	if err := config.ValidateDatabase(opts.Database); err != nil {
+		return err
+	}
+
+	seedDir, err := resolveSeedDir(opts)
+	if err != nil {
+		return err
+	}
+	files, skipped, err := listSeedFiles(seedDir)
+	if err != nil {
+		return err
+	}
+	warnSkippedSeedFiles(opts.Stderr, skipped)
+	if len(files) == 0 {
+		_, _ = fmt.Fprintln(opts.Stdout, "No seed files.")
+		return nil
+	}
+
+	db, err := opts.openDB(opts.Database)
+	if err != nil {
+		return fmt.Errorf("migrations: open database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for _, path := range files {
+		// #nosec G304 -- seed paths are resolved from the configured seed directory.
+		sqlBytes, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("migrations: read seed %s: %w", filepath.Base(path), err)
+		}
+		sqlText := strings.TrimSpace(string(sqlBytes))
+		if sqlText == "" {
+			return fmt.Errorf("migrations: seed %s is empty", filepath.Base(path))
+		}
+		if err := db.Exec(sqlText).Error; err != nil {
+			return fmt.Errorf("migrations: execute seed %s: %w", filepath.Base(path), err)
+		}
+	}
+	_, _ = fmt.Fprintf(opts.Stdout, "Applied %d seed file(s).\n", len(files))
+	return nil
+}
+
+func listSeedFiles(dir string) (files []string, skipped []string, err error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("migrations: read seed dir: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(strings.ToLower(name), ".sql") {
+			files = append(files, filepath.Join(dir, name))
+			continue
+		}
+		skipped = append(skipped, name)
+	}
+	sort.Strings(files)
+	return files, skipped, nil
+}
+
+func warnSkippedSeedFiles(stderr io.Writer, skipped []string) {
+	if stderr == nil || len(skipped) == 0 {
+		return
+	}
+	for _, name := range skipped {
+		_, _ = fmt.Fprintf(stderr, "migrations: warning: skipping non-SQL seed file %s\n", name)
+	}
+}

--- a/migrations/seed_test.go
+++ b/migrations/seed_test.go
@@ -1,0 +1,263 @@
+package migrations
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+)
+
+func TestSeedAppliesOrderedSQLFiles(t *testing.T) {
+	workDir := t.TempDir()
+	seedDir := filepath.Join(workDir, "database", "seeds")
+	if err := os.MkdirAll(seedDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Exec("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").Error; err != nil {
+		t.Fatalf("create widgets: %v", err)
+	}
+
+	writeFile(t, filepath.Join(seedDir, "02_second.sql"), `INSERT INTO widgets (id, name) VALUES (2, 'second');`)
+	writeFile(t, filepath.Join(seedDir, "01_first.sql"), `INSERT INTO widgets (id, name) VALUES (1, 'first');`)
+	writeFile(t, filepath.Join(seedDir, "notes.txt"), "not sql")
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err = Seed(context.Background(), SeedOptions{
+		WorkDir:  workDir,
+		SeedDir:  "database/seeds",
+		Database: cfg,
+		Stdout:   stdout,
+		Stderr:   stderr,
+	})
+	if err != nil {
+		t.Fatalf("Seed() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Applied 2 seed file(s)") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "skipping non-SQL seed file notes.txt") {
+		t.Fatalf("stderr = %q, want skip warning", stderr.String())
+	}
+
+	var names []string
+	if err := db.Raw("SELECT name FROM widgets ORDER BY id").Scan(&names).Error; err != nil {
+		t.Fatalf("select widgets: %v", err)
+	}
+	if len(names) != 2 || names[0] != "first" || names[1] != "second" {
+		t.Fatalf("names = %#v, want [first second]", names)
+	}
+}
+
+func TestSeedMissingDirIsNoop(t *testing.T) {
+	workDir := t.TempDir()
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	stdout := new(bytes.Buffer)
+	err := Seed(context.Background(), SeedOptions{
+		WorkDir:  workDir,
+		SeedDir:  "database/seeds",
+		Database: config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn},
+		Stdout:   stdout,
+	})
+	if err != nil {
+		t.Fatalf("Seed() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "No seed files") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestDropSchemaRemovesTables(t *testing.T) {
+	workDir := t.TempDir()
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Exec("CREATE TABLE widgets (id INTEGER PRIMARY KEY)").Error; err != nil {
+		t.Fatalf("create widgets: %v", err)
+	}
+	if err := ensureRevisionsTable(db.DB); err != nil {
+		t.Fatalf("ensureRevisionsTable: %v", err)
+	}
+	if err := db.Exec(fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+  version varchar(255) PRIMARY KEY,
+  description text,
+  type varchar(255),
+  applied_at datetime
+)`, atlasRevisionsTable)).Error; err != nil {
+		t.Fatalf("create atlas revisions: %v", err)
+	}
+
+	stdout := new(bytes.Buffer)
+	if err := DropSchema(context.Background(), ApplyOptions{
+		Database: cfg,
+		Stdout:   stdout,
+	}); err != nil {
+		t.Fatalf("DropSchema() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Dropped database schema") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if db.Migrator().HasTable("widgets") {
+		t.Fatal("widgets should be gone after DropSchema")
+	}
+	if db.Migrator().HasTable(revisionsTable) {
+		t.Fatal("framework_migrations should be gone after DropSchema")
+	}
+	if db.Migrator().HasTable(atlasRevisionsTable) {
+		t.Fatal("atlas_schema_revisions should be gone after DropSchema")
+	}
+}
+
+func TestResetRoundTrip(t *testing.T) {
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	seedDir := filepath.Join(workDir, "database", "seeds")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir migrations: %v", err)
+	}
+	if err := os.MkdirAll(seedDir, 0o750); err != nil {
+		t.Fatalf("mkdir seeds: %v", err)
+	}
+
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
+		"CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL);")
+	writeFile(t, filepath.Join(migrationDir, "downs", "20260101000000_create_widgets.down.sql"),
+		"DROP TABLE widgets;")
+	writeFile(t, filepath.Join(seedDir, "01_widgets.sql"),
+		"INSERT INTO widgets (id, name) VALUES (1, 'seeded');")
+
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	runner := &applyFakeAtlas{t: t}
+	stdout := new(bytes.Buffer)
+	opts := ResetOptions{
+		ApplyOptions: ApplyOptions{
+			WorkDir:      workDir,
+			MigrationDir: "database/migrations",
+			Database:     cfg,
+			Stdout:       stdout,
+			Stderr:       io.Discard,
+			runner:       runner,
+			now:          func() time.Time { return time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC) },
+		},
+		SeedDir: "database/seeds",
+	}
+
+	if err := Reset(context.Background(), opts); err != nil {
+		t.Fatalf("Reset() first error = %v", err)
+	}
+
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !db.Migrator().HasTable("widgets") {
+		t.Fatal("expected widgets after reset")
+	}
+	var name string
+	if err := db.Raw("SELECT name FROM widgets WHERE id = 1").Scan(&name).Error; err != nil {
+		t.Fatalf("select seeded row: %v", err)
+	}
+	if name != "seeded" {
+		t.Fatalf("name = %q, want seeded", name)
+	}
+
+	stdout.Reset()
+	if err := Reset(context.Background(), opts); err != nil {
+		t.Fatalf("Reset() second error = %v", err)
+	}
+	if !db.Migrator().HasTable("widgets") {
+		t.Fatal("expected widgets after second reset")
+	}
+	var count int64
+	if err := db.Table("widgets").Count(&count).Error; err != nil {
+		t.Fatalf("count widgets: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("widgets count = %d, want 1 after re-seed", count)
+	}
+	if !strings.Contains(stdout.String(), "Dropped database schema") {
+		t.Fatalf("stdout = %q, want drop message", stdout.String())
+	}
+}
+
+func TestResetRefusesProductionWithoutForce(t *testing.T) {
+	workDir := t.TempDir()
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	err := Reset(context.Background(), ResetOptions{
+		ApplyOptions: ApplyOptions{
+			WorkDir:  workDir,
+			Database: config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn},
+			Stdout:   io.Discard,
+			Stderr:   io.Discard,
+			runner:   &applyFakeAtlas{t: t},
+		},
+		Environment: config.EnvironmentProduction,
+		Force:       false,
+	})
+	if err == nil {
+		t.Fatal("Reset() error = nil, want production refusal")
+	}
+	if !strings.Contains(err.Error(), "refuse reset in production without --force") {
+		t.Fatalf("Reset() error = %q", err)
+	}
+}
+
+func TestResetAllowsProductionWithForce(t *testing.T) {
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
+		"CREATE TABLE widgets (id INTEGER PRIMARY KEY);")
+
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	err := Reset(context.Background(), ResetOptions{
+		ApplyOptions: ApplyOptions{
+			WorkDir:      workDir,
+			MigrationDir: "database/migrations",
+			Database:     cfg,
+			Stdout:       io.Discard,
+			Stderr:       io.Discard,
+			runner:       &applyFakeAtlas{t: t},
+			now:          func() time.Time { return time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC) },
+		},
+		Environment: config.EnvironmentProduction,
+		Force:       true,
+	})
+	if err != nil {
+		t.Fatalf("Reset() error = %v", err)
+	}
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !db.Migrator().HasTable("widgets") {
+		t.Fatal("expected widgets after forced production reset")
+	}
+}

--- a/migrations/seed_test.go
+++ b/migrations/seed_test.go
@@ -36,6 +36,9 @@ func TestSeedAppliesOrderedSQLFiles(t *testing.T) {
 	writeFile(t, filepath.Join(seedDir, "02_second.sql"), `INSERT INTO widgets (id, name) VALUES (2, 'second');`)
 	writeFile(t, filepath.Join(seedDir, "01_first.sql"), `INSERT INTO widgets (id, name) VALUES (1, 'first');`)
 	writeFile(t, filepath.Join(seedDir, "notes.txt"), "not sql")
+	if err := os.MkdirAll(filepath.Join(seedDir, "nested"), 0o750); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -54,6 +57,9 @@ func TestSeedAppliesOrderedSQLFiles(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "skipping non-SQL seed file notes.txt") {
 		t.Fatalf("stderr = %q, want skip warning", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "skipping nested seed directory nested") {
+		t.Fatalf("stderr = %q, want nested dir warning", stderr.String())
 	}
 
 	var names []string
@@ -80,6 +86,99 @@ func TestSeedMissingDirIsNoop(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "No seed files") {
 		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestSeedAppliesMultiStatementFile(t *testing.T) {
+	workDir := t.TempDir()
+	seedDir := filepath.Join(workDir, "database", "seeds")
+	if err := os.MkdirAll(seedDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Exec("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").Error; err != nil {
+		t.Fatalf("create widgets: %v", err)
+	}
+
+	writeFile(t, filepath.Join(seedDir, "01_multi.sql"), `
+-- seed two rows in one file
+INSERT INTO widgets (id, name) VALUES (1, 'alpha');
+INSERT INTO widgets (id, name) VALUES (2, 'semi;colon');
+INSERT INTO widgets (id, name) VALUES (3, 'gamma');
+`)
+
+	if err := Seed(context.Background(), SeedOptions{
+		WorkDir:  workDir,
+		SeedDir:  "database/seeds",
+		Database: cfg,
+		Stdout:   io.Discard,
+		Stderr:   io.Discard,
+	}); err != nil {
+		t.Fatalf("Seed() error = %v", err)
+	}
+
+	var names []string
+	if err := db.Raw("SELECT name FROM widgets ORDER BY id").Scan(&names).Error; err != nil {
+		t.Fatalf("select widgets: %v", err)
+	}
+	if len(names) != 3 || names[0] != "alpha" || names[1] != "semi;colon" || names[2] != "gamma" {
+		t.Fatalf("names = %#v, want [alpha semi;colon gamma]", names)
+	}
+}
+
+func TestSplitSQLStatements(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{
+			name: "two inserts",
+			sql:  "INSERT INTO t VALUES (1); INSERT INTO t VALUES (2);",
+			want: []string{"INSERT INTO t VALUES (1)", "INSERT INTO t VALUES (2)"},
+		},
+		{
+			name: "semicolon inside string",
+			sql:  "INSERT INTO t VALUES ('a;b'); INSERT INTO t VALUES (2)",
+			want: []string{"INSERT INTO t VALUES ('a;b')", "INSERT INTO t VALUES (2)"},
+		},
+		{
+			name: "escaped quote",
+			sql:  "INSERT INTO t VALUES ('it''s;ok');",
+			want: []string{"INSERT INTO t VALUES ('it''s;ok')"},
+		},
+		{
+			name: "line comment with semicolon",
+			sql:  "INSERT INTO t VALUES (1); -- skip; me\nINSERT INTO t VALUES (2);",
+			want: []string{"INSERT INTO t VALUES (1)", "-- skip; me\nINSERT INTO t VALUES (2)"},
+		},
+		{
+			name: "comment only",
+			sql:  "-- just a comment\n/* also comment */",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := splitSQLStatements(tt.sql)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d (%#v), want %d (%#v)", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("stmt[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `gombit db seed` and `gombit db reset` for M2-3: ordered SQL seed files under `database/seeds/`, plus a destructive drop → migrate → seed reset with a production `--force` guard.

Closes #14

## Acceptance criteria

- [x] seed and reset work on all supported DBs (SQLite unit tests; Postgres + MySQL via existing `integration` tags / CI jobs)

## Scope notes

- Go seeder registries / factories deferred (SQL seed files only for v0.1 / this issue).
- Cobra CLI migration remains M4-1.
- Broader multi-DB conformance expansion remains #15 / M2-4.

## Validation

- [x] `go test ./migrations/ -run 'TestSeed|TestDrop|TestReset|TestMigrateRollback|TestMigrateNoPending|TestMigrateRecords|TestRollback'`
- [x] `go test ./cmd/gombit/ -run 'TestRunSeed|TestRunReset|TestRunMigrate|TestRunReject'`
- [ ] `go test ./...` (full suite; makemigrations tests need network for Atlas provider download in this environment)
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (SQLite in default suite; Postgres/MySQL covered by `//go:build integration` tests on existing CI jobs)
- [x] Stable features ship docs and appear in an example app
- [ ] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests (N/A — greenfield seed/reset, not an extraction)
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) (N/A — no generators)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR (N/A — no HTTP/API contract change)
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public (N/A — no frontend)
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

Made with [Cursor](https://cursor.com)