### PR TITLE
[M1-8] XSS HTML sanitization middleware

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -54,7 +54,7 @@ steps that need their own runtime surfaces.
 | 6. auth infrastructure | Deferred to M5. |
 | 7. tracing and metrics | Basic trace-ID propagation and HTTP request metrics are owned in M1-7; full OpenTelemetry exporter wiring is future runtime work. |
 | 8. HTTP server construction | Owned in M1-2 through `framework.Run` and `RunContext`. |
-| 9. middleware installation | Recovery is owned in M1-2. Route-registration composition (independently-registered route groups, each with optional group-scoped middleware) is owned in M1-3 — see [`docs/router.md`](router.md). Request ID, trace context, metrics, security headers, request timeout, and trusted-proxy configuration are owned in M1-7. XSS HTML-tag sanitization of request input is owned in M1-8 (fundamental; not covered by security headers alone). CORS, rate limiting, and auth remain separate issues. |
+| 9. middleware installation | Recovery is owned in M1-2. Route-registration composition (independently-registered route groups, each with optional group-scoped middleware) is owned in M1-3 — see [`docs/router.md`](router.md). Request ID, trace context, metrics, security headers, request timeout, and trusted-proxy configuration are owned in M1-7. XSS HTML-tag sanitization of request input is owned in M1-8 (fundamental first-party default on the runtime stack; not covered by security headers alone). CORS, rate limiting, and auth remain separate issues. |
 | 10. module registration | Owned in M1-3 — applications register feature routes directly against `app.Router()`; see [`docs/router.md`](router.md). |
 | 11. readiness/liveness endpoints | Basic raw Gin probes are owned in M1-2; DB/cache-aware readiness is deferred to M1-4/M1-5. |
 | 12. frontend static asset mounting when embedded | Deferred to M5-5. |

--- a/docs/router.md
+++ b/docs/router.md
@@ -52,12 +52,21 @@ Recovery
   -> trace context
   -> request metrics
   -> security headers
+  -> XSS HTML-tag sanitization (request input)
   -> request timeout
   -> feature group middleware (if any)
     -> feature handler
 ```
 
-Canonical design order (draft §13.3) also includes CORS, body-size limit, **XSS HTML-tag sanitization of request input**, rate limiting, and auth context. XSS sanitization is a fundamental security default and is owned by **M1-8**; it is not yet installed on the default router.
+XSS sanitization is a fundamental security default (M1-8): response headers
+alone are not enough. The runtime strips HTML tags from JSON string fields
+(POST/PUT/PATCH) and GET query values using a first-party sanitizer built on
+`golang.org/x/net/html`. Fields named `password` are left unchanged. Invalid
+JSON is passed through so Gin/Huma can return normal validation errors.
+
+Canonical design order (draft §13.3) also includes CORS, body-size limit, rate
+limiting, and auth context. Those remain deferred; when body-size lands it
+inserts immediately before XSS.
 
 Request IDs use the `X-Request-Id` header. If the caller provides one, the
 runtime preserves it; otherwise it generates one and stores it on both Gin's
@@ -86,8 +95,7 @@ headers and uses the direct TCP peer.
 `framework.WithRouter` is the custom-router escape hatch. When an application
 passes its own `*gin.Engine`, Gombit applies trusted-proxy configuration only;
 the application owns recovery, request ID, trace context, metrics, security
-headers, timeout, and (once M1-8 lands) XSS HTML sanitization middleware for
-that router.
+headers, XSS HTML sanitization, and timeout middleware for that router.
 
 `framework/router_test.go`'s `TestDefaultRouterMountsOnlyFrameworkEndpoints`
 and `TestApplicationOwnedRouteRegistrationComposesIndependently` cover this;
@@ -98,14 +106,14 @@ Recovery still applying to an application-registered route.
 
 Contract DTOs, validation → D10 field errors, and `app.API()` are documented in
 [`docs/contract.md`](contract.md). This router surface still does not include
-CORS, rate limiting, XSS HTML sanitization, or authentication middleware:
+CORS, rate limiting, or authentication middleware:
 
-- rate limiting and the cache interface: M1-5
-- Mongo-backed access logging: M1-6
-- XSS HTML-tag sanitization of request input: M1-8
 - auth middleware: M5
 - `gombit openapi generate` CLI: M3-3
 
 Until then, an application that needs middleware can add it directly via
 `app.Router().Use(...)` or on its own route groups; the framework will not
 silently reorder or override it.
+
+`examples/router` posts JSON to `/echo` and returns the comment the handler
+saw after XSS sanitization.

--- a/docs/router.md
+++ b/docs/router.md
@@ -61,8 +61,30 @@ Recovery
 XSS sanitization is a fundamental security default (M1-8): response headers
 alone are not enough. The runtime strips HTML tags from JSON string fields
 (POST/PUT/PATCH) and GET query values using a first-party sanitizer built on
-`golang.org/x/net/html`. Fields named `password` are left unchanged. Invalid
-JSON is passed through so Gin/Huma can return normal validation errors.
+`golang.org/x/net/html`.
+
+**Why first-party (not the template wrapper):** the template's
+`pkg/middleware/xss.go` is a thin wrapper around
+`gin-gonic-xss-middleware` (Bluemonday). M1-8 keeps the *behavior*
+(strip HTML tags from request input before handlers) but does not take that
+Gin wrapper or Bluemonday as a dependency — both were rejected for hygiene
+(stale/unmaintained surface). The framework owns a small sanitizer on
+`golang.org/x/net/html`, which was already in the module graph. This is an
+intentional, documented divergence from extract-preserve for that one package.
+
+Other behavior notes:
+
+- The `password` exemption is an **exact, case-sensitive** JSON/query key
+  match (`password` only). `Password` and other casings are still sanitized.
+- Invalid JSON is passed through so Gin/Huma can return normal validation
+  errors.
+- Non-JSON bodies (form/multipart) are not sanitized in v0.1; the public API
+  path is JSON/Huma. Form/multipart coverage can land before browser/admin
+  session work if needed.
+- Sanitization re-marshals JSON, so key order and whitespace may change.
+  Callers that hash the raw body must hash the bytes handlers actually see.
+- Unclosed dangerous elements (for example a truncated `<script>...`) discard
+  the remainder of the string (fail-closed).
 
 Canonical design order (draft §13.3) also includes CORS, body-size limit, rate
 limiting, and auth context. Those remain deferred; when body-size lands it

--- a/examples/router/main.go
+++ b/examples/router/main.go
@@ -24,10 +24,28 @@ func registerPingRoutes(router *gin.Engine) {
 }
 
 // registerEchoRoutes stands in for a second, independent feature package.
+// The default XSS middleware strips HTML tags from JSON string fields before
+// this handler runs, so the echoed comment is the sanitized value.
 func registerEchoRoutes(router *gin.Engine) {
 	echo := router.Group("/echo")
 	echo.POST("", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok"}})
+		var body struct {
+			Comment string `json:"comment"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": gin.H{
+					"code":    "invalid_json",
+					"message": "request body must be JSON with a comment field",
+				},
+			})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"data": gin.H{
+				"comment": body.Comment,
+			},
+		})
 	})
 }
 

--- a/framework/app.go
+++ b/framework/app.go
@@ -504,6 +504,7 @@ func runtimeMiddlewareStack(cfg config.Config, metrics *httpMetrics) []namedMidd
 			name:    "security_headers",
 			handler: securityHeadersMiddleware(cfg.Environment == config.EnvironmentProduction),
 		},
+		{name: "xss", handler: xssMiddleware()},
 		{name: "request_timeout", handler: requestTimeoutMiddleware(cfg.HTTP.RequestTimeout)},
 	}
 }

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -452,12 +452,12 @@ func TestDefaultRouterLeavesPasswordFieldUnsanitized(t *testing.T) {
 		})
 	})
 
-	const password = `<b>secret</b>`
+	const rawMarkup = `<b>secret</b>`
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(
 		http.MethodPost,
 		"/login",
-		strings.NewReader(`{"password":"`+password+`","note":"<i>hi</i>"}`),
+		strings.NewReader(`{"password":"`+rawMarkup+`","note":"<i>hi</i>"}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
 	app.Router().ServeHTTP(rec, req)
@@ -469,8 +469,8 @@ func TestDefaultRouterLeavesPasswordFieldUnsanitized(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("unmarshal response: %v; body: %s", err, rec.Body.String())
 	}
-	if body["password"] != password {
-		t.Fatalf("password = %q, want unsanitized %q", body["password"], password)
+	if body["password"] != rawMarkup {
+		t.Fatalf("password = %q, want unsanitized %q", body["password"], rawMarkup)
 	}
 	if body["note"] != "hi" {
 		t.Fatalf("note = %q, want %q", body["note"], "hi")

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -29,6 +29,7 @@ func TestDefaultRuntimeMiddlewareOrder(t *testing.T) {
 		"trace_context",
 		"metrics",
 		"security_headers",
+		"xss",
 		"request_timeout",
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -399,5 +400,79 @@ func TestRunContextServesMetricsWithRuntimeMiddleware(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "gombit_http_requests_total") {
 		t.Fatalf("GET /metrics body = %q, want request metrics", string(body))
+	}
+}
+
+func TestDefaultRouterSanitizesXSSInJSONBody(t *testing.T) {
+	app := newTestApp(t)
+	app.Router().POST("/comment", func(c *gin.Context) {
+		var body struct {
+			Comment string `json:"comment"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			t.Fatalf("bind JSON: %v", err)
+		}
+		c.JSON(http.StatusOK, gin.H{"comment": body.Comment})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/comment",
+		strings.NewReader(`{"comment":"<script>alert(1)</script>hi"}`),
+	)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /comment status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v; body: %s", err, rec.Body.String())
+	}
+	if body["comment"] != "hi" {
+		t.Fatalf("comment = %q, want %q", body["comment"], "hi")
+	}
+}
+
+func TestDefaultRouterLeavesPasswordFieldUnsanitized(t *testing.T) {
+	app := newTestApp(t)
+	app.Router().POST("/login", func(c *gin.Context) {
+		var body struct {
+			Password string `json:"password"`
+			Note     string `json:"note"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			t.Fatalf("bind JSON: %v", err)
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"password": body.Password,
+			"note":     body.Note,
+		})
+	})
+
+	const password = `<b>secret</b>`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/login",
+		strings.NewReader(`{"password":"`+password+`","note":"<i>hi</i>"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /login status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v; body: %s", err, rec.Body.String())
+	}
+	if body["password"] != password {
+		t.Fatalf("password = %q, want unsanitized %q", body["password"], password)
+	}
+	if body["note"] != "hi" {
+		t.Fatalf("note = %q, want %q", body["note"], "hi")
 	}
 }

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -476,3 +476,25 @@ func TestDefaultRouterLeavesPasswordFieldUnsanitized(t *testing.T) {
 		t.Fatalf("note = %q, want %q", body["note"], "hi")
 	}
 }
+
+func TestDefaultRouterSanitizesXSSInQuery(t *testing.T) {
+	app := newTestApp(t)
+	app.Router().GET("/search", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"q": c.Query("q")})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/search?q=<script>x</script>hi", nil)
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /search status = %d, want %d; body: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal response: %v; body: %s", err, rec.Body.String())
+	}
+	if body["q"] != "hi" {
+		t.Fatalf("q = %q, want %q", body["q"], "hi")
+	}
+}

--- a/framework/xss.go
+++ b/framework/xss.go
@@ -6,12 +6,15 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/net/html"
 )
 
+// xssPasswordField is exempt from sanitization (exact JSON/query key match,
+// case-sensitive). Keys like "Password" or nested paths still get stripped.
 const xssPasswordField = "password"
 
 // Elements whose text content must not reach handlers (matched to HTML
@@ -29,8 +32,11 @@ var xssSkipElementContent = map[string]struct{}{
 
 // xssMiddleware sanitizes HTML tags from request input before handlers run.
 // JSON string values (POST/PUT/PATCH) and GET query values are stripped to
-// plain text via golang.org/x/net/html. Fields named "password" are left
-// unchanged.
+// plain text via golang.org/x/net/html. The exact key "password" is left
+// unchanged. Non-JSON bodies (form/multipart) pass through unchanged.
+//
+// Re-encoding JSON may change key order and whitespace; callers that hash
+// the raw body must hash the sanitized bytes handlers actually receive.
 func xssMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		switch c.Request.Method {
@@ -100,6 +106,7 @@ func sanitizeJSONBody(c *gin.Context) {
 	}
 	c.Request.Body = io.NopCloser(bytes.NewReader(cleaned))
 	c.Request.ContentLength = int64(len(cleaned))
+	c.Request.Header.Set("Content-Length", strconv.FormatInt(int64(len(cleaned)), 10))
 }
 
 func isJSONContentType(contentType string) bool {
@@ -144,6 +151,10 @@ func sanitizeJSONValue(value any, fieldName string) {
 
 // stripHTML removes HTML tags and discards content inside dangerous elements.
 // Plain strings without "<" or ">" are returned unchanged.
+//
+// An unclosed skip element (for example `<script src=x>...`) discards the
+// remainder of the string — fail-closed for truncated markup. Self-closing
+// skip tags do not enter skip mode.
 func stripHTML(s string) string {
 	if !strings.ContainsAny(s, "<>") {
 		return s
@@ -166,6 +177,8 @@ func stripHTML(s string) string {
 			if _, skip := xssSkipElementContent[string(name)]; skip {
 				skipDepth++
 			}
+		case html.SelfClosingTagToken:
+			// Self-closing skip tags have no body; do not raise skipDepth.
 		case html.EndTagToken:
 			name, _ := tokenizer.TagName()
 			if _, skip := xssSkipElementContent[string(name)]; skip && skipDepth > 0 {

--- a/framework/xss.go
+++ b/framework/xss.go
@@ -1,0 +1,176 @@
+package framework
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/net/html"
+)
+
+const xssPasswordField = "password"
+
+// Elements whose text content must not reach handlers (matched to HTML
+// sanitizer "strict" expectations: tags stripped, dangerous element bodies
+// discarded).
+var xssSkipElementContent = map[string]struct{}{
+	"script":   {},
+	"style":    {},
+	"noscript": {},
+	"iframe":   {},
+	"object":   {},
+	"embed":    {},
+	"textarea": {},
+}
+
+// xssMiddleware sanitizes HTML tags from request input before handlers run.
+// JSON string values (POST/PUT/PATCH) and GET query values are stripped to
+// plain text via golang.org/x/net/html. Fields named "password" are left
+// unchanged.
+func xssMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		switch c.Request.Method {
+		case http.MethodGet:
+			sanitizeQuery(c)
+		case http.MethodPost, http.MethodPut, http.MethodPatch:
+			sanitizeJSONBody(c)
+		}
+		c.Next()
+	}
+}
+
+func sanitizeQuery(c *gin.Context) {
+	query := c.Request.URL.Query()
+	changed := false
+	for key, values := range query {
+		if key == xssPasswordField {
+			continue
+		}
+		for i, value := range values {
+			cleaned := stripHTML(value)
+			if cleaned != value {
+				values[i] = cleaned
+				changed = true
+			}
+		}
+		query[key] = values
+	}
+	if changed {
+		c.Request.URL.RawQuery = query.Encode()
+	}
+}
+
+func sanitizeJSONBody(c *gin.Context) {
+	if c.Request.Body == nil || c.Request.Body == http.NoBody {
+		return
+	}
+	if !isJSONContentType(c.Request.Header.Get("Content-Type")) {
+		return
+	}
+
+	raw, err := io.ReadAll(c.Request.Body)
+	_ = c.Request.Body.Close()
+	if err != nil {
+		c.Request.Body = io.NopCloser(bytes.NewReader(nil))
+		return
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+		return
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var payload any
+	if err := decoder.Decode(&payload); err != nil {
+		// Leave the original body for Gin/Huma validation errors.
+		c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+		return
+	}
+
+	sanitizeJSONValue(payload, "")
+	cleaned, err := json.Marshal(payload)
+	if err != nil {
+		c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+		return
+	}
+	c.Request.Body = io.NopCloser(bytes.NewReader(cleaned))
+	c.Request.ContentLength = int64(len(cleaned))
+}
+
+func isJSONContentType(contentType string) bool {
+	if contentType == "" {
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return strings.HasPrefix(strings.ToLower(strings.TrimSpace(contentType)), "application/json")
+	}
+	return strings.EqualFold(mediaType, "application/json")
+}
+
+func sanitizeJSONValue(value any, fieldName string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if key == xssPasswordField {
+				continue
+			}
+			switch childValue := child.(type) {
+			case string:
+				typed[key] = stripHTML(childValue)
+			default:
+				sanitizeJSONValue(child, key)
+			}
+		}
+	case []any:
+		for i, child := range typed {
+			switch childValue := child.(type) {
+			case string:
+				if fieldName == xssPasswordField {
+					continue
+				}
+				typed[i] = stripHTML(childValue)
+			default:
+				sanitizeJSONValue(child, fieldName)
+			}
+		}
+	}
+}
+
+// stripHTML removes HTML tags and discards content inside dangerous elements.
+// Plain strings without "<" or ">" are returned unchanged.
+func stripHTML(s string) string {
+	if !strings.ContainsAny(s, "<>") {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+	tokenizer := html.NewTokenizer(strings.NewReader(s))
+	skipDepth := 0
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			return b.String()
+		case html.TextToken:
+			if skipDepth == 0 {
+				b.Write(tokenizer.Text())
+			}
+		case html.StartTagToken:
+			name, _ := tokenizer.TagName()
+			if _, skip := xssSkipElementContent[string(name)]; skip {
+				skipDepth++
+			}
+		case html.EndTagToken:
+			name, _ := tokenizer.TagName()
+			if _, skip := xssSkipElementContent[string(name)]; skip && skipDepth > 0 {
+				skipDepth--
+			}
+		}
+	}
+}

--- a/framework/xss_test.go
+++ b/framework/xss_test.go
@@ -1,6 +1,17 @@
 package framework
 
-import "testing"
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
 
 func TestStripHTML(t *testing.T) {
 	t.Parallel()
@@ -14,6 +25,8 @@ func TestStripHTML(t *testing.T) {
 		{name: "script discarded", in: `<script>alert(1)</script>hi`, want: "hi"},
 		{name: "bold stripped", in: `<b>hi</b>`, want: "hi"},
 		{name: "img stripped", in: `x<img src=x onerror=alert(0)>y`, want: "xy"},
+		{name: "unclosed script fail-closed", in: `<script src=x>alert(1)`, want: ""},
+		{name: "nested markup", in: `<div><b>a</b><i>b</i></div>`, want: "ab"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -22,5 +35,99 @@ func TestStripHTML(t *testing.T) {
 				t.Fatalf("stripHTML(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSanitizeJSONValueNestedArray(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{
+		"items": []any{
+			map[string]any{"name": `<b>one</b>`},
+			`<script>x</script>two`,
+		},
+	}
+	sanitizeJSONValue(payload, "")
+
+	items, ok := payload["items"].([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("items = %#v", payload["items"])
+	}
+	first, ok := items[0].(map[string]any)
+	if !ok || first["name"] != "one" {
+		t.Fatalf("items[0] = %#v, want name=one", items[0])
+	}
+	if items[1] != "two" {
+		t.Fatalf("items[1] = %#v, want two", items[1])
+	}
+}
+
+func TestSanitizeJSONBodyInvalidJSONPassthrough(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"comment":`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	sanitizeJSONBody(c)
+
+	got, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Fatalf("body = %q, want original invalid JSON %q", got, raw)
+	}
+}
+
+func TestSanitizeJSONBodyEmptyBodyNoop(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader("   "))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	sanitizeJSONBody(c)
+
+	got, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(got) != "   " {
+		t.Fatalf("body = %q, want unchanged whitespace", got)
+	}
+}
+
+func TestSanitizeJSONBodyUpdatesContentLengthHeader(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"comment":"<b>hi</b>"}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("Content-Length", "999")
+
+	sanitizeJSONBody(c)
+
+	got, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(got, &payload); err != nil {
+		t.Fatalf("unmarshal sanitized body: %v (%s)", err, got)
+	}
+	if payload["comment"] != "hi" {
+		t.Fatalf("comment = %q, want hi", payload["comment"])
+	}
+	if c.Request.ContentLength != int64(len(got)) {
+		t.Fatalf("ContentLength = %d, want %d", c.Request.ContentLength, len(got))
+	}
+	if gotHeader := c.Request.Header.Get("Content-Length"); gotHeader != strconv.Itoa(len(got)) {
+		t.Fatalf("Content-Length header = %q, want %d", gotHeader, len(got))
 	}
 }

--- a/framework/xss_test.go
+++ b/framework/xss_test.go
@@ -1,0 +1,26 @@
+package framework
+
+import "testing"
+
+func TestStripHTML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain", in: "hello", want: "hello"},
+		{name: "script discarded", in: `<script>alert(1)</script>hi`, want: "hi"},
+		{name: "bold stripped", in: `<b>hi</b>`, want: "hi"},
+		{name: "img stripped", in: `x<img src=x onerror=alert(0)>y`, want: "xy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := stripHTML(tt.in); got != tt.want {
+				t.Fatalf("stripHTML(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/shopspring/decimal v1.4.0
 	go.uber.org/zap v1.28.0
+	golang.org/x/net v0.57.0
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.2
 	gorm.io/driver/sqlite v1.6.0
@@ -107,7 +108,6 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
 	golang.org/x/arch v0.29.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect


### PR DESCRIPTION
## Summary

- Add first-party XSS HTML-tag sanitization middleware on the default Gin stack (`framework/xss.go`), using `golang.org/x/net/html` (no Bluemonday / gin-gonic-xss-middleware) so we own the allowlist and stay off third-party XSS wrappers.
- Place it after security headers and before request timeout; strip markup/script from JSON string fields and GET query values before handlers run; leave `password` untouched. GET query sanitization is covered by tests.
- Document the new order and cover it in `examples/router` `/echo`.

Closes #56

## Acceptance criteria

- [x] Markup/script payloads in request fields are sanitized before handlers see them
- [x] Middleware order includes XSS sanitization and is tested
- [x] Docs + example coverage (router/lifecycle/security baseline)

## Scope notes

- Body-size limit, CORS, rate limiting, and auth remain deferred (draft §13.3 neighbors).
- Form/multipart skipped intentionally for v0.1 Huma/JSON; track before admin/session if needed (no new backlog issue opened).
- JSON remarshal may change key order/whitespace; callers hashing bodies must use sanitized bytes.
- Custom routers via `WithRouter` still do not receive the default stack.

## Validation

- [x] `go test ./framework/ ./config/ ./contract/ ./cache/ ./logging/ ./database/ -count=1`
- [ ] `go test ./...`
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A (HTTP-only; no DB)
- [x] Stable features ship docs and appear in an example app
- [ ] Extraction preserves contracts — N/A (first-party middleware; template XSS wrapper not reused)
- [ ] Generators are idempotent/additive, AST-safe — N/A
- [ ] API changes regenerate the OpenAPI doc + TS client — N/A
- [x] No secrets in generated frontend source — N/A (no frontend)
- [x] Scope stays inside this issue's milestone — no M6 battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies

Made with [Cursor](https://cursor.com)