### PR TITLE
[M2-4] Multi-DB conformance CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,20 +240,35 @@ jobs:
           -migrations.mysql-dsn
           'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
 
-  conformance:
-    name: Conformance (${{ matrix.driver }})
+  conformance-sqlite:
+    name: Conformance (sqlite)
     needs: test
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - driver: sqlite
-            dsn: ""
-          - driver: postgres
-            dsn: "postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable"
-          - driver: mysql
-            dsn: "gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Atlas Community Edition
+        run: curl -sSf https://atlasgo.sh | sh -s -- --community
+
+      - name: Run SQLite conformance suite
+        env:
+          ATLAS_BINARY: atlas
+        run: >-
+          go test -tags conformance ./database/conformance
+          -conformance.driver sqlite
+          -count=1
+
+  conformance-postgres:
+    name: Conformance (postgres)
+    needs: test
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:16-alpine
@@ -268,6 +283,34 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Atlas Community Edition
+        run: curl -sSf https://atlasgo.sh | sh -s -- --community
+
+      - name: Run Postgres conformance suite
+        env:
+          ATLAS_BINARY: atlas
+        run: >-
+          go test -tags conformance ./database/conformance
+          -conformance.driver postgres
+          -conformance.dsn
+          'postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable'
+          -count=1
+
+  conformance-mysql:
+    name: Conformance (mysql)
+    needs: test
+    runs-on: ubuntu-latest
+    services:
       mysql:
         image: mysql:8.4
         env:
@@ -295,11 +338,12 @@ jobs:
       - name: Install Atlas Community Edition
         run: curl -sSf https://atlasgo.sh | sh -s -- --community
 
-      - name: Run multi-DB conformance suite
+      - name: Run MySQL conformance suite
         env:
           ATLAS_BINARY: atlas
         run: >-
           go test -tags conformance ./database/conformance
-          -conformance.driver ${{ matrix.driver }}
-          -conformance.dsn '${{ matrix.dsn }}'
+          -conformance.driver mysql
+          -conformance.dsn
+          'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
           -count=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: read
 
-# Pipeline: lint → build → test → (database ∥ migrations)
+# Pipeline: lint → build → test → (database ∥ migrations ∥ conformance)
 jobs:
   lint:
     name: Lint
@@ -239,3 +239,67 @@ jobs:
           go test -tags integration ./migrations
           -migrations.mysql-dsn
           'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
+
+  conformance:
+    name: Conformance (${{ matrix.driver }})
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - driver: sqlite
+            dsn: ""
+          - driver: postgres
+            dsn: "postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable"
+          - driver: mysql
+            dsn: "gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true"
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: gombit
+          POSTGRES_PASSWORD: gombit
+          POSTGRES_DB: gombit
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U gombit -d gombit"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: gombit
+          MYSQL_USER: gombit
+          MYSQL_PASSWORD: gombit
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -ugombit -pgombit"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Atlas Community Edition
+        run: curl -sSf https://atlasgo.sh | sh -s -- --community
+
+      - name: Run multi-DB conformance suite
+        env:
+          ATLAS_BINARY: atlas
+        run: >-
+          go test -tags conformance ./database/conformance
+          -conformance.driver ${{ matrix.driver }}
+          -conformance.dsn '${{ matrix.dsn }}'
+          -count=1

--- a/database/conformance/doc.go
+++ b/database/conformance/doc.go
@@ -1,0 +1,4 @@
+// Package conformance hosts the multi-DB conformance suite.
+//
+// Run it with the conformance build tag (see docs/database.md).
+package conformance

--- a/database/conformance/harness_test.go
+++ b/database/conformance/harness_test.go
@@ -1,0 +1,211 @@
+//go:build conformance
+
+package conformance_test
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+	"github.com/LAA-Software-Engineering/gombit/migrations"
+)
+
+var (
+	conformanceDriver = flag.String("conformance.driver", "sqlite", "database driver: sqlite, postgres, or mysql")
+	conformanceDSN    = flag.String("conformance.dsn", "", "database DSN (sqlite defaults to a temp file when empty)")
+)
+
+type harness struct {
+	t          *testing.T
+	cfg        config.DatabaseConfig
+	atlasBin   string
+	root       string
+	workDir    string
+	migrateDir string
+	opts       migrations.ApplyOptions
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+
+	atlasBin := findAtlas(t)
+	cfg := databaseConfig(t)
+	root := projectRoot(t)
+	workDir := t.TempDir()
+	migrateDir := filepath.Join(workDir, "database", "migrations")
+	if err := os.MkdirAll(migrateDir, 0o750); err != nil {
+		t.Fatalf("mkdir migrations: %v", err)
+	}
+
+	cleanupSchema(t, cfg)
+	t.Cleanup(func() { cleanupSchema(t, cfg) })
+
+	h := &harness{
+		t:          t,
+		cfg:        cfg,
+		atlasBin:   atlasBin,
+		root:       root,
+		workDir:    workDir,
+		migrateDir: migrateDir,
+		opts: migrations.ApplyOptions{
+			WorkDir:      workDir,
+			MigrationDir: "database/migrations",
+			AtlasBinary:  atlasBin,
+			Database:     cfg,
+			Stdout:       new(bytes.Buffer),
+			Stderr:       new(bytes.Buffer),
+		},
+	}
+	h.prepareSchema()
+	return h
+}
+
+func (h *harness) prepareSchema() {
+	h.t.Helper()
+
+	stderr := new(bytes.Buffer)
+	err := migrations.MakeMigrations(context.Background(), migrations.Options{
+		WorkDir:      h.root,
+		Name:         "create_items",
+		Driver:       h.cfg.Driver,
+		MigrationDir: h.migrateDir,
+		AtlasBinary:  h.atlasBin,
+		Models: []migrations.Model{{
+			ImportPath: "github.com/LAA-Software-Engineering/gombit/database/conformance/models",
+			TypeName:   "Item",
+		}},
+		Stdout: io.Discard,
+		Stderr: stderr,
+	})
+	if err != nil {
+		h.t.Fatalf("MakeMigrations() error = %v; stderr=%s", err, stderr.String())
+	}
+
+	ups, err := filepath.Glob(filepath.Join(h.migrateDir, "*.sql"))
+	if err != nil {
+		h.t.Fatalf("glob migrations: %v", err)
+	}
+	if len(ups) != 1 {
+		h.t.Fatalf("migration files = %v, want exactly one Atlas-generated SQL file", ups)
+	}
+
+	version, name, err := migrations.ParseMigrationFilename(filepath.Base(ups[0]))
+	if err != nil {
+		h.t.Fatalf("ParseMigrationFilename: %v", err)
+	}
+	downDir := filepath.Join(h.migrateDir, "downs")
+	if err := os.MkdirAll(downDir, 0o750); err != nil {
+		h.t.Fatalf("mkdir downs: %v", err)
+	}
+	downPath := migrations.DownPath(h.migrateDir, version, name)
+	if err := os.WriteFile(downPath, []byte("DROP TABLE IF EXISTS items;\n"), 0o600); err != nil {
+		h.t.Fatalf("write down migration: %v", err)
+	}
+
+	stdout := new(bytes.Buffer)
+	stderr = new(bytes.Buffer)
+	h.opts.Stdout = stdout
+	h.opts.Stderr = stderr
+	if err := migrations.Migrate(context.Background(), h.opts); err != nil {
+		h.t.Fatalf("Migrate() error = %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Applied") {
+		h.t.Fatalf("migrate stdout = %q, want Applied", stdout.String())
+	}
+}
+
+func (h *harness) openDB() *database.DB {
+	h.t.Helper()
+	db, err := database.Open(h.cfg)
+	if err != nil {
+		h.t.Fatalf("database.Open() error = %v", err)
+	}
+	h.t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func (h *harness) rollback() {
+	h.t.Helper()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	h.opts.Stdout = stdout
+	h.opts.Stderr = stderr
+	if err := migrations.Rollback(context.Background(), h.opts); err != nil {
+		h.t.Fatalf("Rollback() error = %v; stderr=%s", err, stderr.String())
+	}
+}
+
+func findAtlas(t *testing.T) string {
+	t.Helper()
+	if bin := strings.TrimSpace(os.Getenv("ATLAS_BINARY")); bin != "" {
+		return bin
+	}
+	bin, err := exec.LookPath("atlas")
+	if err != nil {
+		t.Skip("Atlas CLI not found; set ATLAS_BINARY to run conformance tests")
+	}
+	return bin
+}
+
+func databaseConfig(t *testing.T) config.DatabaseConfig {
+	t.Helper()
+
+	driver := config.DatabaseDriver(strings.TrimSpace(*conformanceDriver))
+	dsn := strings.TrimSpace(*conformanceDSN)
+
+	switch driver {
+	case config.DatabaseDriverSQLite:
+		if dsn == "" {
+			dsn = "file:" + filepath.Join(t.TempDir(), "conformance.db") + "?cache=shared&_fk=1"
+		}
+	case config.DatabaseDriverPostgres, config.DatabaseDriverMySQL:
+		if dsn == "" {
+			t.Fatalf("-conformance.dsn is required for driver %q", driver)
+		}
+	default:
+		t.Fatalf("unsupported -conformance.driver %q", driver)
+	}
+
+	cfg := config.DatabaseConfig{Driver: driver, DSN: dsn}
+	if err := config.ValidateDatabase(cfg); err != nil {
+		t.Fatalf("ValidateDatabase: %v", err)
+	}
+	return cfg
+}
+
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found from test working directory")
+		}
+		dir = parent
+	}
+}
+
+func cleanupSchema(t *testing.T, cfg config.DatabaseConfig) {
+	t.Helper()
+	if err := migrations.DropSchema(context.Background(), migrations.ApplyOptions{
+		Database: cfg,
+		Stdout:   io.Discard,
+		Stderr:   io.Discard,
+	}); err != nil {
+		t.Fatalf("DropSchema cleanup: %v", err)
+	}
+}

--- a/database/conformance/models/item.go
+++ b/database/conformance/models/item.go
@@ -1,0 +1,23 @@
+// Package models holds GORM fixtures for the multi-DB conformance suite.
+package models
+
+import (
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+// Item exercises portable schema features required by M2-4 conformance:
+// timestamps (via gorm.Model), nullable columns, unique + non-unique indexes,
+// and decimal storage.
+type Item struct {
+	gorm.Model
+	Code  string          `gorm:"size:64;uniqueIndex;not null"`
+	Name  string          `gorm:"size:120;index;not null"`
+	Notes *string         `gorm:"size:255"`
+	Price decimal.Decimal `gorm:"type:decimal(19,4);not null"`
+}
+
+// TableName returns the stable table name for Atlas-generated migrations.
+func (Item) TableName() string {
+	return "items"
+}

--- a/database/conformance/suite_test.go
+++ b/database/conformance/suite_test.go
@@ -67,16 +67,22 @@ func TestConformanceSuite(t *testing.T) {
 		}
 		createdAt := item.CreatedAt
 		updatedAt := item.UpdatedAt
-		time.Sleep(10 * time.Millisecond)
+		// MySQL DATETIME is second-precision by default; wait past one second so
+		// GORM's auto UpdatedAt is guaranteed to advance on every driver.
+		time.Sleep(1100 * time.Millisecond)
 		item.Name = "timestamps-updated"
 		if err := db.Save(&item).Error; err != nil {
 			t.Fatalf("Save: %v", err)
 		}
-		if !item.CreatedAt.Equal(createdAt) {
-			t.Fatalf("CreatedAt changed: got %v want %v", item.CreatedAt, createdAt)
+		var reloaded models.Item
+		if err := db.First(&reloaded, item.ID).Error; err != nil {
+			t.Fatalf("First after update: %v", err)
 		}
-		if !item.UpdatedAt.After(updatedAt) {
-			t.Fatalf("UpdatedAt not bumped: before=%v after=%v", updatedAt, item.UpdatedAt)
+		if !reloaded.CreatedAt.Equal(createdAt) {
+			t.Fatalf("CreatedAt changed: got %v want %v", reloaded.CreatedAt, createdAt)
+		}
+		if !reloaded.UpdatedAt.After(updatedAt) {
+			t.Fatalf("UpdatedAt not bumped: before=%v after=%v", updatedAt, reloaded.UpdatedAt)
 		}
 	})
 

--- a/database/conformance/suite_test.go
+++ b/database/conformance/suite_test.go
@@ -62,27 +62,33 @@ func TestConformanceSuite(t *testing.T) {
 		if err := db.Create(&item).Error; err != nil {
 			t.Fatalf("Create: %v", err)
 		}
-		if item.CreatedAt.IsZero() || item.UpdatedAt.IsZero() {
-			t.Fatalf("timestamps not set: created=%v updated=%v", item.CreatedAt, item.UpdatedAt)
+		// Reload so CreatedAt/UpdatedAt match driver storage precision
+		// (Postgres timestamptz drops Go's nanosecond remainder).
+		var before models.Item
+		if err := db.First(&before, item.ID).Error; err != nil {
+			t.Fatalf("First after create: %v", err)
 		}
-		createdAt := item.CreatedAt
-		updatedAt := item.UpdatedAt
+		if before.CreatedAt.IsZero() || before.UpdatedAt.IsZero() {
+			t.Fatalf("timestamps not set: created=%v updated=%v", before.CreatedAt, before.UpdatedAt)
+		}
+		createdAt := before.CreatedAt
+		updatedAt := before.UpdatedAt
 		// MySQL DATETIME is second-precision by default; wait past one second so
 		// GORM's auto UpdatedAt is guaranteed to advance on every driver.
 		time.Sleep(1100 * time.Millisecond)
-		item.Name = "timestamps-updated"
-		if err := db.Save(&item).Error; err != nil {
+		before.Name = "timestamps-updated"
+		if err := db.Save(&before).Error; err != nil {
 			t.Fatalf("Save: %v", err)
 		}
-		var reloaded models.Item
-		if err := db.First(&reloaded, item.ID).Error; err != nil {
+		var after models.Item
+		if err := db.First(&after, before.ID).Error; err != nil {
 			t.Fatalf("First after update: %v", err)
 		}
-		if !reloaded.CreatedAt.Equal(createdAt) {
-			t.Fatalf("CreatedAt changed: got %v want %v", reloaded.CreatedAt, createdAt)
+		if !after.CreatedAt.Equal(createdAt) {
+			t.Fatalf("CreatedAt changed: got %v want %v", after.CreatedAt, createdAt)
 		}
-		if !reloaded.UpdatedAt.After(updatedAt) {
-			t.Fatalf("UpdatedAt not bumped: before=%v after=%v", updatedAt, reloaded.UpdatedAt)
+		if !after.UpdatedAt.After(updatedAt) {
+			t.Fatalf("UpdatedAt not bumped: before=%v after=%v", updatedAt, after.UpdatedAt)
 		}
 	})
 

--- a/database/conformance/suite_test.go
+++ b/database/conformance/suite_test.go
@@ -1,0 +1,271 @@
+//go:build conformance
+
+package conformance_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/database"
+	"github.com/LAA-Software-Engineering/gombit/database/conformance/models"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+func TestConformanceSuite(t *testing.T) {
+	h := newHarness(t)
+	db := h.openDB()
+
+	t.Run("migrate_up", func(t *testing.T) {
+		if !db.Migrator().HasTable(&models.Item{}) {
+			t.Fatal("expected items table after Atlas migrate apply")
+		}
+		if !db.Migrator().HasTable("framework_migrations") {
+			t.Fatal("expected framework_migrations after migrate")
+		}
+		if !db.Migrator().HasTable("atlas_schema_revisions") {
+			t.Fatal("expected atlas_schema_revisions after Atlas apply")
+		}
+	})
+
+	t.Run("indexes", func(t *testing.T) {
+		indexes, err := db.Migrator().GetIndexes(&models.Item{})
+		if err != nil {
+			t.Fatalf("GetIndexes: %v", err)
+		}
+		var hasUniqueCode, hasNameIndex bool
+		for _, idx := range indexes {
+			cols := idx.Columns()
+			unique, _ := idx.Unique()
+			if len(cols) == 1 && cols[0] == "code" && unique {
+				hasUniqueCode = true
+			}
+			if len(cols) == 1 && cols[0] == "name" {
+				hasNameIndex = true
+			}
+		}
+		if !hasUniqueCode {
+			t.Fatalf("expected unique index on code; indexes=%#v", indexes)
+		}
+		if !hasNameIndex {
+			t.Fatalf("expected index on name; indexes=%#v", indexes)
+		}
+	})
+
+	t.Run("timestamps", func(t *testing.T) {
+		item := models.Item{
+			Code:  "ts-1",
+			Name:  "timestamps",
+			Price: decimal.RequireFromString("1.0000"),
+		}
+		if err := db.Create(&item).Error; err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if item.CreatedAt.IsZero() || item.UpdatedAt.IsZero() {
+			t.Fatalf("timestamps not set: created=%v updated=%v", item.CreatedAt, item.UpdatedAt)
+		}
+		createdAt := item.CreatedAt
+		updatedAt := item.UpdatedAt
+		time.Sleep(10 * time.Millisecond)
+		item.Name = "timestamps-updated"
+		if err := db.Save(&item).Error; err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		if !item.CreatedAt.Equal(createdAt) {
+			t.Fatalf("CreatedAt changed: got %v want %v", item.CreatedAt, createdAt)
+		}
+		if !item.UpdatedAt.After(updatedAt) {
+			t.Fatalf("UpdatedAt not bumped: before=%v after=%v", updatedAt, item.UpdatedAt)
+		}
+	})
+
+	t.Run("nullable", func(t *testing.T) {
+		nullItem := models.Item{
+			Code:  "null-1",
+			Name:  "nullable-null",
+			Price: decimal.RequireFromString("2.5000"),
+		}
+		if err := db.Create(&nullItem).Error; err != nil {
+			t.Fatalf("Create null notes: %v", err)
+		}
+		var loaded models.Item
+		if err := db.First(&loaded, nullItem.ID).Error; err != nil {
+			t.Fatalf("First: %v", err)
+		}
+		if loaded.Notes != nil {
+			t.Fatalf("Notes = %v, want nil", loaded.Notes)
+		}
+
+		note := "hello"
+		withNotes := models.Item{
+			Code:  "null-2",
+			Name:  "nullable-set",
+			Notes: &note,
+			Price: decimal.RequireFromString("3.2500"),
+		}
+		if err := db.Create(&withNotes).Error; err != nil {
+			t.Fatalf("Create with notes: %v", err)
+		}
+		loaded = models.Item{}
+		if err := db.First(&loaded, withNotes.ID).Error; err != nil {
+			t.Fatalf("First with notes: %v", err)
+		}
+		if loaded.Notes == nil || *loaded.Notes != note {
+			t.Fatalf("Notes = %v, want %q", loaded.Notes, note)
+		}
+	})
+
+	t.Run("unique", func(t *testing.T) {
+		first := models.Item{
+			Code:  "unique-1",
+			Name:  "unique-a",
+			Price: decimal.RequireFromString("4.0000"),
+		}
+		if err := db.Create(&first).Error; err != nil {
+			t.Fatalf("Create first: %v", err)
+		}
+		dup := models.Item{
+			Code:  "unique-1",
+			Name:  "unique-b",
+			Price: decimal.RequireFromString("5.0000"),
+		}
+		if err := db.Create(&dup).Error; err == nil {
+			t.Fatal("Create duplicate unique code error = nil, want error")
+		}
+	})
+
+	t.Run("decimal", func(t *testing.T) {
+		want := decimal.RequireFromString("19.9900")
+		item := models.Item{
+			Code:  "dec-1",
+			Name:  "decimal",
+			Price: want,
+		}
+		if err := db.Create(&item).Error; err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		var loaded models.Item
+		if err := db.First(&loaded, item.ID).Error; err != nil {
+			t.Fatalf("First: %v", err)
+		}
+		if !loaded.Price.Equal(want) {
+			t.Fatalf("Price = %s, want %s", loaded.Price.StringFixed(4), want.StringFixed(4))
+		}
+	})
+
+	t.Run("crud", func(t *testing.T) {
+		item := models.Item{
+			Code:  "crud-1",
+			Name:  "create",
+			Price: decimal.RequireFromString("10.0000"),
+		}
+		if err := db.Create(&item).Error; err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		var loaded models.Item
+		if err := db.First(&loaded, "code = ?", "crud-1").Error; err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		loaded.Name = "updated"
+		if err := db.Save(&loaded).Error; err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+		if err := db.Delete(&loaded).Error; err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		var soft models.Item
+		if err := db.First(&soft, loaded.ID).Error; err == nil {
+			t.Fatal("soft-deleted row still visible to default First")
+		}
+		if err := db.Unscoped().First(&soft, loaded.ID).Error; err != nil {
+			t.Fatalf("Unscoped First after soft delete: %v", err)
+		}
+		if !soft.DeletedAt.Valid {
+			t.Fatal("DeletedAt not set after Delete")
+		}
+	})
+
+	t.Run("tx", func(t *testing.T) {
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return tx.Create(&models.Item{
+				Code:  "tx-commit",
+				Name:  "commit",
+				Price: decimal.RequireFromString("11.0000"),
+			}).Error
+		})
+		if err != nil {
+			t.Fatalf("commit tx: %v", err)
+		}
+		var count int64
+		if err := db.Model(&models.Item{}).Where("code = ?", "tx-commit").Count(&count).Error; err != nil {
+			t.Fatalf("Count committed: %v", err)
+		}
+		if count != 1 {
+			t.Fatalf("committed count = %d, want 1", count)
+		}
+
+		err = db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Create(&models.Item{
+				Code:  "tx-rollback",
+				Name:  "rollback",
+				Price: decimal.RequireFromString("12.0000"),
+			}).Error; err != nil {
+				return err
+			}
+			return errors.New("force rollback")
+		})
+		if err == nil {
+			t.Fatal("rollback tx error = nil, want error")
+		}
+		count = 0
+		if err := db.Model(&models.Item{}).Where("code = ?", "tx-rollback").Count(&count).Error; err != nil {
+			t.Fatalf("Count rolled back: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("rolled-back count = %d, want 0", count)
+		}
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		for i := 1; i <= 5; i++ {
+			item := models.Item{
+				Code:  "page-" + decimal.NewFromInt(int64(i)).String(),
+				Name:  "page",
+				Price: decimal.NewFromInt(int64(i)),
+			}
+			if err := db.Create(&item).Error; err != nil {
+				t.Fatalf("Create page item %d: %v", i, err)
+			}
+		}
+		var page []models.Item
+		if err := db.Where("name = ?", "page").Order("code asc").Offset(2).Limit(2).Find(&page).Error; err != nil {
+			t.Fatalf("Find page: %v", err)
+		}
+		if len(page) != 2 {
+			t.Fatalf("page len = %d, want 2", len(page))
+		}
+		if page[0].Code != "page-3" || page[1].Code != "page-4" {
+			t.Fatalf("page codes = [%s, %s], want [page-3, page-4]", page[0].Code, page[1].Code)
+		}
+	})
+
+	t.Run("migrate_down", func(t *testing.T) {
+		h.rollback()
+		check, err := database.Open(h.cfg)
+		if err != nil {
+			t.Fatalf("reopen after rollback: %v", err)
+		}
+		defer func() { _ = check.Close() }()
+		if check.Migrator().HasTable(&models.Item{}) {
+			t.Fatal("items table should be gone after rollback")
+		}
+		var revCount int64
+		if err := check.Table("framework_migrations").Count(&revCount).Error; err != nil {
+			t.Fatalf("count framework_migrations: %v", err)
+		}
+		if revCount != 0 {
+			t.Fatalf("framework_migrations count = %d, want 0", revCount)
+		}
+	})
+}

--- a/docs/database.md
+++ b/docs/database.md
@@ -73,11 +73,52 @@ Appendix C hardening work.
 ## Integration Tests
 
 The default unit suite exercises SQLite without external services. Postgres and
-MySQL conformance can be run with the `integration` build tag and explicit DSN
-flags:
+MySQL open round-trips can be run with the `integration` build tag and explicit
+DSN flags:
 
 ```sh
 go test -tags integration ./database \
   -database.postgres-dsn 'postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable' \
   -database.mysql-dsn 'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
 ```
+
+## Conformance (M2-4)
+
+Official multi-DB support is gated by the conformance suite under
+`database/conformance`. It generates a versioned migration with
+`migrations.MakeMigrations` (Atlas Community Edition), applies it with
+`migrations.Migrate`, then asserts portable behavior on each driver:
+
+- migrate up / migrate down (Gombit-owned companion downs)
+- timestamps, nullable columns, unique constraints, indexes
+- decimal round-trip
+- CRUD, transactions, pagination (`Offset` / `Limit`)
+
+The suite uses the `conformance` build tag so default `go test ./...` stays
+offline. Install Atlas Community Edition and set `ATLAS_BINARY` (or have
+`atlas` on `PATH`). Postgres and MySQL makemigrations also need Docker for
+Atlas `docker://` dev databases.
+
+SQLite (temp file DSN when `-conformance.dsn` is empty):
+
+```sh
+go test -tags conformance ./database/conformance \
+  -conformance.driver sqlite -count=1
+```
+
+Postgres / MySQL:
+
+```sh
+go test -tags conformance ./database/conformance \
+  -conformance.driver postgres \
+  -conformance.dsn 'postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable' \
+  -count=1
+
+go test -tags conformance ./database/conformance \
+  -conformance.driver mysql \
+  -conformance.dsn 'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true' \
+  -count=1
+```
+
+CI runs the same matrix in `.github/workflows/ci.yml` (`Conformance (sqlite|postgres|mysql)`).
+See also [`docs/migrations.md`](migrations.md) for the Atlas migration workflow.

--- a/docs/database.md
+++ b/docs/database.md
@@ -120,5 +120,6 @@ go test -tags conformance ./database/conformance \
   -count=1
 ```
 
-CI runs the same matrix in `.github/workflows/ci.yml` (`Conformance (sqlite|postgres|mysql)`).
+CI runs the same checks as three jobs in `.github/workflows/ci.yml`
+(`Conformance (sqlite|postgres|mysql)`), each with only the DB service it needs.
 See also [`docs/migrations.md`](migrations.md) for the Atlas migration workflow.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -246,3 +246,10 @@ gombit db makemigrations create_products \
 This explicit list is the Program Mode equivalent of importing each feature
 package and passing concrete model values to Atlas. It avoids runtime
 reflection discovery and keeps the loader reviewable.
+
+## Multi-DB Conformance
+
+M2-4 gates official SQLite / PostgreSQL / MySQL support with a conformance
+matrix that applies Atlas-generated migrations and exercises CRUD, transactions,
+timestamps, nullable/unique/index columns, decimal, pagination, and migrate
+up/down. See [`docs/database.md`](database.md#conformance-m2-4).

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -72,7 +72,10 @@ gombit db rollback [--dir database/migrations]
 
 1. Ensures the Gombit revision table `framework_migrations` exists.
 2. Runs Atlas Community Edition
-   `atlas migrate apply --url ... --dir file://... --allow-dirty`.
+   `atlas migrate apply --url ... --dir file://... --allow-dirty`
+   (PostgreSQL also passes `--revisions-schema public` so
+   `atlas_schema_revisions` is a table in `public`, matching Gombit's ledger
+   sync; Atlas's default dedicated revisions schema is not used).
    `--allow-dirty` is required because Gombit creates `framework_migrations`
    before apply, and real apps already have schema tables.
 3. Records into `framework_migrations` only the pending versions that appear in

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/pb33f/libopenapi v0.38.7
 	github.com/pb33f/libopenapi-validator v0.14.0
 	github.com/redis/go-redis/v9 v9.22.0
+	github.com/shopspring/decimal v1.4.0
 	go.uber.org/zap v1.28.0
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.2

--- a/migrations/atlasurl.go
+++ b/migrations/atlasurl.go
@@ -139,6 +139,11 @@ func mysqlAtlasURL(dsn string) (string, error) {
 // rollback read/write the table atlas_schema_revisions via GORM's default
 // search_path (public). Pinning --revisions-schema public keeps all three
 // drivers on the same table name in the default schema.
+//
+// Call sites that talk to an existing DB must use this helper:
+// Migrate (atlas migrate apply) and Status (atlas migrate status).
+// MakeMigrations (migrate diff) and migrate hash do not touch the app DB
+// revisions table and must not add this flag.
 func withAtlasRevisionsSchema(driver config.DatabaseDriver, args []string) []string {
 	if driver != config.DatabaseDriverPostgres {
 		return args

--- a/migrations/atlasurl.go
+++ b/migrations/atlasurl.go
@@ -130,3 +130,18 @@ func mysqlAtlasURL(dsn string) (string, error) {
 	}
 	return u.String(), nil
 }
+
+// withAtlasRevisionsSchema appends Atlas CLI flags so revision bookkeeping stays
+// in the public schema on PostgreSQL.
+//
+// Atlas Community Edition defaults PostgreSQL revisions to a dedicated schema
+// named atlas_schema_revisions (schema.table). Gombit's ledger sync and
+// rollback read/write the table atlas_schema_revisions via GORM's default
+// search_path (public). Pinning --revisions-schema public keeps all three
+// drivers on the same table name in the default schema.
+func withAtlasRevisionsSchema(driver config.DatabaseDriver, args []string) []string {
+	if driver != config.DatabaseDriverPostgres {
+		return args
+	}
+	return append(args, "--revisions-schema", "public")
+}

--- a/migrations/atlasurl_test.go
+++ b/migrations/atlasurl_test.go
@@ -97,3 +97,25 @@ func TestAtlasURL(t *testing.T) {
 		})
 	}
 }
+
+func TestWithAtlasRevisionsSchema(t *testing.T) {
+	base := []string{"migrate", "apply", "--url", "postgres://localhost/db", "--dir", "file://migrations"}
+
+	gotPG := withAtlasRevisionsSchema(config.DatabaseDriverPostgres, append([]string{}, base...))
+	wantPG := append(append([]string{}, base...), "--revisions-schema", "public")
+	if len(gotPG) != len(wantPG) {
+		t.Fatalf("postgres args = %v, want %v", gotPG, wantPG)
+	}
+	for i := range wantPG {
+		if gotPG[i] != wantPG[i] {
+			t.Fatalf("postgres args[%d] = %q, want %q", i, gotPG[i], wantPG[i])
+		}
+	}
+
+	for _, driver := range []config.DatabaseDriver{config.DatabaseDriverSQLite, config.DatabaseDriverMySQL} {
+		got := withAtlasRevisionsSchema(driver, append([]string{}, base...))
+		if len(got) != len(base) {
+			t.Fatalf("%s args = %v, want unchanged %v", driver, got, base)
+		}
+	}
+}

--- a/migrations/migrate.go
+++ b/migrations/migrate.go
@@ -137,6 +137,7 @@ func Migrate(ctx context.Context, opts ApplyOptions) error {
 		// framework_migrations (and later app tables) make the DB non-empty before Atlas runs.
 		"--allow-dirty",
 	}
+	args = withAtlasRevisionsSchema(opts.Database.Driver, args)
 	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
 		return fmt.Errorf("migrations: atlas migrate apply: %w", err)
 	}

--- a/migrations/reset.go
+++ b/migrations/reset.go
@@ -22,7 +22,8 @@ type ResetOptions struct {
 //
 // Driver wipe strategy:
 //   - SQLite: DROP every non-sqlite_* table/view from sqlite_master
-//   - Postgres: DROP SCHEMA public CASCADE; CREATE SCHEMA public; restore grants
+//   - Postgres: DROP SCHEMA atlas_schema_revisions CASCADE (Atlas default);
+//     DROP SCHEMA public CASCADE; CREATE SCHEMA public; restore grants
 //   - MySQL: disable FK checks, DROP every base table and view, re-enable checks
 //
 // The SQLite database file is not deleted so in-memory and shared-cache DSNs work.
@@ -119,6 +120,8 @@ ORDER BY type DESC, name`).Scan(&objects).Error; err != nil {
 
 func dropPostgresSchema(db *database.DB) error {
 	stmts := []string{
+		// Atlas's historical default revisions schema (pre --revisions-schema public).
+		"DROP SCHEMA IF EXISTS atlas_schema_revisions CASCADE",
 		"DROP SCHEMA IF EXISTS public CASCADE",
 		"CREATE SCHEMA public",
 		"GRANT ALL ON SCHEMA public TO public",

--- a/migrations/status.go
+++ b/migrations/status.go
@@ -87,6 +87,7 @@ func Status(ctx context.Context, opts ApplyOptions) error {
 		"--dir",
 		"file://" + filepath.ToSlash(migrationDir),
 	}
+	args = withAtlasRevisionsSchema(opts.Database.Driver, args)
 	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
 		return fmt.Errorf("migrations: atlas migrate status: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Add `database/conformance` suite that generates Atlas migrations, applies them, exercises CRUD/tx/timestamps/nullable/unique/index/decimal/pagination, then rolls back.
- Wire Conformance CI jobs for SQLite / Postgres / MySQL with Atlas Community Edition (per-driver services only).
- Document local run commands and gate language in `docs/database.md` / `docs/migrations.md`.
- Pin Postgres Atlas revisions to `public` via `--revisions-schema` on migrate apply/status.

Closes #15

## Acceptance criteria

- [x] Matrix job runs the DB conformance suite (CRUD, tx, migrate up/down, timestamps, nullable, unique, index, decimal, pagination) on SQLite + Postgres + MySQL, using Atlas-generated migrations
- [x] Matrix green

## Scope notes

- JSON column portability (design §36.2) deferred — not in build-plan AC.
- Existing `database-*` / `migrations-*` smoke jobs left in place (no CI redesign beyond conformance job layout).
- No new example app (CI/test gate; open + migrate examples already exist).

## Validation

- [x] `go test -tags conformance ./database/conformance -conformance.driver sqlite -count=1` (PASS with Atlas CE)
- [x] `go test ./database/ -count=1` (PASS)
- [x] `go test ./...` — covered by CI Test job (conformance tag correctly excluded from default suite)
- [x] golangci-lint — covered by CI Lint job
- [x] Project review against this diff (Approve on `ff3ae0c`; follow-up nits addressed in this push)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix
- [x] Stable features ship docs and appear in an example app — docs yes; example N/A (CI gate, not a user-facing runtime feature)
- [x] Extraction preserves contracts — N/A (new suite)
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — N/A (no generators)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A (no API change)
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public — N/A (no frontend)
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep
- [x] This PR links its issue and states which acceptance criteria it satisfies