### PR TITLE
[M3-3] OpenAPI emission + gombit openapi generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Emit the current spike OpenAPI document:
 go run ./cmd/contract-spike-openapi openapi.json
 ```
 
+Write the live app spec (app must be serving `/openapi.json`):
+
+```sh
+go run ./cmd/gombit openapi generate --out openapi.json
+```
+
+Interactive docs are at `/docs` when `GOMBIT_DOCS_ENABLED` is on (the local
+default). See [`docs/openapi.md`](docs/openapi.md).
+
 The authoritative implementation backlog and architecture decisions live in
 [`docs/GOMBIT_BUILD_PLAN.md`](docs/GOMBIT_BUILD_PLAN.md).
 
@@ -26,6 +35,7 @@ Runtime configuration is documented in [`docs/config.md`](docs/config.md).
 Application lifecycle is documented in [`docs/lifecycle.md`](docs/lifecycle.md).
 Application-owned route registration is documented in [`docs/router.md`](docs/router.md).
 Huma DTO and validation conventions are documented in [`docs/contract.md`](docs/contract.md).
+OpenAPI emission and `/docs` are documented in [`docs/openapi.md`](docs/openapi.md).
 Database runtime support is documented in [`docs/database.md`](docs/database.md).
 Cache runtime support is documented in [`docs/cache.md`](docs/cache.md).
 Runtime logging is documented in [`docs/logging.md`](docs/logging.md).

--- a/cmd/gombit/main.go
+++ b/cmd/gombit/main.go
@@ -26,30 +26,38 @@ func run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer)
 		usage(stderr)
 		return errors.New("gombit: command is required")
 	}
-	if args[0] != "db" {
+	switch args[0] {
+	case "openapi":
+		return runOpenAPI(ctx, args[1:], stdout, stderr)
+	case "db":
+		return runDB(ctx, args[1:], stdout, stderr)
+	default:
 		usage(stderr)
 		return fmt.Errorf("gombit: unknown command %q", args[0])
 	}
-	if len(args) < 2 {
+}
+
+func runDB(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	if len(args) == 0 {
 		dbUsage(stderr)
 		return errors.New("gombit db: subcommand is required")
 	}
-	switch args[1] {
+	switch args[0] {
 	case "makemigrations":
-		return runMakeMigrations(ctx, args[2:], stdout, stderr)
+		return runMakeMigrations(ctx, args[1:], stdout, stderr)
 	case "migrate":
-		return runMigrate(ctx, args[2:], stdout, stderr)
+		return runMigrate(ctx, args[1:], stdout, stderr)
 	case "rollback":
-		return runRollback(ctx, args[2:], stdout, stderr)
+		return runRollback(ctx, args[1:], stdout, stderr)
 	case "status":
-		return runStatus(ctx, args[2:], stdout, stderr)
+		return runStatus(ctx, args[1:], stdout, stderr)
 	case "seed":
-		return runSeed(ctx, args[2:], stdout, stderr)
+		return runSeed(ctx, args[1:], stdout, stderr)
 	case "reset":
-		return runReset(ctx, args[2:], stdout, stderr)
+		return runReset(ctx, args[1:], stdout, stderr)
 	default:
 		dbUsage(stderr)
-		return fmt.Errorf("gombit db: unknown subcommand %q", args[1])
+		return fmt.Errorf("gombit db: unknown subcommand %q", args[0])
 	}
 }
 
@@ -232,7 +240,10 @@ func (m *modelFlags) Set(value string) error {
 }
 
 func usage(w io.Writer) {
-	_, _ = fmt.Fprintln(w, "usage: gombit db <subcommand>")
+	_, _ = fmt.Fprintln(w, "usage: gombit <command>")
+	_, _ = fmt.Fprintln(w, "available commands:")
+	_, _ = fmt.Fprintln(w, "  db <subcommand>")
+	_, _ = fmt.Fprintln(w, "  openapi generate [--out openapi.json] [--url http://127.0.0.1:8080/openapi.json]")
 	dbUsage(w)
 }
 

--- a/cmd/gombit/main.go
+++ b/cmd/gombit/main.go
@@ -242,9 +242,8 @@ func (m *modelFlags) Set(value string) error {
 func usage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "usage: gombit <command>")
 	_, _ = fmt.Fprintln(w, "available commands:")
-	_, _ = fmt.Fprintln(w, "  db <subcommand>")
+	_, _ = fmt.Fprintln(w, "  db <subcommand>   see gombit db")
 	_, _ = fmt.Fprintln(w, "  openapi generate [--out openapi.json] [--url http://127.0.0.1:8080/openapi.json]")
-	dbUsage(w)
 }
 
 func dbUsage(w io.Writer) {

--- a/cmd/gombit/main_test.go
+++ b/cmd/gombit/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -10,6 +12,9 @@ import (
 	"testing"
 
 	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/framework"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gin-gonic/gin"
 )
 
 func TestRunMakeMigrationsInvokesAtlasAndWritesMigration(t *testing.T) {
@@ -106,6 +111,162 @@ func TestRunMakeMigrationsRequiresModel(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "at least one model") {
 		t.Fatalf("run() error = %q, want missing model message", err)
+	}
+}
+
+func TestRunOpenAPIGenerateMatchesLiveFrameworkRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentTest
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	app, err := framework.New(framework.WithConfig(cfg))
+	if err != nil {
+		t.Fatalf("framework.New() error = %v", err)
+	}
+	huma.Register(app.API(), huma.Operation{
+		OperationID: "list-widgets",
+		Method:      http.MethodGet,
+		Path:        app.Config().API.Prefix + "/widgets",
+		Summary:     "List widgets",
+	}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+	app.Router().GET("/raw/ping", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok"}})
+	})
+
+	server := httptest.NewServer(app.Router())
+	t.Cleanup(server.Close)
+
+	out := filepath.Join(t.TempDir(), "openapi.json")
+	stdout := new(bytes.Buffer)
+	err = run(context.Background(), []string{
+		"openapi", "generate",
+		"--url", server.URL + "/openapi.json",
+		"--out", out,
+	}, stdout, ioDiscard{})
+	if err != nil {
+		t.Fatalf("run() error = %v, want nil", err)
+	}
+	// #nosec G304 -- out is built from t.TempDir
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read generated spec: %v", err)
+	}
+	if !strings.Contains(string(got), "/api/v1/widgets") {
+		t.Fatalf("generated spec missing live Huma route; body=%s", got)
+	}
+	if strings.Contains(string(got), "/raw/ping") {
+		t.Fatal("generated spec unexpectedly contains raw Gin route")
+	}
+
+	docs, err := http.Get(server.URL + "/docs")
+	if err != nil {
+		t.Fatalf("GET /docs: %v", err)
+	}
+	t.Cleanup(func() { _ = docs.Body.Close() })
+	if docs.StatusCode != http.StatusOK {
+		t.Fatalf("GET /docs status = %d, want %d", docs.StatusCode, http.StatusOK)
+	}
+}
+
+func TestRunOpenAPIGenerateWritesValidatedSpec(t *testing.T) {
+	spec := `{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Gombit",
+    "version": "0.0.0"
+  },
+  "paths": {
+    "/api/v1/widgets": {
+      "get": {
+        "operationId": "list-widgets",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openapi.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(spec))
+	}))
+	t.Cleanup(server.Close)
+
+	out := filepath.Join(t.TempDir(), "openapi.json")
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err := run(context.Background(), []string{
+		"openapi", "generate",
+		"--url", server.URL + "/openapi.json",
+		"--out", out,
+	}, stdout, stderr)
+	if err != nil {
+		t.Fatalf("run() error = %v, want nil; stderr=%q", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), out) {
+		t.Fatalf("stdout = %q, want output path %q", stdout.String(), out)
+	}
+	// #nosec G304 -- out is built from t.TempDir
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read generated spec: %v", err)
+	}
+	if !strings.Contains(string(got), "/api/v1/widgets") {
+		t.Fatalf("generated spec missing live route; body=%s", got)
+	}
+	if strings.Contains(string(got), "/raw/ping") {
+		t.Fatal("generated spec unexpectedly contains raw Gin route")
+	}
+}
+
+func TestRunOpenAPIGenerateRejectsInvalidSpec(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"not":"openapi"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := run(context.Background(), []string{
+		"openapi", "generate",
+		"--url", server.URL,
+		"--out", filepath.Join(t.TempDir(), "openapi.json"),
+	}, ioDiscard{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("run() error = nil, want invalid spec error")
+	}
+	if !strings.Contains(err.Error(), "OpenAPI") {
+		t.Fatalf("run() error = %q, want OpenAPI validation message", err)
+	}
+}
+
+func TestRunOpenAPIGenerateRejectsBadURL(t *testing.T) {
+	err := run(context.Background(), []string{
+		"openapi", "generate",
+		"--url", "file:///tmp/openapi.json",
+	}, ioDiscard{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("run() error = nil, want scheme error")
+	}
+	if !strings.Contains(err.Error(), "http or https") {
+		t.Fatalf("run() error = %q, want scheme message", err)
+	}
+}
+
+func TestRunRejectsUnknownOpenAPISubcommand(t *testing.T) {
+	err := run(context.Background(), []string{"openapi", "unknown"}, ioDiscard{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("run() error = nil, want unknown subcommand error")
+	}
+	if !strings.Contains(err.Error(), "unknown subcommand") {
+		t.Fatalf("run() error = %q, want unknown subcommand message", err)
 	}
 }
 

--- a/cmd/gombit/main_test.go
+++ b/cmd/gombit/main_test.go
@@ -247,6 +247,48 @@ func TestRunOpenAPIGenerateRejectsInvalidSpec(t *testing.T) {
 	}
 }
 
+func TestRunOpenAPIGenerateRejectsOversizedSpec(t *testing.T) {
+	previous := maxOpenAPISize
+	maxOpenAPISize = 16
+	t.Cleanup(func() { maxOpenAPISize = previous })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"openapi":"3.1.0","info":{"title":"t","version":"0"},"paths":{}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := run(context.Background(), []string{
+		"openapi", "generate",
+		"--url", server.URL,
+		"--out", filepath.Join(t.TempDir(), "openapi.json"),
+	}, ioDiscard{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("run() error = nil, want oversized spec error")
+	}
+	if !strings.Contains(err.Error(), "exceeds 8MiB") {
+		t.Fatalf("run() error = %q, want exceeds 8MiB", err)
+	}
+}
+
+func TestRunRejectsUnknownCommandUsageListsFamilies(t *testing.T) {
+	stderr := new(bytes.Buffer)
+	err := run(context.Background(), []string{"unknown"}, ioDiscard{}, stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want unknown command error")
+	}
+	got := stderr.String()
+	if !strings.Contains(got, "openapi generate") {
+		t.Fatalf("usage = %q, want openapi generate", got)
+	}
+	if !strings.Contains(got, "see gombit db") {
+		t.Fatalf("usage = %q, want pointer to gombit db", got)
+	}
+	if strings.Contains(got, "makemigrations") {
+		t.Fatalf("usage = %q, does not want full db help", got)
+	}
+}
+
 func TestRunOpenAPIGenerateRejectsBadURL(t *testing.T) {
 	err := run(context.Background(), []string{
 		"openapi", "generate",

--- a/cmd/gombit/openapi.go
+++ b/cmd/gombit/openapi.go
@@ -17,9 +17,15 @@ import (
 	openapivalidator "github.com/pb33f/libopenapi-validator"
 )
 
-const defaultOpenAPIURL = "http://127.0.0.1:8080/openapi.json"
+const (
+	defaultOpenAPIURL     = "http://127.0.0.1:8080/openapi.json"
+	defaultMaxOpenAPISize = 8 << 20
+)
 
-var openAPIHTTPClient = &http.Client{Timeout: 30 * time.Second}
+var (
+	openAPIHTTPClient = &http.Client{Timeout: 30 * time.Second}
+	maxOpenAPISize    int64 = defaultMaxOpenAPISize
+)
 
 func runOpenAPI(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
 	if len(args) == 0 {
@@ -81,9 +87,12 @@ func fetchOpenAPI(ctx context.Context, rawURL string) ([]byte, error) {
 		return nil, fmt.Errorf("gombit openapi generate: fetch %s: %w", parsed.String(), err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxOpenAPISize+1))
 	if err != nil {
 		return nil, fmt.Errorf("gombit openapi generate: read response: %w", err)
+	}
+	if int64(len(body)) > maxOpenAPISize {
+		return nil, fmt.Errorf("gombit openapi generate: spec exceeds 8MiB")
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("gombit openapi generate: GET %s: status %d", parsed.String(), resp.StatusCode)

--- a/cmd/gombit/openapi.go
+++ b/cmd/gombit/openapi.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/pb33f/libopenapi"
+	openapivalidator "github.com/pb33f/libopenapi-validator"
+)
+
+const defaultOpenAPIURL = "http://127.0.0.1:8080/openapi.json"
+
+var openAPIHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+func runOpenAPI(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	if len(args) == 0 {
+		openapiUsage(stderr)
+		return errors.New("gombit openapi: subcommand is required")
+	}
+	if args[0] != "generate" {
+		openapiUsage(stderr)
+		return fmt.Errorf("gombit openapi: unknown subcommand %q", args[0])
+	}
+	return runOpenAPIGenerate(ctx, args[1:], stdout, stderr)
+}
+
+func runOpenAPIGenerate(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	flags := flag.NewFlagSet("gombit openapi generate", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	out := flags.String("out", "openapi.json", "output path for the OpenAPI 3.1 document")
+	rawURL := flags.String("url", defaultOpenAPIURL, "URL of the live /openapi.json document")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		flags.Usage()
+		return fmt.Errorf("gombit openapi generate: unexpected argument %q", flags.Arg(0))
+	}
+
+	spec, err := fetchOpenAPI(ctx, *rawURL)
+	if err != nil {
+		return err
+	}
+	if err := validateOpenAPIDocument(spec); err != nil {
+		return fmt.Errorf("gombit openapi generate: %w", err)
+	}
+	if err := contract.WriteOpenAPIFile(*out, spec); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(stdout, "wrote OpenAPI document to %s\n", *out)
+	return err
+}
+
+func fetchOpenAPI(ctx context.Context, rawURL string) ([]byte, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return nil, fmt.Errorf("gombit openapi generate: parse url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("gombit openapi generate: url scheme must be http or https")
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("gombit openapi generate: url host is required")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("gombit openapi generate: build request: %w", err)
+	}
+	resp, err := openAPIHTTPClient.Do(req) //nolint:gosec // URL is a user-supplied CLI flag for the local/live spec
+	if err != nil {
+		return nil, fmt.Errorf("gombit openapi generate: fetch %s: %w", parsed.String(), err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, fmt.Errorf("gombit openapi generate: read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gombit openapi generate: GET %s: status %d", parsed.String(), resp.StatusCode)
+	}
+	return body, nil
+}
+
+func validateOpenAPIDocument(data []byte) error {
+	document, err := libopenapi.NewDocument(data)
+	if err != nil {
+		return fmt.Errorf("parse OpenAPI document: %w", err)
+	}
+	validator, validatorErrs := openapivalidator.NewValidator(document)
+	if len(validatorErrs) > 0 {
+		return fmt.Errorf("create OpenAPI validator: %v", validatorErrs)
+	}
+	valid, documentErrs := validator.ValidateDocument()
+	if !valid || len(documentErrs) > 0 {
+		return fmt.Errorf("invalid OpenAPI 3.1 document: %v", documentErrs)
+	}
+	return nil
+}
+
+func openapiUsage(w io.Writer) {
+	_, _ = fmt.Fprintln(w, "available openapi subcommands:")
+	_, _ = fmt.Fprintln(w, "  generate [--out openapi.json] [--url http://127.0.0.1:8080/openapi.json]")
+}

--- a/cmd/gombit/openapi.go
+++ b/cmd/gombit/openapi.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -79,7 +80,7 @@ func fetchOpenAPI(ctx context.Context, rawURL string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("gombit openapi generate: fetch %s: %w", parsed.String(), err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
 	if err != nil {
 		return nil, fmt.Errorf("gombit openapi generate: read response: %w", err)
@@ -91,6 +92,18 @@ func fetchOpenAPI(ctx context.Context, rawURL string) ([]byte, error) {
 }
 
 func validateOpenAPIDocument(data []byte) error {
+	var probe map[string]any
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return fmt.Errorf("parse OpenAPI document: %w", err)
+	}
+	version, _ := probe["openapi"].(string)
+	if !strings.HasPrefix(version, "3.1.") && version != "3.1" {
+		if version == "" {
+			return errors.New("parse OpenAPI document: missing openapi 3.1 version")
+		}
+		return fmt.Errorf("parse OpenAPI document: openapi version %q is not 3.1", version)
+	}
+
 	document, err := libopenapi.NewDocument(data)
 	if err != nil {
 		return fmt.Errorf("parse OpenAPI document: %w", err)

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ const (
 	envHTTPTrustedProxies      = "GOMBIT_HTTP_TRUSTED_PROXIES"
 	envHTTPRequestTimeout      = "GOMBIT_HTTP_REQUEST_TIMEOUT"
 	envAPIPrefix               = "GOMBIT_API_PREFIX"
+	envDocsEnabled             = "GOMBIT_DOCS_ENABLED"
 	envDatabaseDriver          = "GOMBIT_DATABASE_DRIVER"
 	envDatabaseDSN             = "GOMBIT_DATABASE_DSN"
 	envDatabaseMaxOpenConns    = "GOMBIT_DATABASE_MAX_OPEN_CONNS"
@@ -68,7 +69,8 @@ type HTTPConfig struct {
 
 // APIConfig contains public API configuration.
 type APIConfig struct {
-	Prefix string
+	Prefix      string
+	DocsEnabled bool
 }
 
 // DatabaseDriver names a supported SQL database driver.
@@ -169,7 +171,8 @@ func Default() Config {
 			RequestTimeout: 60 * time.Second,
 		},
 		API: APIConfig{
-			Prefix: "/api/v1",
+			Prefix:      "/api/v1",
+			DocsEnabled: true,
 		},
 		Database: DatabaseConfig{
 			Driver: DatabaseDriverSQLite,
@@ -209,6 +212,7 @@ func LoadFromEnv(lookup EnvLookup) (Config, error) {
 	applyString(lookup, envHTTPAddr, &cfg.HTTP.Addr)
 	applyStringList(lookup, envHTTPTrustedProxies, &cfg.HTTP.TrustedProxies)
 	applyString(lookup, envAPIPrefix, &cfg.API.Prefix)
+	_, docsEnabledSet := lookup(envDocsEnabled)
 
 	var errs FieldErrors
 	applyDuration(
@@ -246,6 +250,11 @@ func LoadFromEnv(lookup EnvLookup) (Config, error) {
 	}
 	applyLogLevel(lookup, envLogLevel, &cfg.Logging.Level)
 	applyLogSink(lookup, envLogSink, &cfg.Logging.Sink)
+	if docsEnabledSet {
+		applyBool(lookup, envDocsEnabled, "API.DocsEnabled", &cfg.API.DocsEnabled, &errs)
+	} else if cfg.Environment == EnvironmentProduction {
+		cfg.API.DocsEnabled = false
+	}
 
 	if err := cfg.Validate(); err != nil {
 		var fieldErrors FieldErrors

--- a/config/config.go
+++ b/config/config.go
@@ -69,7 +69,12 @@ type HTTPConfig struct {
 
 // APIConfig contains public API configuration.
 type APIConfig struct {
-	Prefix      string
+	Prefix string
+	// DocsEnabled serves the FastAPI-style UI at /docs.
+	// Default() (development) leaves this true. Changing Environment on a
+	// Default() value does not flip it — use DefaultFor(env) or set this
+	// field. LoadFromEnv uses DefaultDocsEnabled when GOMBIT_DOCS_ENABLED
+	// is unset.
 	DocsEnabled bool
 }
 
@@ -161,18 +166,30 @@ type LoggingConfig struct {
 // EnvLookup reads an environment variable by name.
 type EnvLookup func(key string) (value string, ok bool)
 
-// Default returns the default development configuration.
+// Default returns the default development configuration, including /docs on.
+// It does not follow Environment: mutating Environment on the result leaves
+// DocsEnabled and the cache namespace at development values. Use DefaultFor
+// when constructing a non-development config for framework.WithConfig.
 func Default() Config {
+	return DefaultFor(EnvironmentDevelopment)
+}
+
+// DefaultFor returns Default-shaped configuration for env, including
+// environment-derived DocsEnabled and cache namespace.
+func DefaultFor(env Environment) Config {
+	if env == "" {
+		env = EnvironmentDevelopment
+	}
 	return Config{
 		AppName:     "Gombit",
-		Environment: EnvironmentDevelopment,
+		Environment: env,
 		HTTP: HTTPConfig{
 			Addr:           ":8080",
 			RequestTimeout: 60 * time.Second,
 		},
 		API: APIConfig{
 			Prefix:      "/api/v1",
-			DocsEnabled: true,
+			DocsEnabled: DefaultDocsEnabled(env),
 		},
 		Database: DatabaseConfig{
 			Driver: DatabaseDriverSQLite,
@@ -180,7 +197,7 @@ func Default() Config {
 		},
 		Cache: CacheConfig{
 			Driver:    CacheDriverMemory,
-			Namespace: DefaultCacheNamespace("Gombit", EnvironmentDevelopment),
+			Namespace: DefaultCacheNamespace("Gombit", env),
 			Redis: RedisConfig{
 				Addr:         "127.0.0.1:6379",
 				DialTimeout:  5 * time.Second,
@@ -193,6 +210,21 @@ func Default() Config {
 			Sink:  LogSinkStderr,
 		},
 	}
+}
+
+// DefaultDocsEnabled reports whether /docs is on when GOMBIT_DOCS_ENABLED is
+// unset. Production is off; development and test are on.
+func DefaultDocsEnabled(env Environment) bool {
+	return env != EnvironmentProduction
+}
+
+// ApplyEnvironmentDefaults sets fields that follow Environment when the
+// caller did not set them explicitly. LoadFromEnv uses this when
+// GOMBIT_DOCS_ENABLED is unset. WithConfig callers that only change
+// Environment on Default() should use DefaultFor instead.
+func ApplyEnvironmentDefaults(cfg Config) Config {
+	cfg.API.DocsEnabled = DefaultDocsEnabled(cfg.Environment)
+	return cfg
 }
 
 // Load reads configuration from the process environment and validates it.
@@ -252,8 +284,8 @@ func LoadFromEnv(lookup EnvLookup) (Config, error) {
 	applyLogSink(lookup, envLogSink, &cfg.Logging.Sink)
 	if docsEnabledSet {
 		applyBool(lookup, envDocsEnabled, "API.DocsEnabled", &cfg.API.DocsEnabled, &errs)
-	} else if cfg.Environment == EnvironmentProduction {
-		cfg.API.DocsEnabled = false
+	} else {
+		cfg = ApplyEnvironmentDefaults(cfg)
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,9 @@ func TestDefault(t *testing.T) {
 	if got.API.Prefix != "/api/v1" {
 		t.Fatalf("API.Prefix = %q, want %q", got.API.Prefix, "/api/v1")
 	}
+	if !got.API.DocsEnabled {
+		t.Fatal("API.DocsEnabled = false, want true")
+	}
 	if got.Database.Driver != DatabaseDriverSQLite {
 		t.Fatalf("Database.Driver = %q, want %q", got.Database.Driver, DatabaseDriverSQLite)
 	}
@@ -94,7 +97,8 @@ func TestLoadFromEnv(t *testing.T) {
 			RequestTimeout: 15 * time.Second,
 		},
 		API: APIConfig{
-			Prefix: "/api",
+			Prefix:      "/api",
+			DocsEnabled: true,
 		},
 		Database: DatabaseConfig{
 			Driver:          DatabaseDriverPostgres,
@@ -125,6 +129,43 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("LoadFromEnv() = %#v, want %#v", got, want)
+	}
+}
+
+func TestLoadFromEnvDisablesDocsInProductionByDefault(t *testing.T) {
+	got, err := LoadFromEnv(mapLookup(map[string]string{
+		envEnv: string(EnvironmentProduction),
+	}))
+	if err != nil {
+		t.Fatalf("LoadFromEnv() error = %v, want nil", err)
+	}
+	if got.API.DocsEnabled {
+		t.Fatal("API.DocsEnabled = true, want false in production when unset")
+	}
+}
+
+func TestLoadFromEnvAllowsDocsInProductionWhenEnabled(t *testing.T) {
+	got, err := LoadFromEnv(mapLookup(map[string]string{
+		envEnv:         string(EnvironmentProduction),
+		envDocsEnabled: "true",
+	}))
+	if err != nil {
+		t.Fatalf("LoadFromEnv() error = %v, want nil", err)
+	}
+	if !got.API.DocsEnabled {
+		t.Fatal("API.DocsEnabled = false, want true when GOMBIT_DOCS_ENABLED=true")
+	}
+}
+
+func TestLoadFromEnvDisablesDocsWhenExplicitlyOff(t *testing.T) {
+	got, err := LoadFromEnv(mapLookup(map[string]string{
+		envDocsEnabled: "false",
+	}))
+	if err != nil {
+		t.Fatalf("LoadFromEnv() error = %v, want nil", err)
+	}
+	if got.API.DocsEnabled {
+		t.Fatal("API.DocsEnabled = true, want false when GOMBIT_DOCS_ENABLED=false")
 	}
 }
 
@@ -174,7 +215,8 @@ func TestLoadUsesProcessEnvironment(t *testing.T) {
 			RequestTimeout: 60 * time.Second,
 		},
 		API: APIConfig{
-			Prefix: "/api",
+			Prefix:      "/api",
+			DocsEnabled: false,
 		},
 		Database: DatabaseConfig{
 			Driver: DatabaseDriverMySQL,
@@ -214,7 +256,8 @@ func TestValidateReportsExplicitFieldErrors(t *testing.T) {
 			RequestTimeout: -time.Second,
 		},
 		API: APIConfig{
-			Prefix: "api",
+			Prefix:      "api",
+			DocsEnabled: true,
 		},
 		Database: DatabaseConfig{
 			Driver:          "oracle",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -132,6 +132,42 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 }
 
+func TestDefaultForAppliesEnvironmentDocsAndNamespace(t *testing.T) {
+	dev := DefaultFor(EnvironmentDevelopment)
+	if !dev.API.DocsEnabled {
+		t.Fatal("DefaultFor(development) DocsEnabled = false, want true")
+	}
+	if dev.Cache.Namespace != "gombit:development" {
+		t.Fatalf("DefaultFor(development) Namespace = %q", dev.Cache.Namespace)
+	}
+
+	prod := DefaultFor(EnvironmentProduction)
+	if prod.Environment != EnvironmentProduction {
+		t.Fatalf("DefaultFor(production) Environment = %q", prod.Environment)
+	}
+	if prod.API.DocsEnabled {
+		t.Fatal("DefaultFor(production) DocsEnabled = true, want false")
+	}
+	if prod.Cache.Namespace != "gombit:production" {
+		t.Fatalf("DefaultFor(production) Namespace = %q", prod.Cache.Namespace)
+	}
+	if !Default().API.DocsEnabled {
+		t.Fatal("Default() DocsEnabled = false, want development default true")
+	}
+}
+
+func TestApplyEnvironmentDefaultsSetsDocsFromEnvironment(t *testing.T) {
+	cfg := Default()
+	cfg.Environment = EnvironmentProduction
+	if !cfg.API.DocsEnabled {
+		t.Fatal("precondition: Default()+production still has DocsEnabled true")
+	}
+	got := ApplyEnvironmentDefaults(cfg)
+	if got.API.DocsEnabled {
+		t.Fatal("ApplyEnvironmentDefaults(production) DocsEnabled = true, want false")
+	}
+}
+
 func TestLoadFromEnvDisablesDocsInProductionByDefault(t *testing.T) {
 	got, err := LoadFromEnv(mapLookup(map[string]string{
 		envEnv: string(EnvironmentProduction),

--- a/contract/doc.go
+++ b/contract/doc.go
@@ -19,5 +19,8 @@
 //
 //	{"error":{"code":"not_found","message":"...","request_id":"..."}}
 //
-// See docs/contract.md.
+// OpenAPI 3.1 is served at /openapi.json. Interactive docs are at /docs when
+// enabled. Use OpenAPIJSON / WriteOpenAPI to persist the live spec.
+//
+// See docs/contract.md and docs/openapi.md.
 package contract

--- a/contract/huma_config.go
+++ b/contract/huma_config.go
@@ -2,11 +2,23 @@ package contract
 
 import "github.com/danielgtaylor/huma/v2"
 
+const (
+	// OpenAPIPath is the Huma OpenAPI prefix. Clients fetch /openapi.json.
+	OpenAPIPath = "/openapi"
+	// DocsPath is the FastAPI-style interactive docs UI.
+	DocsPath = "/docs"
+)
+
 // HumaConfig returns the default Huma configuration for a Gombit app.
 //
-// Docs and schema browser routes stay disabled; OpenAPI JSON remains available
-// for local inspection until M3-3 owns the generate CLI.
+// Interactive docs are enabled at /docs (Swagger UI). The schema browser stays
+// disabled. Pass docsEnabled=false to omit the docs route (production default).
 func HumaConfig(title, version string) huma.Config {
+	return HumaConfigFor(title, version, true)
+}
+
+// HumaConfigFor returns Huma configuration with docs explicitly enabled or not.
+func HumaConfigFor(title, version string, docsEnabled bool) huma.Config {
 	if title == "" {
 		title = "Gombit"
 	}
@@ -14,7 +26,13 @@ func HumaConfig(title, version string) huma.Config {
 		version = "0.0.0"
 	}
 	config := huma.DefaultConfig(title, version)
-	config.DocsPath = ""
+	config.OpenAPIPath = OpenAPIPath
 	config.SchemasPath = ""
+	if docsEnabled {
+		config.DocsPath = DocsPath
+		config.DocsRenderer = huma.DocsRendererSwaggerUI
+		return config
+	}
+	config.DocsPath = ""
 	return config
 }

--- a/contract/openapi.go
+++ b/contract/openapi.go
@@ -1,0 +1,58 @@
+package contract
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// OpenAPIJSON marshals the Huma-generated OpenAPI 3.1 document.
+func OpenAPIJSON(api huma.API) ([]byte, error) {
+	if api == nil {
+		return nil, fmt.Errorf("contract: nil API")
+	}
+	spec, err := json.MarshalIndent(api.OpenAPI(), "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("contract: marshal OpenAPI: %w", err)
+	}
+	return spec, nil
+}
+
+// WriteOpenAPI writes the Huma-generated OpenAPI document to path.
+func WriteOpenAPI(path string, api huma.API) error {
+	spec, err := OpenAPIJSON(api)
+	if err != nil {
+		return err
+	}
+	return WriteOpenAPIFile(path, spec)
+}
+
+// WriteOpenAPIFile writes a pre-marshaled OpenAPI document to path.
+func WriteOpenAPIFile(path string, spec []byte) error {
+	if path == "" {
+		return fmt.Errorf("contract: OpenAPI output path is required")
+	}
+	if len(spec) == 0 {
+		return fmt.Errorf("contract: OpenAPI document is empty")
+	}
+	if spec[len(spec)-1] != '\n' {
+		copied := make([]byte, len(spec)+1)
+		copy(copied, spec)
+		copied[len(spec)] = '\n'
+		spec = copied
+	}
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return fmt.Errorf("contract: create OpenAPI directory: %w", err)
+		}
+	}
+	//nolint:gosec // openapi.json is a non-secret artifact meant to be broadly readable
+	if err := os.WriteFile(path, spec, 0o644); err != nil {
+		return fmt.Errorf("contract: write OpenAPI: %w", err)
+	}
+	return nil
+}

--- a/contract/openapi_test.go
+++ b/contract/openapi_test.go
@@ -132,6 +132,13 @@ func TestDocsServesSwaggerUI(t *testing.T) {
 	if !strings.Contains(body, "/openapi") {
 		t.Fatalf("GET /docs missing OpenAPI URL for try-it-out; body: %s", body)
 	}
+	csp := rec.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "unpkg.com/swagger-ui-dist") {
+		t.Fatalf("GET /docs CSP = %q, want Swagger UI script source so try-it-out can load", csp)
+	}
+	if !strings.Contains(csp, "connect-src") || !strings.Contains(csp, "'self'") {
+		t.Fatalf("GET /docs CSP = %q, want connect-src 'self' for try-it-out", csp)
+	}
 	if !strings.Contains(body, "Try it out") && !strings.Contains(strings.ToLower(body), "swagger") {
 		t.Fatalf("GET /docs missing try-it-out UI markers; body: %s", body)
 	}

--- a/contract/openapi_test.go
+++ b/contract/openapi_test.go
@@ -1,0 +1,218 @@
+package contract_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humagin"
+	"github.com/gin-gonic/gin"
+	"github.com/pb33f/libopenapi"
+	openapivalidator "github.com/pb33f/libopenapi-validator"
+)
+
+func TestOpenAPIJSONMatchesServedDocument(t *testing.T) {
+	router, api := newContractAPI(t)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "list-widgets",
+		Method:      http.MethodGet,
+		Path:        "/widgets",
+		Summary:     "List widgets",
+	}, func(ctx context.Context, input *struct{}) (*struct {
+		Body contract.Data[[]string]
+	}, error) {
+		return &struct {
+			Body contract.Data[[]string]
+		}{Body: contract.Data[[]string]{Data: []string{"widget-1"}}}, nil
+	})
+
+	generated, err := contract.OpenAPIJSON(api)
+	if err != nil {
+		t.Fatalf("OpenAPIJSON() error = %v", err)
+	}
+	validateOpenAPI31(t, generated)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/openapi.json", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /openapi.json status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if !jsonEqual(generated, rec.Body.Bytes()) {
+		t.Fatalf("generated OpenAPI JSON differs from served /openapi.json")
+	}
+
+	var spec map[string]any
+	if err := json.Unmarshal(generated, &spec); err != nil {
+		t.Fatalf("decode spec: %v", err)
+	}
+	openapi, _ := spec["openapi"].(string)
+	if !strings.HasPrefix(openapi, "3.1.") {
+		t.Fatalf("openapi = %q, want OpenAPI 3.1.x", openapi)
+	}
+	paths, _ := spec["paths"].(map[string]any)
+	if _, ok := paths["/widgets"]; !ok {
+		t.Fatalf("spec missing /widgets; paths=%v", paths)
+	}
+}
+
+func TestWriteOpenAPIWritesDocument(t *testing.T) {
+	_, api := newContractAPI(t)
+	huma.Register(api, huma.Operation{
+		OperationID: "ping",
+		Method:      http.MethodGet,
+		Path:        "/ping",
+	}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	path := filepath.Join(t.TempDir(), "out", "openapi.json")
+	if err := contract.WriteOpenAPI(path, api); err != nil {
+		t.Fatalf("WriteOpenAPI() error = %v", err)
+	}
+	// #nosec G304 -- path is built from t.TempDir
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written spec: %v", err)
+	}
+	want, err := contract.OpenAPIJSON(api)
+	if err != nil {
+		t.Fatalf("OpenAPIJSON() error = %v", err)
+	}
+	if !jsonEqual(got, append(want, '\n')) && !jsonEqual(got, want) {
+		t.Fatalf("written spec does not match OpenAPIJSON()")
+	}
+	if !strings.HasSuffix(string(got), "\n") {
+		t.Fatal("written spec missing trailing newline")
+	}
+}
+
+func TestOpenAPIJSONRequiresAPI(t *testing.T) {
+	if _, err := contract.OpenAPIJSON(nil); err == nil {
+		t.Fatal("OpenAPIJSON(nil) error = nil, want error")
+	}
+	if err := contract.WriteOpenAPIFile("", []byte(`{}`)); err == nil {
+		t.Fatal("WriteOpenAPIFile empty path error = nil, want error")
+	}
+	if err := contract.WriteOpenAPIFile("openapi.json", nil); err == nil {
+		t.Fatal("WriteOpenAPIFile empty spec error = nil, want error")
+	}
+}
+
+func TestDocsServesSwaggerUI(t *testing.T) {
+	router, api := newContractAPI(t)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-widgets",
+		Method:      http.MethodGet,
+		Path:        "/widgets",
+	}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/docs", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /docs status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	ct := rec.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Fatalf("GET /docs Content-Type = %q, want text/html", ct)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "swagger-ui") {
+		t.Fatalf("GET /docs missing swagger-ui; body: %s", body)
+	}
+	if !strings.Contains(body, "/openapi") {
+		t.Fatalf("GET /docs missing OpenAPI URL for try-it-out; body: %s", body)
+	}
+	if !strings.Contains(body, "Try it out") && !strings.Contains(strings.ToLower(body), "swagger") {
+		t.Fatalf("GET /docs missing try-it-out UI markers; body: %s", body)
+	}
+}
+
+func TestRawGinRouteAbsentFromOpenAPI(t *testing.T) {
+	router, api := newContractAPI(t)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-widgets",
+		Method:      http.MethodGet,
+		Path:        "/widgets",
+	}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+	router.GET("/raw/ping", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok"}})
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/raw/ping", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /raw/ping status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	spec, err := contract.OpenAPIJSON(api)
+	if err != nil {
+		t.Fatalf("OpenAPIJSON() error = %v", err)
+	}
+	if strings.Contains(string(spec), "/raw/ping") {
+		t.Fatal("raw Gin route /raw/ping unexpectedly appears in OpenAPI")
+	}
+	if strings.Contains(string(spec), "\"/docs\"") {
+		t.Fatal("docs UI unexpectedly appears in OpenAPI paths")
+	}
+}
+
+func newContractAPI(t *testing.T) (*gin.Engine, huma.API) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	api := humagin.New(router, contract.HumaConfig("contract-test", "0.0.0"))
+	return router, api
+}
+
+func validateOpenAPI31(t *testing.T, data []byte) {
+	t.Helper()
+
+	document, err := libopenapi.NewDocument(data)
+	if err != nil {
+		t.Fatalf("parse OpenAPI document: %v", err)
+	}
+	validator, validatorErrs := openapivalidator.NewValidator(document)
+	if len(validatorErrs) > 0 {
+		t.Fatalf("create OpenAPI validator: %v", validatorErrs)
+	}
+	valid, documentErrs := validator.ValidateDocument()
+	if !valid || len(documentErrs) > 0 {
+		t.Fatalf("validate OpenAPI 3.1 document: valid=%v errors=%v", valid, documentErrs)
+	}
+}
+
+func jsonEqual(left, right []byte) bool {
+	var leftValue any
+	var rightValue any
+	if err := json.Unmarshal(left, &leftValue); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(right, &rightValue); err != nil {
+		return false
+	}
+	return jsonEqualValue(leftValue, rightValue)
+}
+
+func jsonEqualValue(left, right any) bool {
+	leftBytes, err := json.Marshal(left)
+	if err != nil {
+		return false
+	}
+	rightBytes, err := json.Marshal(right)
+	if err != nil {
+		return false
+	}
+	return string(leftBytes) == string(rightBytes)
+}

--- a/contract/validation_test.go
+++ b/contract/validation_test.go
@@ -69,19 +69,27 @@ func TestValidationReturnsD10FieldErrors(t *testing.T) {
 	}
 }
 
-func TestHumaConfigDisablesDocsAndSchemas(t *testing.T) {
+func TestHumaConfigEnablesDocsAndDisablesSchemas(t *testing.T) {
 	cfg := contract.HumaConfig("Demo", "1.2.3")
-	if cfg.DocsPath != "" {
-		t.Fatalf("DocsPath = %q, want empty", cfg.DocsPath)
+	if cfg.DocsPath != contract.DocsPath {
+		t.Fatalf("DocsPath = %q, want %q", cfg.DocsPath, contract.DocsPath)
+	}
+	if cfg.DocsRenderer != huma.DocsRendererSwaggerUI {
+		t.Fatalf("DocsRenderer = %q, want %q", cfg.DocsRenderer, huma.DocsRendererSwaggerUI)
 	}
 	if cfg.SchemasPath != "" {
 		t.Fatalf("SchemasPath = %q, want empty", cfg.SchemasPath)
 	}
-	if cfg.OpenAPIPath != "/openapi" {
-		t.Fatalf("OpenAPIPath = %q, want /openapi", cfg.OpenAPIPath)
+	if cfg.OpenAPIPath != contract.OpenAPIPath {
+		t.Fatalf("OpenAPIPath = %q, want %q", cfg.OpenAPIPath, contract.OpenAPIPath)
 	}
 	if cfg.Info == nil || cfg.Info.Title != "Demo" || cfg.Info.Version != "1.2.3" {
 		t.Fatalf("Info = %#v, want Demo/1.2.3", cfg.Info)
+	}
+
+	disabled := contract.HumaConfigFor("Demo", "1.2.3", false)
+	if disabled.DocsPath != "" {
+		t.Fatalf("HumaConfigFor(docs=false) DocsPath = %q, want empty", disabled.DocsPath)
 	}
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,7 +6,10 @@ runtime packages.
 
 ## Defaults
 
-`config.Default()` returns the current development defaults:
+`config.Default()` returns the current development defaults
+(`config.DefaultFor(development)`). `config.DefaultFor(env)` applies the same
+shape with environment-derived `/docs` and cache namespace. Mutating
+`Environment` on `Default()` does not flip those fields.
 
 - app name: `Gombit`
 - environment: `development`

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,6 +13,7 @@ runtime packages.
 - HTTP address: `:8080`
 - HTTP request timeout: `60s`
 - API prefix: `/api/v1`
+- interactive API docs: enabled (`/docs`)
 - database driver: `sqlite`
 - database DSN: `file:gombit.db?cache=shared&_fk=1`
 - cache driver: `memory`
@@ -34,6 +35,7 @@ configuration. The M1-1 boundary recognizes:
 | `GOMBIT_HTTP_TRUSTED_PROXIES` | `Config.HTTP.TrustedProxies` | unset |
 | `GOMBIT_HTTP_REQUEST_TIMEOUT` | `Config.HTTP.RequestTimeout` | `60s` |
 | `GOMBIT_API_PREFIX` | `Config.API.Prefix` | `/api/v1` |
+| `GOMBIT_DOCS_ENABLED` | `Config.API.DocsEnabled` | `true` (off in production when unset) |
 | `GOMBIT_DATABASE_DRIVER` | `Config.Database.Driver` | `sqlite` |
 | `GOMBIT_DATABASE_DSN` | `Config.Database.DSN` | `file:gombit.db?cache=shared&_fk=1` |
 | `GOMBIT_DATABASE_MAX_OPEN_CONNS` | `Config.Database.MaxOpenConns` | `0` |
@@ -69,6 +71,9 @@ The value sets the cooperative per-request context deadline and the
 `GOMBIT_DATABASE_CONN_MAX_LIFETIME` uses Go duration syntax such as `30m` or
 `1h`.
 Redis timeout values use the same Go duration syntax.
+`GOMBIT_DOCS_ENABLED` accepts boolean values (`true`/`false`, `1`/`0`,
+`yes`/`no`, `on`/`off`). When unset, docs stay on in `development` and `test`
+and turn off in `production`. `/openapi.json` is always served.
 `GOMBIT_LOG_LEVEL` accepts `debug`, `info`, `warn`, and `error`.
 `GOMBIT_LOG_SINK` accepts `stderr`, `stdout`, and `mongo`; Mongo logging is an
 external module hook, not a runtime dependency.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -4,8 +4,9 @@ Gombit's public API contract conventions: Huma-typed handlers over Gin, D10
 success/error envelopes, validation tags → structured `fields`, and draft §41
 application error categories mapped centrally to HTTP status codes.
 
-ADR-011 selected Huma as the contract layer. OpenAPI CLI generation belongs to
-M3-3; the TypeScript client belongs to M3-4.
+ADR-011 selected Huma as the contract layer. OpenAPI emission, `/docs`, and
+`gombit openapi generate` are documented in [`docs/openapi.md`](openapi.md).
+The TypeScript client belongs to M3-4.
 
 ## Registering contract routes
 
@@ -156,15 +157,16 @@ validation still uses the Install path and always yields `validation_error`.
 The `validation_error` code is preserved from M3-1 / D10 (not renamed to
 `validation`).
 
-## OpenAPI preview
+## OpenAPI
 
-With the default Huma config, `/openapi.json` is served for local inspection and
-reflects the D10 `ErrorEnvelope` schema. `gombit openapi generate` and CI drift
-checks land in M3-3 / M3-5.
+`/openapi.json` is served from the Huma API and reflects the D10
+`ErrorEnvelope` schema. `/docs` is the FastAPI-style Swagger UI (on by default
+in local/dev). `gombit openapi generate` writes the live spec to disk. See
+[`docs/openapi.md`](openapi.md).
 
 ## What is not here yet
 
-- `gombit openapi generate` / `/docs` UI (M3-3)
 - TypeScript client generation (M3-4)
+- CI contract drift check (M3-5)
 - Pagination query DSL / filter/sort helpers (design §42)
 - gRPC status mapping (post-v0.1)

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -38,7 +38,11 @@ available so codegen and drift checks still work.
 | --- | --- | --- |
 | `GOMBIT_DOCS_ENABLED` | `Config.API.DocsEnabled` | `true` outside production; `false` in production when unset |
 
-Applications that pass `framework.WithConfig` set `API.DocsEnabled` explicitly.
+`config.Default()` is the development preset (`DocsEnabled` true). Changing
+only `Environment` on that value does not turn docs off. Use
+`config.DefaultFor(env)` or set `API.DocsEnabled` when passing
+`framework.WithConfig`. `config.Load` / `LoadFromEnv` apply
+`DefaultDocsEnabled` when `GOMBIT_DOCS_ENABLED` is unset.
 `contract.HumaConfigFor(title, version, docsEnabled)` is the Huma helper
 `framework.New` uses.
 
@@ -65,7 +69,10 @@ if err != nil {
 return contract.WriteOpenAPI("openapi.json", app.API())
 ```
 
-`contract.OpenAPIJSON` matches the bytes served at `/openapi.json`.
+`contract.OpenAPIJSON` is semantically identical to `GET /openapi.json` (same
+document; `OpenAPIJSON` pretty-prints, Huma's route does not). The CLI writes
+the fetched live bytes. Do not treat whitespace-only differences as contract
+drift (M3-5).
 
 ## What is not here yet
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -20,7 +20,10 @@ curl -sS http://127.0.0.1:8080/openapi.json
 ```
 
 Try-it-out requests hit the running app, so D10 validation and category errors
-appear as they would for any client.
+appear as they would for any client. The docs page uses Huma's Swagger UI
+renderer and loads the UI assets from `unpkg.com`; Huma sets a page-specific
+CSP (`connect-src 'self'`) so try-it-out can call the same origin. Other
+routes keep the runtime `default-src 'self'` policy.
 
 Raw `app.Router()` routes (webhooks, SSE, probes, metrics) stay out of the
 OpenAPI document and therefore out of `/docs`.

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,0 +1,70 @@
+# OpenAPI emission and docs
+
+Gombit emits OpenAPI 3.1 from Huma-typed handlers. The live document is served
+at `/openapi.json`. A FastAPI-style interactive docs UI is served at `/docs`
+in local and test environments. `gombit openapi generate` writes that document
+to disk.
+
+## Live surfaces
+
+| Surface | URL | Role |
+| --- | --- | --- |
+| OpenAPI document | `/openapi.json` | Machine-readable contract (CLI, CI, codegen) |
+| Interactive docs | `/docs` | Swagger UI backed by `/openapi.json`, with try-it-out against the same server |
+
+`examples/contract` registers Huma widget routes. After `go run ./examples/contract`:
+
+```sh
+curl -sS http://127.0.0.1:8080/openapi.json
+# open http://127.0.0.1:8080/docs
+```
+
+Try-it-out requests hit the running app, so D10 validation and category errors
+appear as they would for any client.
+
+Raw `app.Router()` routes (webhooks, SSE, probes, metrics) stay out of the
+OpenAPI document and therefore out of `/docs`.
+
+## Production
+
+Docs are on by default in `development` and `test`. `config.Load` turns them
+off in `production` unless `GOMBIT_DOCS_ENABLED=true`. `/openapi.json` stays
+available so codegen and drift checks still work.
+
+| Variable | Field | Default |
+| --- | --- | --- |
+| `GOMBIT_DOCS_ENABLED` | `Config.API.DocsEnabled` | `true` outside production; `false` in production when unset |
+
+Applications that pass `framework.WithConfig` set `API.DocsEnabled` explicitly.
+`contract.HumaConfigFor(title, version, docsEnabled)` is the Huma helper
+`framework.New` uses.
+
+## Write the spec to disk
+
+With the app running:
+
+```sh
+go run ./cmd/gombit openapi generate \
+  --url http://127.0.0.1:8080/openapi.json \
+  --out openapi.json
+```
+
+`--url` defaults to `http://127.0.0.1:8080/openapi.json`. `--out` defaults to
+`openapi.json`. The CLI validates the document as OpenAPI 3.1 before writing.
+
+In-process generation (tests, `go:generate`) uses the same helpers:
+
+```go
+spec, err := contract.OpenAPIJSON(app.API())
+if err != nil {
+    return err
+}
+return contract.WriteOpenAPI("openapi.json", app.API())
+```
+
+`contract.OpenAPIJSON` matches the bytes served at `/openapi.json`.
+
+## What is not here yet
+
+- TypeScript client generation (`gombit client generate`): M3-4
+- CI drift check that fails when the spec is stale: M3-5

--- a/docs/router.md
+++ b/docs/router.md
@@ -2,8 +2,9 @@
 
 M1-3 de-domains the router introduced in M1-2: `framework.New` builds a
 `*gin.Engine` with zero knowledge of any application domain and mounts only
-its own endpoints. Today that means `/livez`, `/readyz`, `/metrics`, and the
-Huma OpenAPI preview routes (`/openapi.json` and siblings). Public API handlers
+its own endpoints. Today that means `/livez`, `/readyz`, `/metrics`, the Huma
+OpenAPI routes (`/openapi.json` and siblings), and `/docs` when
+`API.DocsEnabled` is true. Public API handlers
 register on `app.API()` (see [`docs/contract.md`](contract.md)); raw Gin routes
 continue to use `app.Router()`.
 
@@ -131,7 +132,9 @@ Contract DTOs, validation → D10 field errors, and `app.API()` are documented i
 CORS, rate limiting, or authentication middleware:
 
 - auth middleware: M5
-- `gombit openapi generate` CLI: M3-3
+
+OpenAPI emission, `/docs`, and `gombit openapi generate` are documented in
+[`docs/openapi.md`](openapi.md).
 
 Until then, an application that needs middleware can add it directly via
 `app.Router().Use(...)` or on its own route groups; the framework will not

--- a/examples/config/main.go
+++ b/examples/config/main.go
@@ -13,5 +13,5 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("%s listens on %s with API prefix %s\n", cfg.AppName, cfg.HTTP.Addr, cfg.API.Prefix)
+	fmt.Printf("%s listens on %s with API prefix %s (docs enabled=%t)\n", cfg.AppName, cfg.HTTP.Addr, cfg.API.Prefix, cfg.API.DocsEnabled)
 }

--- a/examples/contract/README.md
+++ b/examples/contract/README.md
@@ -1,12 +1,23 @@
 # Contract example
 
-Demonstrates Huma DTOs, D10 validation errors, success `meta`, and §41
-category errors (`not_found`) on `framework.App.API()`.
+Demonstrates Huma DTOs, D10 validation errors, success `meta`, §41
+category errors (`not_found`), `/openapi.json`, and the `/docs` try-it-out UI
+on `framework.App.API()`.
 
 ## Run
 
 ```sh
 go run ./examples/contract
+```
+
+Open [http://127.0.0.1:8080/docs](http://127.0.0.1:8080/docs) for Swagger UI.
+Try-it-out calls this same process. Raw Gin routes are not listed there.
+
+```sh
+curl -sS http://127.0.0.1:8080/openapi.json
+go run ./cmd/gombit openapi generate \
+  --url http://127.0.0.1:8080/openapi.json \
+  --out /tmp/gombit-openapi.json
 ```
 
 ## List (data + page meta)
@@ -50,4 +61,5 @@ curl -sS -X POST http://127.0.0.1:8080/api/v1/widgets \
   -d '{}'
 ```
 
-See [`docs/contract.md`](../../docs/contract.md).
+See [`docs/contract.md`](../../docs/contract.md) and
+[`docs/openapi.md`](../../docs/openapi.md).

--- a/framework/app.go
+++ b/framework/app.go
@@ -131,6 +131,9 @@ func New(options ...Option) (*App, error) {
 }
 
 // WithConfig sets the app configuration.
+// DocsEnabled is taken as given: Default() leaves /docs on even if you later
+// set Environment to production. Use config.DefaultFor(env) or set
+// API.DocsEnabled yourself.
 func WithConfig(cfg config.Config) Option {
 	return func(app *App) error {
 		if err := cfg.Validate(); err != nil {

--- a/framework/app.go
+++ b/framework/app.go
@@ -114,7 +114,7 @@ func New(options ...Option) (*App, error) {
 			RequestID: GetRequestIDFromContext,
 		})
 		// OpenAPI Info.Version stays 0.0.0 until runtime versioning lands.
-		app.api = humagin.New(app.router, contract.HumaConfig(app.cfg.AppName, "0.0.0"))
+		app.api = humagin.New(app.router, contract.HumaConfigFor(app.cfg.AppName, "0.0.0", app.cfg.API.DocsEnabled))
 	}
 	if app.cache == nil {
 		store, err := cache.Open(app.cfg.Cache)

--- a/framework/contract_test.go
+++ b/framework/contract_test.go
@@ -157,6 +157,23 @@ func TestAPIDocsServesSwaggerUIAndOmitsRawRoutes(t *testing.T) {
 	}
 }
 
+func TestAPIDocsOffForDefaultForProduction(t *testing.T) {
+	previousMode := gin.Mode()
+	t.Cleanup(func() {
+		gin.SetMode(previousMode)
+	})
+
+	cfg := config.DefaultFor(config.EnvironmentProduction)
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	app := newTestApp(t, WithConfig(cfg))
+
+	docs := httptest.NewRecorder()
+	app.Router().ServeHTTP(docs, httptest.NewRequest(http.MethodGet, "/docs", nil))
+	if docs.Code != http.StatusNotFound {
+		t.Fatalf("GET /docs status = %d, want %d for DefaultFor(production)", docs.Code, http.StatusNotFound)
+	}
+}
+
 func TestAPIDocsCanBeDisabled(t *testing.T) {
 	cfg := config.Default()
 	cfg.Environment = config.EnvironmentTest

--- a/framework/contract_test.go
+++ b/framework/contract_test.go
@@ -128,6 +128,10 @@ func TestAPIDocsServesSwaggerUIAndOmitsRawRoutes(t *testing.T) {
 	if !strings.Contains(docs.Body.String(), "/openapi") {
 		t.Fatalf("GET /docs missing OpenAPI URL for try-it-out; body: %s", docs.Body.String())
 	}
+	csp := docs.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "unpkg.com/swagger-ui-dist") || !strings.Contains(csp, "connect-src") {
+		t.Fatalf("GET /docs CSP = %q, want Swagger UI + connect-src so try-it-out works", csp)
+	}
 
 	specRec := httptest.NewRecorder()
 	app.Router().ServeHTTP(specRec, httptest.NewRequest(http.MethodGet, "/openapi.json", nil))

--- a/framework/contract_test.go
+++ b/framework/contract_test.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/LAA-Software-Engineering/gombit/config"
 	"github.com/LAA-Software-Engineering/gombit/contract"
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/gin-gonic/gin"
 )
 
 func TestAPIValidationReturnsD10FieldErrors(t *testing.T) {
@@ -92,6 +94,85 @@ func TestAPIOpenAPIUsesD10ErrorSchema(t *testing.T) {
 	}
 }
 
+func TestAPIDocsServesSwaggerUIAndOmitsRawRoutes(t *testing.T) {
+	app := newTestApp(t)
+
+	prefix := app.Config().API.Prefix
+	huma.Register(app.API(), huma.Operation{
+		OperationID: "list-widgets",
+		Method:      http.MethodGet,
+		Path:        prefix + "/widgets",
+		Summary:     "List widgets",
+	}, func(ctx context.Context, input *struct{}) (*struct {
+		Body contract.Data[[]string]
+	}, error) {
+		return &struct {
+			Body contract.Data[[]string]
+		}{Body: contract.Data[[]string]{Data: []string{"widget-1"}}}, nil
+	})
+	app.Router().GET("/raw/ping", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok"}})
+	})
+
+	docs := httptest.NewRecorder()
+	app.Router().ServeHTTP(docs, httptest.NewRequest(http.MethodGet, "/docs", nil))
+	if docs.Code != http.StatusOK {
+		t.Fatalf("GET /docs status = %d; body: %s", docs.Code, docs.Body.String())
+	}
+	if !strings.Contains(docs.Header().Get("Content-Type"), "text/html") {
+		t.Fatalf("GET /docs Content-Type = %q, want text/html", docs.Header().Get("Content-Type"))
+	}
+	if !strings.Contains(docs.Body.String(), "swagger-ui") {
+		t.Fatalf("GET /docs missing swagger-ui; body: %s", docs.Body.String())
+	}
+	if !strings.Contains(docs.Body.String(), "/openapi") {
+		t.Fatalf("GET /docs missing OpenAPI URL for try-it-out; body: %s", docs.Body.String())
+	}
+
+	specRec := httptest.NewRecorder()
+	app.Router().ServeHTTP(specRec, httptest.NewRequest(http.MethodGet, "/openapi.json", nil))
+	if specRec.Code != http.StatusOK {
+		t.Fatalf("GET /openapi.json status = %d; body: %s", specRec.Code, specRec.Body.String())
+	}
+	generated, err := contract.OpenAPIJSON(app.API())
+	if err != nil {
+		t.Fatalf("OpenAPIJSON() error = %v", err)
+	}
+	if !jsonBodiesEqual(generated, specRec.Body.Bytes()) {
+		t.Fatal("generated OpenAPI JSON differs from served /openapi.json")
+	}
+	spec := specRec.Body.String()
+	if !strings.Contains(spec, prefix+"/widgets") {
+		t.Fatalf("OpenAPI missing Huma route %s/widgets; body: %s", prefix, spec)
+	}
+	if strings.Contains(spec, "/raw/ping") {
+		t.Fatal("raw Gin route /raw/ping unexpectedly appears in OpenAPI")
+	}
+	if strings.Contains(spec, "/livez") || strings.Contains(spec, "/readyz") || strings.Contains(spec, "/metrics") {
+		t.Fatal("framework probe/metrics routes unexpectedly appear in OpenAPI")
+	}
+}
+
+func TestAPIDocsDisabledInProductionConfig(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentProduction
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.API.DocsEnabled = false
+	app := newTestApp(t, WithConfig(cfg))
+
+	docs := httptest.NewRecorder()
+	app.Router().ServeHTTP(docs, httptest.NewRequest(http.MethodGet, "/docs", nil))
+	if docs.Code != http.StatusNotFound {
+		t.Fatalf("GET /docs status = %d, want %d when docs disabled", docs.Code, http.StatusNotFound)
+	}
+
+	spec := httptest.NewRecorder()
+	app.Router().ServeHTTP(spec, httptest.NewRequest(http.MethodGet, "/openapi.json", nil))
+	if spec.Code != http.StatusOK {
+		t.Fatalf("GET /openapi.json status = %d, want %d when docs disabled", spec.Code, http.StatusOK)
+	}
+}
+
 func TestAppExposesAPI(t *testing.T) {
 	app := newTestApp(t)
 	if app.API() == nil {
@@ -138,4 +219,21 @@ func TestAPICategoryErrorReturnsD10Envelope(t *testing.T) {
 	if body.Body.RequestID != "req-framework-2" {
 		t.Fatalf("request_id = %q, want req-framework-2", body.Body.RequestID)
 	}
+}
+
+func jsonBodiesEqual(left, right []byte) bool {
+	var leftValue any
+	var rightValue any
+	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
+		return false
+	}
+	leftBytes, err := json.Marshal(leftValue)
+	if err != nil {
+		return false
+	}
+	rightBytes, err := json.Marshal(rightValue)
+	if err != nil {
+		return false
+	}
+	return string(leftBytes) == string(rightBytes)
 }

--- a/framework/contract_test.go
+++ b/framework/contract_test.go
@@ -157,9 +157,9 @@ func TestAPIDocsServesSwaggerUIAndOmitsRawRoutes(t *testing.T) {
 	}
 }
 
-func TestAPIDocsDisabledInProductionConfig(t *testing.T) {
+func TestAPIDocsCanBeDisabled(t *testing.T) {
 	cfg := config.Default()
-	cfg.Environment = config.EnvironmentProduction
+	cfg.Environment = config.EnvironmentTest
 	cfg.HTTP.Addr = "127.0.0.1:0"
 	cfg.API.DocsEnabled = false
 	app := newTestApp(t, WithConfig(cfg))

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -151,8 +151,7 @@ func TestProductionRouterAddsHSTS(t *testing.T) {
 		gin.SetMode(previousMode)
 	})
 
-	cfg := config.Default()
-	cfg.Environment = config.EnvironmentProduction
+	cfg := config.DefaultFor(config.EnvironmentProduction)
 	cfg.HTTP.Addr = "127.0.0.1:0"
 	app := newTestApp(t, WithConfig(cfg))
 

--- a/framework/router_test.go
+++ b/framework/router_test.go
@@ -23,6 +23,7 @@ func TestDefaultRouterMountsOnlyFrameworkEndpoints(t *testing.T) {
 	sort.Strings(got)
 
 	want := []string{
+		"GET /docs",
 		"GET /livez",
 		"GET /metrics",
 		"GET /openapi-3.0.json",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Serves the live OpenAPI 3.1 document at `/openapi.json` and a FastAPI-style Swagger UI at `/docs` (on by default in local/dev; production can disable it). Adds `gombit openapi generate` to write that spec to disk after validating it.

Follow-up commit addresses the review nits: `DefaultFor` / `DefaultDocsEnabled` / `ApplyEnvironmentDefaults`, oversized-spec error, root usage no longer dumps `db` help, and docs now say the in-process spec is semantically identical to `/openapi.json`.

Closes #18

## Acceptance criteria

- [x] Spec validates as OpenAPI 3.1
- [x] Generated/served spec matches live Huma routes
- [x] `/docs` try-it-out UI is served and points at `/openapi.json`
- [x] Raw Gin routes are absent from the spec and therefore from `/docs`
- [x] CLI writes the spec to disk (`gombit openapi generate --out`)
- [x] Production may disable `/docs` (`GOMBIT_DOCS_ENABLED` / `API.DocsEnabled`)

## Scope notes

- TypeScript client generation remains M3-4.
- CI drift check remains M3-5.
- Cobra adoption for the CLI tree remains M4-1; this command uses the existing stdlib `flag` router (ADR-014).
- `/openapi.json` stays available when docs are disabled so codegen and later drift checks still work.

## Validation

- [x] `go test ./...` — pass (re-run `go test ./config ./contract ./framework ./cmd/gombit` after review fixes)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — pass
- [x] Project `code-review` skill run against this diff — approve; nits addressed in follow-up

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix
  - No database changes in this PR; OpenAPI/docs/CLI covered by unit tests.
- [x] Stable features ship docs and appear in an example app
  - `docs/openapi.md`, `examples/contract`
- [ ] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests
  - N/A: new contract/CLI surface, not an extraction from the template.
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators)
  - N/A: `openapi generate` writes a spec file the user asked for; it does not edit Go source.
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR
  - N/A: this PR *adds* spec emission; there is no generated TS client yet (M3-4).
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
  - N/A: no frontend source in this PR.
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84a5aa58-4c2e-4718-a805-46e3e86e8b5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84a5aa58-4c2e-4718-a805-46e3e86e8b5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

