### PR TITLE
[M3-2] Response envelope + error mapping

### DIFF
--- a/contract/category.go
+++ b/contract/category.go
@@ -1,0 +1,52 @@
+package contract
+
+import "net/http"
+
+// Category is a draft §41 framework error category. Transport adapters map
+// categories to HTTP status codes via StatusFor; they do not leak into service
+// layer return types as raw status integers.
+type Category string
+
+const (
+	CategoryValidation             Category = "validation"
+	CategoryAuthentication         Category = "authentication"
+	CategoryAuthorization          Category = "authorization"
+	CategoryNotFound               Category = "not_found"
+	CategoryConflict               Category = "conflict"
+	CategoryRateLimited            Category = "rate_limited"
+	CategoryDependencyUnavailable  Category = "dependency_unavailable"
+	CategoryInternal               Category = "internal"
+)
+
+var categoryStatus = map[Category]int{
+	CategoryValidation:            http.StatusUnprocessableEntity,
+	CategoryAuthentication:        http.StatusUnauthorized,
+	CategoryAuthorization:         http.StatusForbidden,
+	CategoryNotFound:              http.StatusNotFound,
+	CategoryConflict:              http.StatusConflict,
+	CategoryRateLimited:           http.StatusTooManyRequests,
+	CategoryDependencyUnavailable: http.StatusServiceUnavailable,
+	CategoryInternal:              http.StatusInternalServerError,
+}
+
+// StatusFor returns the HTTP status for a §41 category. Unknown categories map
+// to 500 Internal Server Error.
+func StatusFor(cat Category) int {
+	if status, ok := categoryStatus[cat]; ok {
+		return status
+	}
+	return http.StatusInternalServerError
+}
+
+// CodeFor returns the stable D10 error.code for a category. Validation keeps
+// the M3-1 / D10 name "validation_error"; other categories use the category
+// string. Unknown categories map to "internal".
+func CodeFor(cat Category) string {
+	if cat == CategoryValidation {
+		return CodeValidationError
+	}
+	if _, ok := categoryStatus[cat]; ok {
+		return string(cat)
+	}
+	return string(CategoryInternal)
+}

--- a/contract/category_test.go
+++ b/contract/category_test.go
@@ -1,0 +1,73 @@
+package contract
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestCategoryStatusAndCodeTable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		cat        Category
+		wantStatus int
+		wantCode   string
+	}{
+		{CategoryValidation, http.StatusUnprocessableEntity, CodeValidationError},
+		{CategoryAuthentication, http.StatusUnauthorized, "authentication"},
+		{CategoryAuthorization, http.StatusForbidden, "authorization"},
+		{CategoryNotFound, http.StatusNotFound, "not_found"},
+		{CategoryConflict, http.StatusConflict, "conflict"},
+		{CategoryRateLimited, http.StatusTooManyRequests, "rate_limited"},
+		{CategoryDependencyUnavailable, http.StatusServiceUnavailable, "dependency_unavailable"},
+		{CategoryInternal, http.StatusInternalServerError, "internal"},
+		{Category("unknown"), http.StatusInternalServerError, "internal"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.cat), func(t *testing.T) {
+			t.Parallel()
+			if got := StatusFor(tt.cat); got != tt.wantStatus {
+				t.Fatalf("StatusFor(%q) = %d, want %d", tt.cat, got, tt.wantStatus)
+			}
+			if got := CodeFor(tt.cat); got != tt.wantCode {
+				t.Fatalf("CodeFor(%q) = %q, want %q", tt.cat, got, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestNewConstructors(t *testing.T) {
+	t.Parallel()
+
+	err := NotFound("widget not found")
+	if err.GetStatus() != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", err.GetStatus())
+	}
+	if err.Body.Code != "not_found" {
+		t.Fatalf("code = %q, want not_found", err.Body.Code)
+	}
+	if err.Body.Message != "widget not found" {
+		t.Fatalf("message = %q", err.Body.Message)
+	}
+
+	withFields := Conflict("name taken").WithFields(map[string][]string{
+		"name": {"already exists"},
+	})
+	if withFields.Body.Code != "conflict" {
+		t.Fatalf("field-bearing conflict code = %q, want conflict (not validation_error)", withFields.Body.Code)
+	}
+	if withFields.GetStatus() != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", withFields.GetStatus())
+	}
+	if len(withFields.Body.Fields["name"]) == 0 {
+		t.Fatalf("fields missing: %#v", withFields.Body.Fields)
+	}
+
+	val := Validation("", map[string][]string{"email": {"invalid"}})
+	if val.Body.Code != CodeValidationError {
+		t.Fatalf("validation code = %q", val.Body.Code)
+	}
+	if val.Body.Message != validationMessage {
+		t.Fatalf("validation message = %q", val.Body.Message)
+	}
+}

--- a/contract/doc.go
+++ b/contract/doc.go
@@ -1,12 +1,21 @@
-// Package contract defines Gombit's Huma DTO conventions and the D10 error
-// envelope used for validation failures.
+// Package contract defines Gombit's Huma DTO conventions, the D10 success and
+// error envelopes, and draft §41 application error category mapping.
 //
 // Public API routes are Huma-typed handlers. Request and response shapes come
 // from Go structs and Huma validation tags — there is no bespoke Bind layer.
-// Validation failures render as:
+//
+// Success:
+//
+//	{"data": ...}
+//	{"data": ..., "meta": {"page": 1, "per_page": 20, "total": 125}}
+//
+// Validation failures (Huma Install path):
 //
 //	{"error":{"code":"validation_error","message":"...","fields":{...},"request_id":"..."}}
 //
-// Application error categories and success meta helpers are owned by later
-// contract issues (M3-2+). See docs/contract.md.
+// Application errors (return contract.NotFound / New / ... via WithContext):
+//
+//	{"error":{"code":"not_found","message":"...","request_id":"..."}}
+//
+// See docs/contract.md.
 package contract

--- a/contract/doc.go
+++ b/contract/doc.go
@@ -9,6 +9,8 @@
 //	{"data": ...}
 //	{"data": ..., "meta": {"page": 1, "per_page": 20, "total": 125}}
 //
+// Use contract.DataMeta[T, PageMeta] (or another concrete meta type) so OpenAPI
+// emits a real meta schema.
 // Validation failures (Huma Install path):
 //
 //	{"error":{"code":"validation_error","message":"...","fields":{...},"request_id":"..."}}

--- a/contract/envelope.go
+++ b/contract/envelope.go
@@ -1,7 +1,19 @@
 package contract
 
-// Data is the minimal D10 success envelope. Pagination and other meta fields
-// are added in M3-2.
+// Data is the D10 success envelope without meta: {"data": ...}.
 type Data[T any] struct {
 	Data T `json:"data"`
+}
+
+// DataMeta is the D10 success envelope with optional meta: {"data": ..., "meta": ...}.
+type DataMeta[T any] struct {
+	Data T   `json:"data"`
+	Meta any `json:"meta,omitempty"`
+}
+
+// PageMeta is the conventional pagination meta object for collection responses.
+type PageMeta struct {
+	Page    int   `json:"page"`
+	PerPage int   `json:"per_page"`
+	Total   int64 `json:"total"`
 }

--- a/contract/envelope.go
+++ b/contract/envelope.go
@@ -5,13 +5,23 @@ type Data[T any] struct {
 	Data T `json:"data"`
 }
 
-// DataMeta is the D10 success envelope with optional meta: {"data": ..., "meta": ...}.
-type DataMeta[T any] struct {
-	Data T   `json:"data"`
-	Meta any `json:"meta,omitempty"`
+// DataMeta is the D10 success envelope with typed meta:
+// {"data": ..., "meta": ...}.
+//
+// Use a concrete meta type so OpenAPI emits a real schema (not empty object).
+// Prefer a pointer meta value so omitempty drops absent meta:
+//
+//	contract.DataMeta[[]Widget, PageMeta]{Data: items, Meta: &contract.PageMeta{...}}
+//
+// A non-nil zero PageMeta still serializes (omitempty does not treat structs as empty).
+type DataMeta[T any, M any] struct {
+	Data T  `json:"data"`
+	Meta *M `json:"meta,omitempty"`
 }
 
 // PageMeta is the conventional pagination meta object for collection responses.
+// It is the v0.1 typed default for list endpoints; other meta shapes can use the
+// second type parameter on DataMeta when needed.
 type PageMeta struct {
 	Page    int   `json:"page"`
 	PerPage int   `json:"per_page"`

--- a/contract/envelope_test.go
+++ b/contract/envelope_test.go
@@ -27,9 +27,9 @@ func TestDataJSONShape(t *testing.T) {
 func TestDataMetaPageJSONShape(t *testing.T) {
 	t.Parallel()
 
-	body := DataMeta[[]string]{
+	body := DataMeta[[]string, PageMeta]{
 		Data: []string{"a", "b"},
-		Meta: PageMeta{Page: 1, PerPage: 20, Total: 125},
+		Meta: &PageMeta{Page: 1, PerPage: 20, Total: 125},
 	}
 	raw, err := json.Marshal(body)
 	if err != nil {
@@ -58,14 +58,29 @@ func TestDataMetaPageJSONShape(t *testing.T) {
 	}
 }
 
-func TestDataMetaOmitsEmptyMeta(t *testing.T) {
+func TestDataMetaOmitsNilMeta(t *testing.T) {
 	t.Parallel()
 
-	raw, err := json.Marshal(DataMeta[string]{Data: "ok"})
+	raw, err := json.Marshal(DataMeta[string, PageMeta]{Data: "ok"})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
 	if string(raw) != `{"data":"ok"}` {
 		t.Fatalf("json = %s, want data-only when meta is nil", raw)
+	}
+}
+
+func TestDataMetaZeroPageMetaStillSerializes(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(DataMeta[string, PageMeta]{
+		Data: "ok",
+		Meta: &PageMeta{},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"meta"`) {
+		t.Fatalf("non-nil zero PageMeta should serialize; got %s", raw)
 	}
 }

--- a/contract/envelope_test.go
+++ b/contract/envelope_test.go
@@ -1,0 +1,71 @@
+package contract
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDataJSONShape(t *testing.T) {
+	t.Parallel()
+
+	body := Data[string]{Data: "ok"}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"data":"ok"}`
+	if string(raw) != want {
+		t.Fatalf("json = %s, want %s", raw, want)
+	}
+	if strings.Contains(string(raw), `"meta"`) {
+		t.Fatalf("Data must not emit meta; got %s", raw)
+	}
+}
+
+func TestDataMetaPageJSONShape(t *testing.T) {
+	t.Parallel()
+
+	body := DataMeta[[]string]{
+		Data: []string{"a", "b"},
+		Meta: PageMeta{Page: 1, PerPage: 20, Total: 125},
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	data, ok := got["data"].([]any)
+	if !ok || len(data) != 2 || data[0] != "a" || data[1] != "b" {
+		t.Fatalf("data = %#v", got["data"])
+	}
+	meta, ok := got["meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("meta missing: %#v", got)
+	}
+	wantMeta := map[string]any{
+		"page":     float64(1),
+		"per_page": float64(20),
+		"total":    float64(125),
+	}
+	if !reflect.DeepEqual(meta, wantMeta) {
+		t.Fatalf("meta = %#v, want %#v", meta, wantMeta)
+	}
+}
+
+func TestDataMetaOmitsEmptyMeta(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(DataMeta[string]{Data: "ok"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(raw) != `{"data":"ok"}` {
+		t.Fatalf("json = %s, want data-only when meta is nil", raw)
+	}
+}

--- a/contract/error.go
+++ b/contract/error.go
@@ -66,6 +66,10 @@ func (e *ErrorEnvelope) WithFields(fields map[string][]string) *ErrorEnvelope {
 }
 
 // New builds a D10 ErrorEnvelope from a §41 category and message.
+//
+// Callers should wrap with WithContext so request_id is populated:
+//
+//	return nil, contract.WithContext(ctx, contract.New(contract.CategoryNotFound, "missing"))
 func New(cat Category, message string) *ErrorEnvelope {
 	return &ErrorEnvelope{
 		status: StatusFor(cat),
@@ -77,6 +81,7 @@ func New(cat Category, message string) *ErrorEnvelope {
 }
 
 // Validation returns a validation category error (HTTP 422, code validation_error).
+// Wrap with WithContext in handlers to attach request_id.
 func Validation(message string, fields map[string][]string) *ErrorEnvelope {
 	if message == "" {
 		message = validationMessage
@@ -85,36 +90,43 @@ func Validation(message string, fields map[string][]string) *ErrorEnvelope {
 }
 
 // Authentication returns an authentication category error (HTTP 401).
+// Wrap with WithContext in handlers to attach request_id.
 func Authentication(message string) *ErrorEnvelope {
 	return New(CategoryAuthentication, message)
 }
 
 // Authorization returns an authorization category error (HTTP 403).
+// Wrap with WithContext in handlers to attach request_id.
 func Authorization(message string) *ErrorEnvelope {
 	return New(CategoryAuthorization, message)
 }
 
 // NotFound returns a not_found category error (HTTP 404).
+// Wrap with WithContext in handlers to attach request_id.
 func NotFound(message string) *ErrorEnvelope {
 	return New(CategoryNotFound, message)
 }
 
 // Conflict returns a conflict category error (HTTP 409).
+// Wrap with WithContext in handlers to attach request_id.
 func Conflict(message string) *ErrorEnvelope {
 	return New(CategoryConflict, message)
 }
 
 // RateLimited returns a rate_limited category error (HTTP 429).
+// Wrap with WithContext in handlers to attach request_id.
 func RateLimited(message string) *ErrorEnvelope {
 	return New(CategoryRateLimited, message)
 }
 
 // DependencyUnavailable returns a dependency_unavailable error (HTTP 503).
+// Wrap with WithContext in handlers to attach request_id.
 func DependencyUnavailable(message string) *ErrorEnvelope {
 	return New(CategoryDependencyUnavailable, message)
 }
 
 // Internal returns an internal category error (HTTP 500).
+// Wrap with WithContext in handlers to attach request_id.
 func Internal(message string) *ErrorEnvelope {
 	return New(CategoryInternal, message)
 }

--- a/contract/error.go
+++ b/contract/error.go
@@ -44,4 +44,79 @@ func (e *ErrorEnvelope) GetStatus() int {
 	return e.status
 }
 
+// WithRequestID returns a shallow copy with request_id set (for tests/helpers).
+func (e *ErrorEnvelope) WithRequestID(requestID string) *ErrorEnvelope {
+	if e == nil {
+		return nil
+	}
+	out := *e
+	out.Body.RequestID = requestID
+	return &out
+}
+
+// WithFields returns a shallow copy with D10 fields set. The error code stays
+// the category code (not forced to validation_error).
+func (e *ErrorEnvelope) WithFields(fields map[string][]string) *ErrorEnvelope {
+	if e == nil {
+		return nil
+	}
+	out := *e
+	out.Body.Fields = fields
+	return &out
+}
+
+// New builds a D10 ErrorEnvelope from a §41 category and message.
+func New(cat Category, message string) *ErrorEnvelope {
+	return &ErrorEnvelope{
+		status: StatusFor(cat),
+		Body: ErrorBody{
+			Code:    CodeFor(cat),
+			Message: message,
+		},
+	}
+}
+
+// Validation returns a validation category error (HTTP 422, code validation_error).
+func Validation(message string, fields map[string][]string) *ErrorEnvelope {
+	if message == "" {
+		message = validationMessage
+	}
+	return New(CategoryValidation, message).WithFields(fields)
+}
+
+// Authentication returns an authentication category error (HTTP 401).
+func Authentication(message string) *ErrorEnvelope {
+	return New(CategoryAuthentication, message)
+}
+
+// Authorization returns an authorization category error (HTTP 403).
+func Authorization(message string) *ErrorEnvelope {
+	return New(CategoryAuthorization, message)
+}
+
+// NotFound returns a not_found category error (HTTP 404).
+func NotFound(message string) *ErrorEnvelope {
+	return New(CategoryNotFound, message)
+}
+
+// Conflict returns a conflict category error (HTTP 409).
+func Conflict(message string) *ErrorEnvelope {
+	return New(CategoryConflict, message)
+}
+
+// RateLimited returns a rate_limited category error (HTTP 429).
+func RateLimited(message string) *ErrorEnvelope {
+	return New(CategoryRateLimited, message)
+}
+
+// DependencyUnavailable returns a dependency_unavailable error (HTTP 503).
+func DependencyUnavailable(message string) *ErrorEnvelope {
+	return New(CategoryDependencyUnavailable, message)
+}
+
+// Internal returns an internal category error (HTTP 500).
+func Internal(message string) *ErrorEnvelope {
+	return New(CategoryInternal, message)
+}
+
 var _ huma.StatusError = (*ErrorEnvelope)(nil)

--- a/contract/error_mapping_test.go
+++ b/contract/error_mapping_test.go
@@ -1,0 +1,88 @@
+package contract
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humagin"
+	"github.com/gin-gonic/gin"
+)
+
+func TestHumaHandlerReturnsNotFoundEnvelope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	api := humagin.New(router, HumaConfig("contract-test", "0.0.0"))
+
+	type getInput struct {
+		ID string `path:"id"`
+	}
+	huma.Register(api, huma.Operation{
+		OperationID: "get-widget",
+		Method:      http.MethodGet,
+		Path:        "/widgets/{id}",
+	}, func(ctx context.Context, input *getInput) (*struct {
+		Body Data[string]
+	}, error) {
+		return nil, WithContext(ctx, NotFound("widget not found"))
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/widgets/missing", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var body ErrorEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v; body: %s", err, rec.Body.String())
+	}
+	if body.Body.Code != "not_found" {
+		t.Fatalf("code = %q, want not_found", body.Body.Code)
+	}
+	if body.Body.Message != "widget not found" {
+		t.Fatalf("message = %q", body.Body.Message)
+	}
+	if body.Body.RequestID != "req-test-1" {
+		t.Fatalf("request_id = %q, want req-test-1 (from TestMain Install)", body.Body.RequestID)
+	}
+}
+
+func TestConflictWithFieldsKeepsCategoryCode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	api := humagin.New(router, HumaConfig("contract-test", "0.0.0"))
+
+	huma.Register(api, huma.Operation{
+		OperationID: "create-dup",
+		Method:      http.MethodPost,
+		Path:        "/widgets",
+	}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+		return nil, WithContext(ctx, Conflict("duplicate name").WithFields(map[string][]string{
+			"name": {"already exists"},
+		}))
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/widgets", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", rec.Code, rec.Body.String())
+	}
+	var body ErrorEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v; body: %s", err, rec.Body.String())
+	}
+	if body.Body.Code != "conflict" {
+		t.Fatalf("code = %q, want conflict", body.Body.Code)
+	}
+	if len(body.Body.Fields["name"]) == 0 {
+		t.Fatalf("fields.name missing: %#v", body.Body.Fields)
+	}
+}

--- a/contract/error_mapping_test.go
+++ b/contract/error_mapping_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -84,5 +85,40 @@ func TestConflictWithFieldsKeepsCategoryCode(t *testing.T) {
 	}
 	if len(body.Body.Fields["name"]) == 0 {
 		t.Fatalf("fields.name missing: %#v", body.Body.Fields)
+	}
+}
+
+func TestDataMetaPageMetaAppearsInOpenAPI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	api := humagin.New(router, HumaConfig("contract-test", "0.0.0"))
+
+	type item struct {
+		Name string `json:"name"`
+	}
+	type listOut struct {
+		Body DataMeta[[]item, PageMeta]
+	}
+	huma.Register(api, huma.Operation{
+		OperationID: "list-items",
+		Method:      http.MethodGet,
+		Path:        "/items",
+	}, func(ctx context.Context, input *struct{}) (*listOut, error) {
+		return &listOut{Body: DataMeta[[]item, PageMeta]{
+			Data: []item{{Name: "a"}},
+			Meta: &PageMeta{Page: 1, PerPage: 20, Total: 1},
+		}}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/openapi.json", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("openapi status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	spec := rec.Body.String()
+	for _, want := range []string{`"page"`, `"per_page"`, `"total"`, `"PageMeta"`} {
+		if !strings.Contains(spec, want) {
+			t.Fatalf("OpenAPI missing %s; body: %s", want, spec)
+		}
 	}
 }

--- a/contract/install.go
+++ b/contract/install.go
@@ -16,16 +16,27 @@ type InstallOptions struct {
 	RequestID func(context.Context) string
 }
 
-var installOnce sync.Once
+var (
+	installOnce    sync.Once
+	requestIDFrom  func(context.Context) string
+	requestIDMu    sync.RWMutex
+)
 
 // Install replaces Huma's default RFC 9457 Problem Details errors with the D10
 // envelope. It is safe to call more than once; only the first call applies.
+//
+// Install only classifies errors built through Huma's NewError hooks (request
+// validation). Application errors from New / NotFound / etc. set status and
+// code via StatusFor / CodeFor and are not reclassified.
 func Install(opts InstallOptions) {
 	installOnce.Do(func() {
 		requestID := opts.RequestID
 		if requestID == nil {
 			requestID = func(context.Context) string { return "" }
 		}
+		requestIDMu.Lock()
+		requestIDFrom = requestID
+		requestIDMu.Unlock()
 
 		huma.NewError = func(status int, msg string, errs ...error) huma.StatusError {
 			return newEnvelope(status, msg, "", errs...)
@@ -38,6 +49,26 @@ func Install(opts InstallOptions) {
 			return newEnvelope(status, msg, id, errs...)
 		}
 	})
+}
+
+// WithContext returns err with request_id filled from Install's RequestID
+// reader when available. Application handlers should wrap category errors:
+//
+//	return nil, contract.WithContext(ctx, contract.NotFound("missing"))
+func WithContext(ctx context.Context, err *ErrorEnvelope) *ErrorEnvelope {
+	if err == nil {
+		return nil
+	}
+	requestIDMu.RLock()
+	fn := requestIDFrom
+	requestIDMu.RUnlock()
+	if fn == nil || ctx == nil {
+		return err
+	}
+	if id := fn(ctx); id != "" {
+		return err.WithRequestID(id)
+	}
+	return err
 }
 
 func newEnvelope(status int, msg, requestID string, errs ...error) *ErrorEnvelope {
@@ -73,9 +104,9 @@ func classifyError(status int, msg string, fields map[string][]string) (code, me
 }
 
 func isValidationFailure(status int, msg string, fields map[string][]string) bool {
-	// Any error carrying field details is treated as validation until M3-2 owns
-	// application error categories (field-bearing domain errors may then use a
-	// different code while keeping D10 fields).
+	// Huma Install path only: field details or 422/validation-failed indicate
+	// request validation. Application constructors (New/NotFound/...) bypass
+	// this function entirely.
 	if len(fields) > 0 {
 		return true
 	}

--- a/docs/adr/011-contract-layer-huma.md
+++ b/docs/adr/011-contract-layer-huma.md
@@ -70,8 +70,9 @@ OpenAPI 3.1 emission without a custom contract framework.
   Details error schema. That is not the Gombit public error contract. **M3-1
   replaces validation (and other Huma-generated) errors with the locked D10
   envelope** via `contract.Install` / `framework.App.API()` — see
-  [`docs/contract.md`](../contract.md). M3-2 still owns application error
-  categories and the category→status mapping table. The `fields` member is
+  [`docs/contract.md`](../contract.md). M3-2 owns application error categories
+  and the category→status mapping table (`contract.StatusFor` /
+  `contract.NotFound`, etc.). The `fields` member is
   optional and should appear only when field-level details exist:
 
 ```json

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -41,11 +41,21 @@ type createWidgetOutput struct {
 }
 
 type listWidgetsOutput struct {
-    Body contract.DataMeta[[]Widget] // {"data": [...], "meta": {...}}
+    // Typed meta so OpenAPI emits PageMeta fields (not empty object).
+    Body contract.DataMeta[[]Widget, contract.PageMeta]
 }
 ```
 
-`contract.PageMeta` is the conventional pagination object:
+`contract.PageMeta` is the v0.1 pagination meta for collection responses.
+Pass a non-nil pointer when meta should appear; a nil `Meta` is omitted.
+A non-nil zero `PageMeta` still serializes (JSON `omitempty` does not drop empty structs).
+
+```go
+Body: contract.DataMeta[[]Widget, contract.PageMeta]{
+    Data: items,
+    Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: 125},
+},
+```
 
 ```json
 {
@@ -136,7 +146,8 @@ return nil, contract.WithContext(ctx, contract.NotFound("widget not found"))
 
 Helpers: `Validation`, `Authentication`, `Authorization`, `NotFound`,
 `Conflict`, `RateLimited`, `DependencyUnavailable`, `Internal`, plus
-`New(category, message)`.
+`New(category, message)`. Always wrap with `WithContext` in handlers so
+`request_id` is set — constructors alone leave it empty.
 
 `WithFields` attaches D10 `fields` without forcing the code to
 `validation_error` (for example a `conflict` with a field detail). Huma tag

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,12 +1,11 @@
-# Contract (Huma DTOs + validation)
+# Contract (Huma DTOs + envelope)
 
-M3-1 introduces Gombit's public API contract conventions: Huma-typed handlers
-over Gin, validation tags on request structs, and the locked D10 error envelope
-with structured `fields`.
+Gombit's public API contract conventions: Huma-typed handlers over Gin, D10
+success/error envelopes, validation tags → structured `fields`, and draft §41
+application error categories mapped centrally to HTTP status codes.
 
-ADR-011 selected Huma as the contract layer. This document is the application-
-facing guide for DTO shape and validation errors. Application error categories
-and success `meta` belong to M3-2; OpenAPI CLI generation belongs to M3-3.
+ADR-011 selected Huma as the contract layer. OpenAPI CLI generation belongs to
+M3-3; the TypeScript client belongs to M3-4.
 
 ## Registering contract routes
 
@@ -32,9 +31,34 @@ return framework.Run(app)
 Use `app.Router()` only for routes that must stay outside the OpenAPI contract
 (webhooks, SSE, legacy). See [`docs/router.md`](router.md).
 
-`examples/contract` shows a minimal create endpoint.
+`examples/contract` shows create, list (with `meta`), get, and not-found.
 
-## Request / response DTOs
+## Success envelope
+
+```go
+type createWidgetOutput struct {
+    Body contract.Data[Widget] // {"data": {...}}
+}
+
+type listWidgetsOutput struct {
+    Body contract.DataMeta[[]Widget] // {"data": [...], "meta": {...}}
+}
+```
+
+`contract.PageMeta` is the conventional pagination object:
+
+```json
+{
+  "data": [],
+  "meta": {
+    "page": 1,
+    "per_page": 20,
+    "total": 125
+  }
+}
+```
+
+## Request DTOs
 
 Go structs are the source of truth. Prefer Huma tags — not a separate
 `validate:"..."` layer and not hand-written OpenAPI files.
@@ -44,14 +68,6 @@ type CreateWidgetBody struct {
     Name  string `json:"name" minLength:"1" maxLength:"80" doc:"Human-readable name"`
     Color string `json:"color,omitempty" maxLength:"30"`
 }
-
-type createWidgetInput struct {
-    Body CreateWidgetBody
-}
-
-type createWidgetOutput struct {
-    Body contract.Data[Widget]
-}
 ```
 
 Conventions:
@@ -59,8 +75,6 @@ Conventions:
 - Nest the JSON body under an input field named `Body` (Huma binding).
 - Put validation metadata on body fields (`minLength`, `maxLength`, `format`,
   `enum`, `required`, and the other Huma tags).
-- Wrap success payloads in `contract.Data[T]` so responses are `{"data": ...}`.
-  Pagination `meta` arrives in M3-2.
 - Document fields with `doc` / `example` so they appear in OpenAPI.
 
 ## Validation → D10 `fields`
@@ -99,6 +113,38 @@ field name from messages like `expected required property name to be present`.
 
 Content-Type stays `application/json` (not `application/problem+json`).
 
+## Application errors (§41 categories)
+
+Services and handlers should return category errors, not ad-hoc status codes.
+Constructors build a D10 `ErrorEnvelope` (`huma.StatusError`). Wrap with
+`contract.WithContext` so `request_id` is filled:
+
+```go
+return nil, contract.WithContext(ctx, contract.NotFound("widget not found"))
+```
+
+| Category | D10 `error.code` | HTTP |
+| --- | --- | --- |
+| `validation` | `validation_error` | 422 |
+| `authentication` | `authentication` | 401 |
+| `authorization` | `authorization` | 403 |
+| `not_found` | `not_found` | 404 |
+| `conflict` | `conflict` | 409 |
+| `rate_limited` | `rate_limited` | 429 |
+| `dependency_unavailable` | `dependency_unavailable` | 503 |
+| `internal` | `internal` | 500 |
+
+Helpers: `Validation`, `Authentication`, `Authorization`, `NotFound`,
+`Conflict`, `RateLimited`, `DependencyUnavailable`, `Internal`, plus
+`New(category, message)`.
+
+`WithFields` attaches D10 `fields` without forcing the code to
+`validation_error` (for example a `conflict` with a field detail). Huma tag
+validation still uses the Install path and always yields `validation_error`.
+
+The `validation_error` code is preserved from M3-1 / D10 (not renamed to
+`validation`).
+
 ## OpenAPI preview
 
 With the default Huma config, `/openapi.json` is served for local inspection and
@@ -107,6 +153,7 @@ checks land in M3-3 / M3-5.
 
 ## What is not here yet
 
-- Central application error categories and HTTP status mapping (M3-2)
-- Success envelope `meta` helpers (M3-2)
-- `gombit openapi generate` / `gombit client generate` (M3-3 / M3-4)
+- `gombit openapi generate` / `/docs` UI (M3-3)
+- TypeScript client generation (M3-4)
+- Pagination query DSL / filter/sort helpers (design §42)
+- gRPC status mapping (post-v0.1)

--- a/examples/contract/README.md
+++ b/examples/contract/README.md
@@ -1,12 +1,37 @@
 # Contract example
 
-Demonstrates Huma DTO conventions and D10 validation errors on
-`framework.App.API()`.
+Demonstrates Huma DTOs, D10 validation errors, success `meta`, and §41
+category errors (`not_found`) on `framework.App.API()`.
 
 ## Run
 
 ```sh
 go run ./examples/contract
+```
+
+## List (data + page meta)
+
+```sh
+curl -sS http://127.0.0.1:8080/api/v1/widgets
+```
+
+## Get existing / missing
+
+```sh
+curl -sS http://127.0.0.1:8080/api/v1/widgets/widget-1
+curl -sS http://127.0.0.1:8080/api/v1/widgets/missing
+```
+
+Missing id returns:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "widget not found",
+    "request_id": "..."
+  }
+}
 ```
 
 ## Valid create
@@ -23,21 +48,6 @@ curl -sS -X POST http://127.0.0.1:8080/api/v1/widgets \
 curl -sS -X POST http://127.0.0.1:8080/api/v1/widgets \
   -H 'Content-Type: application/json' \
   -d '{}'
-```
-
-Example response:
-
-```json
-{
-  "error": {
-    "code": "validation_error",
-    "message": "The request contains invalid fields.",
-    "fields": {
-      "name": ["expected required property name to be present"]
-    },
-    "request_id": "..."
-  }
-}
 ```
 
 See [`docs/contract.md`](../../docs/contract.md).

--- a/examples/contract/main.go
+++ b/examples/contract/main.go
@@ -31,7 +31,53 @@ type createWidgetOutput struct {
 	Body contract.Data[Widget]
 }
 
+type listWidgetsOutput struct {
+	Body contract.DataMeta[[]Widget]
+}
+
+type getWidgetInput struct {
+	ID string `path:"id" doc:"Widget identifier"`
+}
+
+type getWidgetOutput struct {
+	Body contract.Data[Widget]
+}
+
 func registerWidgetRoutes(api huma.API, prefix string) {
+	huma.Register(api, huma.Operation{
+		OperationID: "list-widgets",
+		Method:      http.MethodGet,
+		Path:        prefix + "/widgets",
+		Summary:     "List widgets",
+		Tags:        []string{"Widgets"},
+	}, func(ctx context.Context, input *struct{}) (*listWidgetsOutput, error) {
+		return &listWidgetsOutput{
+			Body: contract.DataMeta[[]Widget]{
+				Data: []Widget{
+					{ID: "widget-1", Name: "First widget", Color: "blue"},
+				},
+				Meta: contract.PageMeta{Page: 1, PerPage: 20, Total: 1},
+			},
+		}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-widget",
+		Method:      http.MethodGet,
+		Path:        prefix + "/widgets/{id}",
+		Summary:     "Get a widget",
+		Tags:        []string{"Widgets"},
+	}, func(ctx context.Context, input *getWidgetInput) (*getWidgetOutput, error) {
+		if input.ID != "widget-1" {
+			return nil, contract.WithContext(ctx, contract.NotFound("widget not found"))
+		}
+		return &getWidgetOutput{
+			Body: contract.Data[Widget]{
+				Data: Widget{ID: "widget-1", Name: "First widget", Color: "blue"},
+			},
+		}, nil
+	})
+
 	huma.Register(api, huma.Operation{
 		OperationID: "create-widget",
 		Method:      http.MethodPost,

--- a/examples/contract/main.go
+++ b/examples/contract/main.go
@@ -32,7 +32,7 @@ type createWidgetOutput struct {
 }
 
 type listWidgetsOutput struct {
-	Body contract.DataMeta[[]Widget]
+	Body contract.DataMeta[[]Widget, contract.PageMeta]
 }
 
 type getWidgetInput struct {
@@ -52,11 +52,11 @@ func registerWidgetRoutes(api huma.API, prefix string) {
 		Tags:        []string{"Widgets"},
 	}, func(ctx context.Context, input *struct{}) (*listWidgetsOutput, error) {
 		return &listWidgetsOutput{
-			Body: contract.DataMeta[[]Widget]{
+			Body: contract.DataMeta[[]Widget, contract.PageMeta]{
 				Data: []Widget{
 					{ID: "widget-1", Name: "First widget", Color: "blue"},
 				},
-				Meta: contract.PageMeta{Page: 1, PerPage: 20, Total: 1},
+				Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: 1},
 			},
 		}, nil
 	})

--- a/framework/contract_test.go
+++ b/framework/contract_test.go
@@ -98,3 +98,44 @@ func TestAppExposesAPI(t *testing.T) {
 		t.Fatal("API() = nil, want huma.API")
 	}
 }
+
+func TestAPICategoryErrorReturnsD10Envelope(t *testing.T) {
+	app := newTestApp(t)
+
+	type getInput struct {
+		ID string `path:"id"`
+	}
+	type getOutput struct {
+		Body contract.Data[map[string]string]
+	}
+
+	prefix := app.Config().API.Prefix
+	huma.Register(app.API(), huma.Operation{
+		OperationID: "get-widget",
+		Method:      http.MethodGet,
+		Path:        prefix + "/widgets/{id}",
+		Summary:     "Get a widget",
+	}, func(ctx context.Context, input *getInput) (*getOutput, error) {
+		return nil, contract.WithContext(ctx, contract.NotFound("widget not found"))
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, prefix+"/widgets/missing", nil)
+	req.Header.Set(RequestIDHeader, "req-framework-2")
+	app.Router().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+
+	var body contract.ErrorEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error envelope: %v; body: %s", err, rec.Body.String())
+	}
+	if body.Body.Code != "not_found" {
+		t.Fatalf("code = %q, want not_found", body.Body.Code)
+	}
+	if body.Body.RequestID != "req-framework-2" {
+		t.Fatalf("request_id = %q, want req-framework-2", body.Body.RequestID)
+	}
+}


### PR DESCRIPTION
## Summary

- Extend the `contract` package with D10 success `meta` (`DataMeta`, `PageMeta`) and draft §41 application error categories mapped centrally to HTTP status codes.
- Handlers return `contract.NotFound` / `New` / etc. as `*ErrorEnvelope` (`huma.StatusError`); `WithContext` attaches `request_id`. Huma validation still uses Install → `validation_error`.
- Docs + `examples/contract` cover list meta, get, and not-found.

Closes #17

## Acceptance criteria

- [x] envelope covered by tests
- [x] category→status mapping table tested

## Scope notes

- `validation_error` code preserved (not renamed to `validation`) for D10/M3-1 compatibility.
- Deferred: `gombit openapi generate` / `/docs` (M3-3), TS client (M3-4), pagination query DSL (§42), gRPC status mapping (post-v0.1).

## Validation

- [x] `go test ./contract/ ./framework/ -count=1 -shuffle=on`
- [x] `go build -o /dev/null ./examples/contract/`
- [x] CI green on this branch
- [x] Typed `DataMeta` fix landed
- [ ] `go test ./...`
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A (HTTP/contract only; no DB)
- [x] Stable features ship docs and appear in an example app
- [ ] Extraction preserves contracts — N/A (extends M3-1 contract package; not a template extraction)
- [ ] Generators are idempotent/additive, AST-safe — N/A
- [ ] API changes regenerate the OpenAPI doc + TS client — N/A (M3-3/M3-4; OpenAPI schema still uses ErrorEnvelope)
- [x] No secrets in generated frontend source — N/A (no frontend)
- [x] Scope stays inside this issue's milestone — no M6 battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies

Made with [Cursor](https://cursor.com)