### PR TITLE
[M3-1] Huma DTO + validation conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Accepted architecture decisions are recorded under [`docs/adr/`](docs/adr/).
 Runtime configuration is documented in [`docs/config.md`](docs/config.md).
 Application lifecycle is documented in [`docs/lifecycle.md`](docs/lifecycle.md).
 Application-owned route registration is documented in [`docs/router.md`](docs/router.md).
+Huma DTO and validation conventions are documented in [`docs/contract.md`](docs/contract.md).
 Database runtime support is documented in [`docs/database.md`](docs/database.md).
 Cache runtime support is documented in [`docs/cache.md`](docs/cache.md).
 Runtime logging is documented in [`docs/logging.md`](docs/logging.md).

--- a/contract/doc.go
+++ b/contract/doc.go
@@ -1,0 +1,12 @@
+// Package contract defines Gombit's Huma DTO conventions and the D10 error
+// envelope used for validation failures.
+//
+// Public API routes are Huma-typed handlers. Request and response shapes come
+// from Go structs and Huma validation tags — there is no bespoke Bind layer.
+// Validation failures render as:
+//
+//	{"error":{"code":"validation_error","message":"...","fields":{...},"request_id":"..."}}
+//
+// Application error categories and success meta helpers are owned by later
+// contract issues (M3-2+). See docs/contract.md.
+package contract

--- a/contract/envelope.go
+++ b/contract/envelope.go
@@ -1,0 +1,7 @@
+package contract
+
+// Data is the minimal D10 success envelope. Pagination and other meta fields
+// are added in M3-2.
+type Data[T any] struct {
+	Data T `json:"data"`
+}

--- a/contract/error.go
+++ b/contract/error.go
@@ -1,0 +1,47 @@
+package contract
+
+import (
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// CodeValidationError is the stable D10 code for request validation failures.
+const CodeValidationError = "validation_error"
+
+const validationMessage = "The request contains invalid fields."
+
+// ErrorBody is the D10 error object nested under "error".
+type ErrorBody struct {
+	Code      string              `json:"code"`
+	Message   string              `json:"message"`
+	Fields    map[string][]string `json:"fields,omitempty"`
+	RequestID string              `json:"request_id,omitempty"`
+}
+
+// ErrorEnvelope is the D10 error response body and a huma.StatusError.
+//
+// It intentionally does not implement huma.ContentTypeFilter so responses keep
+// Content-Type application/json instead of application/problem+json.
+type ErrorEnvelope struct {
+	status int
+	Body   ErrorBody `json:"error"`
+}
+
+// Error satisfies the error interface.
+func (e *ErrorEnvelope) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Body.Message
+}
+
+// GetStatus returns the HTTP status for this error.
+func (e *ErrorEnvelope) GetStatus() int {
+	if e == nil || e.status == 0 {
+		return http.StatusInternalServerError
+	}
+	return e.status
+}
+
+var _ huma.StatusError = (*ErrorEnvelope)(nil)

--- a/contract/fields.go
+++ b/contract/fields.go
@@ -1,0 +1,87 @@
+package contract
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+var requiredPropertyRE = regexp.MustCompile(`(?i)^expected required property (\S+) to be present$`)
+
+// FieldsFromErrors maps Huma validation detail errors into D10 field errors.
+//
+// Body locations lose the leading "body." prefix so JSON field names match the
+// request body. Query, path, and header locations keep their prefixes.
+func FieldsFromErrors(errs ...error) map[string][]string {
+	if len(errs) == 0 {
+		return nil
+	}
+
+	fields := make(map[string][]string)
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		key, message := fieldFromError(err)
+		if key == "" || message == "" {
+			continue
+		}
+		fields[key] = append(fields[key], message)
+	}
+	if len(fields) == 0 {
+		return nil
+	}
+	return fields
+}
+
+func fieldFromError(err error) (key, message string) {
+	if detailer, ok := err.(huma.ErrorDetailer); ok {
+		detail := detailer.ErrorDetail()
+		if detail == nil {
+			return "", ""
+		}
+		message = strings.TrimSpace(detail.Message)
+		if message == "" {
+			message = strings.TrimSpace(detail.Error())
+		}
+		key = fieldKey(detail.Location)
+		if key == "_error" {
+			if inferred := fieldFromMessage(message); inferred != "" {
+				key = inferred
+			}
+		}
+		return key, message
+	}
+
+	message = strings.TrimSpace(err.Error())
+	if message == "" {
+		return "", ""
+	}
+	if inferred := fieldFromMessage(message); inferred != "" {
+		return inferred, message
+	}
+	return "_error", message
+}
+
+func fieldKey(location string) string {
+	location = strings.TrimSpace(location)
+	if location == "" {
+		return "_error"
+	}
+	if strings.HasPrefix(location, "body.") {
+		return strings.TrimPrefix(location, "body.")
+	}
+	if location == "body" {
+		return "_error"
+	}
+	return location
+}
+
+func fieldFromMessage(message string) string {
+	matches := requiredPropertyRE.FindStringSubmatch(strings.TrimSpace(message))
+	if len(matches) != 2 {
+		return ""
+	}
+	return matches[1]
+}

--- a/contract/fields_test.go
+++ b/contract/fields_test.go
@@ -1,0 +1,85 @@
+package contract
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+func TestFieldsFromErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		errs []error
+		want map[string][]string
+	}{
+		{
+			name: "nil and empty",
+			errs: nil,
+			want: nil,
+		},
+		{
+			name: "body field strips prefix",
+			errs: []error{
+				&huma.ErrorDetail{Location: "body.name", Message: "expected length >= 1"},
+			},
+			want: map[string][]string{"name": {"expected length >= 1"}},
+		},
+		{
+			name: "nested body path",
+			errs: []error{
+				&huma.ErrorDetail{Location: "body.items[0].tags", Message: "expected array"},
+			},
+			want: map[string][]string{"items[0].tags": {"expected array"}},
+		},
+		{
+			name: "query path header keep prefix",
+			errs: []error{
+				&huma.ErrorDetail{Location: "query.limit", Message: "expected number"},
+				&huma.ErrorDetail{Location: "path.widget-id", Message: "expected uuid"},
+				&huma.ErrorDetail{Location: "header.x-token", Message: "required"},
+			},
+			want: map[string][]string{
+				"query.limit":    {"expected number"},
+				"path.widget-id": {"expected uuid"},
+				"header.x-token": {"required"},
+			},
+		},
+		{
+			name: "multiple messages same field",
+			errs: []error{
+				&huma.ErrorDetail{Location: "body.email", Message: "required"},
+				&huma.ErrorDetail{Location: "body.email", Message: "invalid format"},
+			},
+			want: map[string][]string{"email": {"required", "invalid format"}},
+		},
+		{
+			name: "plain error falls back",
+			errs: []error{errString("boom")},
+			want: map[string][]string{"_error": {"boom"}},
+		},
+		{
+			name: "required property inferred from message",
+			errs: []error{
+				&huma.ErrorDetail{Message: "expected required property name to be present"},
+			},
+			want: map[string][]string{"name": {"expected required property name to be present"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FieldsFromErrors(tt.errs...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("FieldsFromErrors() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/contract/huma_config.go
+++ b/contract/huma_config.go
@@ -1,0 +1,20 @@
+package contract
+
+import "github.com/danielgtaylor/huma/v2"
+
+// HumaConfig returns the default Huma configuration for a Gombit app.
+//
+// Docs and schema browser routes stay disabled; OpenAPI JSON remains available
+// for local inspection until M3-3 owns the generate CLI.
+func HumaConfig(title, version string) huma.Config {
+	if title == "" {
+		title = "Gombit"
+	}
+	if version == "" {
+		version = "0.0.0"
+	}
+	config := huma.DefaultConfig(title, version)
+	config.DocsPath = ""
+	config.SchemasPath = ""
+	return config
+}

--- a/contract/install.go
+++ b/contract/install.go
@@ -73,6 +73,9 @@ func classifyError(status int, msg string, fields map[string][]string) (code, me
 }
 
 func isValidationFailure(status int, msg string, fields map[string][]string) bool {
+	// Any error carrying field details is treated as validation until M3-2 owns
+	// application error categories (field-bearing domain errors may then use a
+	// different code while keeping D10 fields).
 	if len(fields) > 0 {
 		return true
 	}

--- a/contract/install.go
+++ b/contract/install.go
@@ -1,0 +1,111 @@
+package contract
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// InstallOptions configures Huma error installation.
+type InstallOptions struct {
+	// RequestID reads the active request ID from a request context.
+	RequestID func(context.Context) string
+}
+
+var installOnce sync.Once
+
+// Install replaces Huma's default RFC 9457 Problem Details errors with the D10
+// envelope. It is safe to call more than once; only the first call applies.
+func Install(opts InstallOptions) {
+	installOnce.Do(func() {
+		requestID := opts.RequestID
+		if requestID == nil {
+			requestID = func(context.Context) string { return "" }
+		}
+
+		huma.NewError = func(status int, msg string, errs ...error) huma.StatusError {
+			return newEnvelope(status, msg, "", errs...)
+		}
+		huma.NewErrorWithContext = func(ctx huma.Context, status int, msg string, errs ...error) huma.StatusError {
+			id := ""
+			if ctx != nil {
+				id = requestID(ctx.Context())
+			}
+			return newEnvelope(status, msg, id, errs...)
+		}
+	})
+}
+
+func newEnvelope(status int, msg, requestID string, errs ...error) *ErrorEnvelope {
+	fields := FieldsFromErrors(errs...)
+	code, message := classifyError(status, msg, fields)
+	return &ErrorEnvelope{
+		status: status,
+		Body: ErrorBody{
+			Code:      code,
+			Message:   message,
+			Fields:    fields,
+			RequestID: requestID,
+		},
+	}
+}
+
+func classifyError(status int, msg string, fields map[string][]string) (code, message string) {
+	msg = strings.TrimSpace(msg)
+	if isValidationFailure(status, msg, fields) {
+		message = validationMessage
+		if msg != "" && !strings.EqualFold(msg, "validation failed") {
+			message = msg
+		}
+		return CodeValidationError, message
+	}
+	if msg == "" {
+		msg = http.StatusText(status)
+	}
+	if msg == "" {
+		msg = "request failed"
+	}
+	return statusCodeSlug(status), msg
+}
+
+func isValidationFailure(status int, msg string, fields map[string][]string) bool {
+	if len(fields) > 0 {
+		return true
+	}
+	if status == http.StatusUnprocessableEntity {
+		return true
+	}
+	if status == http.StatusBadRequest && strings.EqualFold(msg, "validation failed") {
+		return true
+	}
+	return false
+}
+
+func statusCodeSlug(status int) string {
+	text := strings.TrimSpace(http.StatusText(status))
+	if text == "" {
+		return "error"
+	}
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range strings.ToLower(text) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	slug := strings.Trim(b.String(), "_")
+	if slug == "" {
+		return "error"
+	}
+	return slug
+}

--- a/contract/install_test.go
+++ b/contract/install_test.go
@@ -1,0 +1,31 @@
+package contract
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestClassifyErrorValidation(t *testing.T) {
+	t.Parallel()
+
+	code, message := classifyError(http.StatusUnprocessableEntity, "validation failed", map[string][]string{
+		"name": {"required"},
+	})
+	if code != CodeValidationError {
+		t.Fatalf("code = %q, want %q", code, CodeValidationError)
+	}
+	if message != validationMessage {
+		t.Fatalf("message = %q, want %q", message, validationMessage)
+	}
+}
+
+func TestStatusCodeSlug(t *testing.T) {
+	t.Parallel()
+
+	if got := statusCodeSlug(http.StatusNotFound); got != "not_found" {
+		t.Fatalf("statusCodeSlug(404) = %q, want not_found", got)
+	}
+	if got := statusCodeSlug(0); got != "error" {
+		t.Fatalf("statusCodeSlug(0) = %q, want error", got)
+	}
+}

--- a/contract/main_test.go
+++ b/contract/main_test.go
@@ -1,0 +1,18 @@
+package contract_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+)
+
+func TestMain(m *testing.M) {
+	// Install is sync.Once — install once for the whole package so shuffled
+	// test order cannot leave RequestID unset.
+	contract.Install(contract.InstallOptions{
+		RequestID: func(context.Context) string { return "req-test-1" },
+	})
+	os.Exit(m.Run())
+}

--- a/contract/validation_test.go
+++ b/contract/validation_test.go
@@ -15,10 +15,6 @@ import (
 )
 
 func TestValidationReturnsD10FieldErrors(t *testing.T) {
-	contract.Install(contract.InstallOptions{
-		RequestID: func(context.Context) string { return "req-test-1" },
-	})
-
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	api := humagin.New(router, contract.HumaConfig("contract-test", "0.0.0"))
@@ -90,8 +86,6 @@ func TestHumaConfigDisablesDocsAndSchemas(t *testing.T) {
 }
 
 func TestOpenAPIUsesD10ErrorSchema(t *testing.T) {
-	contract.Install(contract.InstallOptions{})
-
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	api := humagin.New(router, contract.HumaConfig("contract-test", "0.0.0"))

--- a/contract/validation_test.go
+++ b/contract/validation_test.go
@@ -1,0 +1,123 @@
+package contract_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humagin"
+	"github.com/gin-gonic/gin"
+)
+
+func TestValidationReturnsD10FieldErrors(t *testing.T) {
+	contract.Install(contract.InstallOptions{
+		RequestID: func(context.Context) string { return "req-test-1" },
+	})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	api := humagin.New(router, contract.HumaConfig("contract-test", "0.0.0"))
+
+	type createBody struct {
+		Name string `json:"name" minLength:"1" maxLength:"80"`
+	}
+	type createInput struct {
+		Body createBody
+	}
+	type createOutput struct {
+		Body contract.Data[createBody]
+	}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "create-widget",
+		Method:      http.MethodPost,
+		Path:        "/widgets",
+		Summary:     "Create a widget",
+	}, func(ctx context.Context, input *createInput) (*createOutput, error) {
+		return &createOutput{Body: contract.Data[createBody]{Data: input.Body}}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/widgets", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusUnprocessableEntity, rec.Body.String())
+	}
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	if strings.Contains(ct, "problem+json") {
+		t.Fatalf("Content-Type = %q, must not be problem+json", ct)
+	}
+
+	var body contract.ErrorEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error envelope: %v; body: %s", err, rec.Body.String())
+	}
+	if body.Body.Code != contract.CodeValidationError {
+		t.Fatalf("code = %q, want %q", body.Body.Code, contract.CodeValidationError)
+	}
+	if body.Body.RequestID != "req-test-1" {
+		t.Fatalf("request_id = %q, want req-test-1", body.Body.RequestID)
+	}
+	if len(body.Body.Fields["name"]) == 0 {
+		t.Fatalf("fields.name missing; fields=%#v body=%s", body.Body.Fields, rec.Body.String())
+	}
+}
+
+func TestHumaConfigDisablesDocsAndSchemas(t *testing.T) {
+	cfg := contract.HumaConfig("Demo", "1.2.3")
+	if cfg.DocsPath != "" {
+		t.Fatalf("DocsPath = %q, want empty", cfg.DocsPath)
+	}
+	if cfg.SchemasPath != "" {
+		t.Fatalf("SchemasPath = %q, want empty", cfg.SchemasPath)
+	}
+	if cfg.OpenAPIPath != "/openapi" {
+		t.Fatalf("OpenAPIPath = %q, want /openapi", cfg.OpenAPIPath)
+	}
+	if cfg.Info == nil || cfg.Info.Title != "Demo" || cfg.Info.Version != "1.2.3" {
+		t.Fatalf("Info = %#v, want Demo/1.2.3", cfg.Info)
+	}
+}
+
+func TestOpenAPIUsesD10ErrorSchema(t *testing.T) {
+	contract.Install(contract.InstallOptions{})
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	api := humagin.New(router, contract.HumaConfig("contract-test", "0.0.0"))
+
+	huma.Register(api, huma.Operation{
+		OperationID: "ping",
+		Method:      http.MethodGet,
+		Path:        "/ping",
+	}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/openapi.json", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /openapi.json status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	spec := rec.Body.String()
+	if !strings.Contains(spec, `"ErrorEnvelope"`) && !strings.Contains(spec, `"error"`) {
+		t.Fatalf("OpenAPI missing D10 error shape markers; body: %s", spec)
+	}
+	if strings.Contains(spec, `"ErrorModel"`) {
+		t.Fatalf("OpenAPI still advertises ErrorModel Problem Details schema")
+	}
+	if strings.Contains(spec, "application/problem+json") {
+		t.Fatalf("OpenAPI still advertises application/problem+json")
+	}
+}

--- a/docs/adr/011-contract-layer-huma.md
+++ b/docs/adr/011-contract-layer-huma.md
@@ -67,10 +67,12 @@ OpenAPI 3.1 emission without a custom contract framework.
 - Raw Gin routes must remain tested as an escape hatch and must not silently
   leak into the OpenAPI document.
 - The current spike `openapi.json` includes Huma's default RFC 9457 Problem
-  Details error schema. That is not the Gombit public error contract. M3-1 and
-  M3-2 remain responsible for mapping validation and application errors to the
-  locked D10 envelope. The `fields` member is optional and should appear only
-  when field-level details exist:
+  Details error schema. That is not the Gombit public error contract. **M3-1
+  replaces validation (and other Huma-generated) errors with the locked D10
+  envelope** via `contract.Install` / `framework.App.API()` — see
+  [`docs/contract.md`](../contract.md). M3-2 still owns application error
+  categories and the category→status mapping table. The `fields` member is
+  optional and should appear only when field-level details exist:
 
 ```json
 {"error":{"code":"...","message":"...","fields":{},"request_id":"..."}}

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,0 +1,112 @@
+# Contract (Huma DTOs + validation)
+
+M3-1 introduces Gombit's public API contract conventions: Huma-typed handlers
+over Gin, validation tags on request structs, and the locked D10 error envelope
+with structured `fields`.
+
+ADR-011 selected Huma as the contract layer. This document is the application-
+facing guide for DTO shape and validation errors. Application error categories
+and success `meta` belong to M3-2; OpenAPI CLI generation belongs to M3-3.
+
+## Registering contract routes
+
+`framework.New` mounts a Huma API on the same `*gin.Engine` as `app.Router()`.
+Register public API operations on `app.API()`:
+
+```go
+app, err := framework.New()
+if err != nil {
+    return err
+}
+
+prefix := app.Config().API.Prefix // default /api/v1
+huma.Register(app.API(), huma.Operation{
+    OperationID: "create-widget",
+    Method:      http.MethodPost,
+    Path:        prefix + "/widgets",
+}, handler)
+
+return framework.Run(app)
+```
+
+Use `app.Router()` only for routes that must stay outside the OpenAPI contract
+(webhooks, SSE, legacy). See [`docs/router.md`](router.md).
+
+`examples/contract` shows a minimal create endpoint.
+
+## Request / response DTOs
+
+Go structs are the source of truth. Prefer Huma tags — not a separate
+`validate:"..."` layer and not hand-written OpenAPI files.
+
+```go
+type CreateWidgetBody struct {
+    Name  string `json:"name" minLength:"1" maxLength:"80" doc:"Human-readable name"`
+    Color string `json:"color,omitempty" maxLength:"30"`
+}
+
+type createWidgetInput struct {
+    Body CreateWidgetBody
+}
+
+type createWidgetOutput struct {
+    Body contract.Data[Widget]
+}
+```
+
+Conventions:
+
+- Nest the JSON body under an input field named `Body` (Huma binding).
+- Put validation metadata on body fields (`minLength`, `maxLength`, `format`,
+  `enum`, `required`, and the other Huma tags).
+- Wrap success payloads in `contract.Data[T]` so responses are `{"data": ...}`.
+  Pagination `meta` arrives in M3-2.
+- Document fields with `doc` / `example` so they appear in OpenAPI.
+
+## Validation → D10 `fields`
+
+Invalid requests return HTTP **422** with:
+
+```json
+{
+  "error": {
+    "code": "validation_error",
+    "message": "The request contains invalid fields.",
+    "fields": {
+      "name": ["expected required property name to be present"]
+    },
+    "request_id": "..."
+  }
+}
+```
+
+`contract.Install` (called from `framework.New`) replaces Huma's default RFC
+9457 Problem Details errors with this envelope. `fields` keys are derived from
+Huma `ErrorDetail.Location` values:
+
+| Huma location | D10 field key |
+| --- | --- |
+| `body.name` | `name` |
+| `body.items[0].tags` | `items[0].tags` |
+| `query.limit` | `query.limit` |
+| `path.widget-id` | `path.widget-id` |
+
+When Huma omits a location for a missing required property, Gombit infers the
+field name from messages like `expected required property name to be present`.
+
+`request_id` comes from the runtime request-ID middleware
+(`X-Request-Id` / `framework.GetRequestIDFromContext`).
+
+Content-Type stays `application/json` (not `application/problem+json`).
+
+## OpenAPI preview
+
+With the default Huma config, `/openapi.json` is served for local inspection and
+reflects the D10 `ErrorEnvelope` schema. `gombit openapi generate` and CI drift
+checks land in M3-3 / M3-5.
+
+## What is not here yet
+
+- Central application error categories and HTTP status mapping (M3-2)
+- Success envelope `meta` helpers (M3-2)
+- `gombit openapi generate` / `gombit client generate` (M3-3 / M3-4)

--- a/docs/router.md
+++ b/docs/router.md
@@ -2,10 +2,12 @@
 
 M1-3 de-domains the router introduced in M1-2: `framework.New` builds a
 `*gin.Engine` with zero knowledge of any application domain and mounts only
-its own endpoints. Today that means `/livez`, `/readyz`, and `/metrics`; the
-OpenAPI document joins later (M3).
+its own endpoints. Today that means `/livez`, `/readyz`, `/metrics`, and the
+Huma OpenAPI preview routes (`/openapi.json` and siblings). Public API handlers
+register on `app.API()` (see [`docs/contract.md`](contract.md)); raw Gin routes
+continue to use `app.Router()`.
 
-Applications register their own routes directly against the escape hatch:
+Applications register their own routes against the appropriate surface:
 
 ```go
 app, err := framework.New()
@@ -13,8 +15,8 @@ if err != nil {
     return err
 }
 
-registerProductRoutes(app.Router())
-registerAccountRoutes(app.Router())
+registerProductRoutes(app.API(), app.Config().API.Prefix) // contract / OpenAPI
+registerWebhookRoutes(app.Router())                         // escape hatch
 
 return framework.Run(app)
 ```
@@ -23,8 +25,8 @@ Each `registerXRoutes` function is the runtime equivalent of a feature
 package's `routes.go` (build plan §3.2 /
 `.cursor/skills/create-feature/references/layout.md`): registration is
 **explicit**, called from `main`, and never discovered through reflection
-(principle 6.2). `examples/router` demonstrates this with two independent
-toy route groups, `ping` and `echo`.
+(principle 6.2). `examples/router` demonstrates raw Gin groups; `examples/contract`
+demonstrates Huma-typed registration with D10 validation errors.
 
 ## No module/registry abstraction
 
@@ -91,14 +93,13 @@ Recovery still applying to an application-registered route.
 
 ## What is not here yet
 
-This surface does not include CORS, rate limiting, or authentication
-middleware. Those are extracted with their own runtime dependencies in later
-issues:
+Contract DTOs, validation → D10 field errors, and `app.API()` are documented in
+[`docs/contract.md`](contract.md). This router surface still does not include
+CORS, rate limiting, or authentication middleware:
 
-- rate limiting and the cache interface: M1-5
-- Mongo-backed access logging: M1-6
 - auth middleware: M5
+- `gombit openapi generate` CLI: M3-3
 
-Until then, an application that needs one of these can add it directly via
+Until then, an application that needs middleware can add it directly via
 `app.Router().Use(...)` or on its own route groups; the framework will not
 silently reorder or override it.

--- a/examples/contract/README.md
+++ b/examples/contract/README.md
@@ -1,0 +1,43 @@
+# Contract example
+
+Demonstrates Huma DTO conventions and D10 validation errors on
+`framework.App.API()`.
+
+## Run
+
+```sh
+go run ./examples/contract
+```
+
+## Valid create
+
+```sh
+curl -sS -X POST http://127.0.0.1:8080/api/v1/widgets \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Second widget","color":"green"}'
+```
+
+## Invalid body (D10 field errors)
+
+```sh
+curl -sS -X POST http://127.0.0.1:8080/api/v1/widgets \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+Example response:
+
+```json
+{
+  "error": {
+    "code": "validation_error",
+    "message": "The request contains invalid fields.",
+    "fields": {
+      "name": ["expected required property name to be present"]
+    },
+    "request_id": "..."
+  }
+}
+```
+
+See [`docs/contract.md`](../../docs/contract.md).

--- a/examples/contract/main.go
+++ b/examples/contract/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/LAA-Software-Engineering/gombit/framework"
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// Widget is a sample typed resource for the contract example.
+type Widget struct {
+	ID    string `json:"id" example:"widget-1" doc:"Stable widget identifier"`
+	Name  string `json:"name" example:"First widget" doc:"Human-readable widget name"`
+	Color string `json:"color,omitempty" example:"blue" doc:"Optional display color"`
+}
+
+// CreateWidgetBody is the typed JSON request body for POST /widgets.
+type CreateWidgetBody struct {
+	Name  string `json:"name" minLength:"1" maxLength:"80" example:"Second widget" doc:"Human-readable widget name"`
+	Color string `json:"color,omitempty" maxLength:"30" example:"green" doc:"Optional display color"`
+}
+
+type createWidgetInput struct {
+	Body CreateWidgetBody
+}
+
+type createWidgetOutput struct {
+	Body contract.Data[Widget]
+}
+
+func registerWidgetRoutes(api huma.API, prefix string) {
+	huma.Register(api, huma.Operation{
+		OperationID: "create-widget",
+		Method:      http.MethodPost,
+		Path:        prefix + "/widgets",
+		Summary:     "Create a widget",
+		Tags:        []string{"Widgets"},
+	}, func(ctx context.Context, input *createWidgetInput) (*createWidgetOutput, error) {
+		return &createWidgetOutput{
+			Body: contract.Data[Widget]{
+				Data: Widget{
+					ID:    "widget-1",
+					Name:  input.Body.Name,
+					Color: input.Body.Color,
+				},
+			},
+		}, nil
+	})
+}
+
+func main() {
+	app, err := framework.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	registerWidgetRoutes(app.API(), app.Config().API.Prefix)
+
+	if err := framework.Run(app); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/framework/app.go
+++ b/framework/app.go
@@ -14,8 +14,11 @@ import (
 
 	"github.com/LAA-Software-Engineering/gombit/cache"
 	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/contract"
 	"github.com/LAA-Software-Engineering/gombit/database"
 	"github.com/LAA-Software-Engineering/gombit/logging"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humagin"
 	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -41,6 +44,7 @@ type App struct {
 	db              *database.DB
 	logger          *zap.Logger
 	router          *gin.Engine
+	api             huma.API
 	startHooks      []Hook
 	stopHooks       []Hook
 	shutdownTimeout time.Duration
@@ -104,6 +108,12 @@ func New(options ...Option) (*App, error) {
 		app.router = router
 	} else if err := configureTrustedProxies(app.router, app.cfg.HTTP.TrustedProxies); err != nil {
 		return nil, err
+	}
+	if app.api == nil {
+		contract.Install(contract.InstallOptions{
+			RequestID: GetRequestIDFromContext,
+		})
+		app.api = humagin.New(app.router, contract.HumaConfig(app.cfg.AppName, "0.0.0"))
 	}
 	if app.cache == nil {
 		store, err := cache.Open(app.cfg.Cache)
@@ -252,6 +262,13 @@ func (a *App) Router() *gin.Engine {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.router
+}
+
+// API returns the Huma API used for contract-typed route registration.
+func (a *App) API() huma.API {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.api
 }
 
 // Addr returns the bound HTTP address after the app has started.

--- a/framework/app.go
+++ b/framework/app.go
@@ -113,6 +113,7 @@ func New(options ...Option) (*App, error) {
 		contract.Install(contract.InstallOptions{
 			RequestID: GetRequestIDFromContext,
 		})
+		// OpenAPI Info.Version stays 0.0.0 until runtime versioning lands.
 		app.api = humagin.New(app.router, contract.HumaConfig(app.cfg.AppName, "0.0.0"))
 	}
 	if app.cache == nil {

--- a/framework/contract_test.go
+++ b/framework/contract_test.go
@@ -1,0 +1,100 @@
+package framework
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/danielgtaylor/huma/v2"
+)
+
+func TestAPIValidationReturnsD10FieldErrors(t *testing.T) {
+	app := newTestApp(t)
+
+	type createBody struct {
+		Name string `json:"name" minLength:"1" maxLength:"80"`
+	}
+	type createInput struct {
+		Body createBody
+	}
+	type createOutput struct {
+		Body contract.Data[createBody]
+	}
+
+	prefix := app.Config().API.Prefix
+	huma.Register(app.API(), huma.Operation{
+		OperationID: "create-widget",
+		Method:      http.MethodPost,
+		Path:        prefix + "/widgets",
+		Summary:     "Create a widget",
+	}, func(ctx context.Context, input *createInput) (*createOutput, error) {
+		return &createOutput{Body: contract.Data[createBody]{Data: input.Body}}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, prefix+"/widgets", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(RequestIDHeader, "req-framework-1")
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusUnprocessableEntity, rec.Body.String())
+	}
+	if got := rec.Header().Get(RequestIDHeader); got != "req-framework-1" {
+		t.Fatalf("%s = %q, want req-framework-1", RequestIDHeader, got)
+	}
+
+	var body contract.ErrorEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error envelope: %v; body: %s", err, rec.Body.String())
+	}
+	if body.Body.Code != contract.CodeValidationError {
+		t.Fatalf("code = %q, want %q", body.Body.Code, contract.CodeValidationError)
+	}
+	if body.Body.RequestID != "req-framework-1" {
+		t.Fatalf("request_id = %q, want req-framework-1", body.Body.RequestID)
+	}
+	if len(body.Body.Fields["name"]) == 0 {
+		t.Fatalf("fields.name missing; fields=%#v body=%s", body.Body.Fields, rec.Body.String())
+	}
+}
+
+func TestAPIOpenAPIUsesD10ErrorSchema(t *testing.T) {
+	app := newTestApp(t)
+
+	huma.Register(app.API(), huma.Operation{
+		OperationID: "ping",
+		Method:      http.MethodGet,
+		Path:        "/ping",
+	}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	rec := httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/openapi.json", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /openapi.json status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	spec := rec.Body.String()
+	if strings.Contains(spec, `"ErrorModel"`) {
+		t.Fatalf("OpenAPI still advertises ErrorModel Problem Details schema")
+	}
+	if strings.Contains(spec, "application/problem+json") {
+		t.Fatalf("OpenAPI still advertises application/problem+json")
+	}
+	if !strings.Contains(spec, `"ErrorEnvelope"`) {
+		t.Fatalf("OpenAPI missing ErrorEnvelope schema; body: %s", spec)
+	}
+}
+
+func TestAppExposesAPI(t *testing.T) {
+	app := newTestApp(t)
+	if app.API() == nil {
+		t.Fatal("API() = nil, want huma.API")
+	}
+}

--- a/framework/doc.go
+++ b/framework/doc.go
@@ -1,2 +1,3 @@
-// Package framework provides Gombit's runtime application lifecycle.
+// Package framework provides Gombit's runtime application lifecycle and HTTP
+// surfaces (Gin router escape hatch and Huma contract API).
 package framework

--- a/framework/router_test.go
+++ b/framework/router_test.go
@@ -22,7 +22,15 @@ func TestDefaultRouterMountsOnlyFrameworkEndpoints(t *testing.T) {
 	}
 	sort.Strings(got)
 
-	want := []string{"GET /livez", "GET /metrics", "GET /readyz"}
+	want := []string{
+		"GET /livez",
+		"GET /metrics",
+		"GET /openapi-3.0.json",
+		"GET /openapi-3.0.yaml",
+		"GET /openapi.json",
+		"GET /openapi.yaml",
+		"GET /readyz",
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Router().Routes() = %v, want %v", got, want)
 	}


### PR DESCRIPTION
## Summary

- Add a `contract` runtime package that maps Huma validation failures to the locked D10 error envelope (`error.code` / `message` / `fields` / `request_id`).
- Mount Huma on `framework.App` via `app.API()` so public handlers register against the same Gin engine as `app.Router()`.
- Document conventions in `docs/contract.md` and ship `examples/contract`.

Closes #16

## Acceptance criteria

- [x] invalid request returns structured field errors

## Scope notes

Deferred to later issues (intentional):

- M3-2 (#17): success `meta`, §41 category→status mapping, broader application error helpers
- M3-3 (#18): `gombit openapi generate` CLI
- Root spike `openapi.json` / `internal/contractspike` left as M0 fixtures (still Problem Details)

## Validation

- [x] `go test ./contract/ ./framework/ -count=1` (pass)
- [x] `go build -o /tmp/gombit-contract-example ./examples/contract/` (pass)
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — blocked locally by disk quota while downloading the linter toolchain; rely on CI
- [x] Project `code-review` skill checklist walked against this diff (Approve: AC met, D10/Huma decisions followed, no M6 creep, docs + example present)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A for DB matrix (no persistence in this PR); unit + httptest coverage in `contract/` and `framework/`
- [x] Stable features ship docs and appear in an example app
- [ ] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests — N/A (greenfield contract surface; spike left intact)
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — N/A (no generators)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A until M3-3/M3-4; `/openapi.json` now reflects D10 `ErrorEnvelope` on the runtime API
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public — N/A (no frontend)
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

Made with [Cursor](https://cursor.com)