### PR TITLE
[M3-5] Contract drift check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: read
 
-# Pipeline: lint → build → test → (database ∥ migrations ∥ conformance)
+# Pipeline: lint → build → test → (database ∥ migrations ∥ conformance ∥ contract-drift)
 jobs:
   lint:
     name: Lint
@@ -67,6 +67,31 @@ jobs:
 
       - name: Run tests
         run: go test ./...
+
+  contract-drift:
+    name: Contract drift
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Regenerate sample spec and client
+        run: go run ./cmd/gombit client check --write
+
+      - name: Fail on contract drift
+        run: git diff --exit-code -- examples/client/openapi.json examples/client/frontend/src/api/generated
 
   database-sqlite:
     name: Database (sqlite)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,11 @@ Run the same baseline checks as CI before opening a pull request:
 ```sh
 go test ./...
 golangci-lint run
+go run ./cmd/gombit client check
 ```
+
+`gombit client check --write` regenerates `examples/client/openapi.json` and
+the sample TypeScript client. CI fails if those files would change.
 
 ## Working agreement
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Application lifecycle is documented in [`docs/lifecycle.md`](docs/lifecycle.md).
 Application-owned route registration is documented in [`docs/router.md`](docs/router.md).
 Huma DTO and validation conventions are documented in [`docs/contract.md`](docs/contract.md).
 OpenAPI emission and `/docs` are documented in [`docs/openapi.md`](docs/openapi.md).
-TypeScript client generation is documented in [`docs/client.md`](docs/client.md).
+TypeScript client generation and the contract drift check are documented in
+[`docs/client.md`](docs/client.md).
 Database runtime support is documented in [`docs/database.md`](docs/database.md).
 Cache runtime support is documented in [`docs/cache.md`](docs/cache.md).
 Runtime logging is documented in [`docs/logging.md`](docs/logging.md).

--- a/client/doc.go
+++ b/client/doc.go
@@ -2,4 +2,7 @@
 //
 // gombit client generate runs openapi-typescript for schema types and writes a
 // thin openapi-fetch wrapper whose errors map to the D10 envelope.
+//
+// gombit client check regenerates the sample spec and client in-process from
+// SampleApp and fails when committed artifacts would change.
 package client

--- a/client/drift.go
+++ b/client/drift.go
@@ -1,0 +1,216 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/danielgtaylor/huma/v2"
+)
+
+//go:generate go run ../cmd/gombit client check --write --spec ../examples/client/openapi.json --out ../examples/client/frontend/src/api/generated
+
+const (
+	// SampleSpecPath is the committed OpenAPI fixture for the sample widget API.
+	SampleSpecPath = "examples/client/openapi.json"
+	// SampleOutDir is the committed TypeScript client generated from SampleSpecPath.
+	SampleOutDir = "examples/client/frontend/src/api/generated"
+)
+
+var sampleClientFiles = []string{"schema.ts", "client.ts", "error.ts"}
+
+// DriftOptions configures a contract drift check or fixture rewrite.
+type DriftOptions struct {
+	// WorkDir is the repository root. Empty means the current working directory.
+	WorkDir string
+	// SpecPath is the committed OpenAPI fixture, relative to WorkDir unless absolute.
+	// Default: SampleSpecPath.
+	SpecPath string
+	// OutDir is the committed generated-client directory, relative to WorkDir unless absolute.
+	// Default: SampleOutDir.
+	OutDir string
+	// API is the Huma API to emit. Nil means SampleApp().
+	API huma.API
+	// Write regenerates committed fixtures instead of comparing them.
+	Write bool
+	// NPXBinary is the npx executable used by Generate. Default: npx.
+	NPXBinary string
+	Stdout    io.Writer
+	Stderr    io.Writer
+}
+
+// CheckDrift regenerates the sample OpenAPI document and TypeScript client and
+// reports whether committed artifacts would change.
+//
+// The spec is compared semantically via encoding/json, so whitespace-only
+// differences are not drift. Generated TypeScript is compared byte-for-byte.
+// Generation is in-process from SampleApp (or opts.API) and does not fetch a
+// live /openapi.json URL.
+//
+// When Write is true, fixtures are rewritten in place with contract.WriteOpenAPI
+// and Generate.
+func CheckDrift(ctx context.Context, opts DriftOptions) error {
+	if ctx == nil {
+		return errors.New("client: nil context")
+	}
+	opts = normalizeDriftOptions(opts)
+
+	api := opts.API
+	if api == nil {
+		app, err := SampleApp()
+		if err != nil {
+			return fmt.Errorf("client: sample app: %w", err)
+		}
+		api = app.API()
+	}
+
+	if opts.Write {
+		return writeSampleFixtures(ctx, opts, api)
+	}
+	return compareSampleFixtures(ctx, opts, api)
+}
+
+func normalizeDriftOptions(opts DriftOptions) DriftOptions {
+	if opts.WorkDir == "" {
+		opts.WorkDir = "."
+	}
+	if opts.SpecPath == "" {
+		opts.SpecPath = SampleSpecPath
+	}
+	if opts.OutDir == "" {
+		opts.OutDir = SampleOutDir
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = io.Discard
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = io.Discard
+	}
+	if opts.NPXBinary == "" {
+		opts.NPXBinary = "npx"
+	}
+	return opts
+}
+
+func resolvePath(workDir, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(workDir, path)
+}
+
+func writeSampleFixtures(ctx context.Context, opts DriftOptions, api huma.API) error {
+	specPath := resolvePath(opts.WorkDir, opts.SpecPath)
+	if err := contract.WriteOpenAPI(specPath, api); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(opts.Stdout, "wrote %s\n", displayPath(opts.WorkDir, specPath)); err != nil {
+		return err
+	}
+	return Generate(ctx, Options{
+		WorkDir:   opts.WorkDir,
+		SpecPath:  specPath,
+		OutDir:    resolvePath(opts.WorkDir, opts.OutDir),
+		NPXBinary: opts.NPXBinary,
+		Stdout:    opts.Stdout,
+		Stderr:    opts.Stderr,
+	})
+}
+
+func compareSampleFixtures(ctx context.Context, opts DriftOptions, api huma.API) error {
+	tmpDir, err := os.MkdirTemp("", "gombit-drift-*")
+	if err != nil {
+		return fmt.Errorf("client: temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	generatedSpecPath := filepath.Join(tmpDir, "openapi.json")
+	if err := contract.WriteOpenAPI(generatedSpecPath, api); err != nil {
+		return err
+	}
+	// #nosec G304 -- generatedSpecPath is created in this function
+	generatedSpec, err := os.ReadFile(generatedSpecPath)
+	if err != nil {
+		return fmt.Errorf("client: read generated spec: %w", err)
+	}
+
+	specPath := resolvePath(opts.WorkDir, opts.SpecPath)
+	// #nosec G304 -- spec path is a user-supplied committed fixture
+	committedSpec, err := os.ReadFile(specPath)
+	if err != nil {
+		return fmt.Errorf("client: read committed spec: %w", err)
+	}
+
+	var drifted []string
+	equal, err := jsonEqual(committedSpec, generatedSpec)
+	if err != nil {
+		return err
+	}
+	if !equal {
+		drifted = append(drifted, displayPath(opts.WorkDir, specPath))
+	}
+
+	generatedOut := filepath.Join(tmpDir, "generated")
+	if err := Generate(ctx, Options{
+		WorkDir:   tmpDir,
+		SpecPath:  generatedSpecPath,
+		OutDir:    generatedOut,
+		NPXBinary: opts.NPXBinary,
+		Stdout:    io.Discard,
+		Stderr:    opts.Stderr,
+	}); err != nil {
+		return err
+	}
+
+	committedOut := resolvePath(opts.WorkDir, opts.OutDir)
+	for _, name := range sampleClientFiles {
+		committedPath := filepath.Join(committedOut, name)
+		generatedPath := filepath.Join(generatedOut, name)
+		// #nosec G304 -- committedPath is the checked-in generated client file
+		committed, readErr := os.ReadFile(committedPath)
+		if readErr != nil {
+			return fmt.Errorf("client: read committed %s: %w", displayPath(opts.WorkDir, committedPath), readErr)
+		}
+		// #nosec G304 -- generatedPath is created in this function
+		generated, readErr := os.ReadFile(generatedPath)
+		if readErr != nil {
+			return fmt.Errorf("client: read generated %s: %w", name, readErr)
+		}
+		if !bytes.Equal(committed, generated) {
+			drifted = append(drifted, displayPath(opts.WorkDir, committedPath))
+		}
+	}
+
+	if len(drifted) > 0 {
+		return fmt.Errorf("client: contract drift in %s; regenerate with gombit client check --write", strings.Join(drifted, ", "))
+	}
+	_, err = fmt.Fprintln(opts.Stdout, "no contract drift")
+	return err
+}
+
+func jsonEqual(left, right []byte) (bool, error) {
+	var leftValue any
+	var rightValue any
+	if err := json.Unmarshal(left, &leftValue); err != nil {
+		return false, fmt.Errorf("client: parse committed spec: %w", err)
+	}
+	if err := json.Unmarshal(right, &rightValue); err != nil {
+		return false, fmt.Errorf("client: parse generated spec: %w", err)
+	}
+	leftBytes, err := json.Marshal(leftValue)
+	if err != nil {
+		return false, fmt.Errorf("client: marshal committed spec: %w", err)
+	}
+	rightBytes, err := json.Marshal(rightValue)
+	if err != nil {
+		return false, fmt.Errorf("client: marshal generated spec: %w", err)
+	}
+	return string(leftBytes) == string(rightBytes), nil
+}

--- a/client/drift_test.go
+++ b/client/drift_test.go
@@ -184,13 +184,6 @@ func TestCheckDriftRequiresCommittedSpec(t *testing.T) {
 	}
 }
 
-func TestCheckDriftNilContext(t *testing.T) {
-	err := CheckDrift(nil, DriftOptions{})
-	if err == nil {
-		t.Fatal("CheckDrift(nil) error = nil, want error")
-	}
-}
-
 func moduleRoot(t *testing.T) string {
 	t.Helper()
 	_, file, _, ok := runtime.Caller(0)

--- a/client/drift_test.go
+++ b/client/drift_test.go
@@ -1,0 +1,231 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gin-gonic/gin"
+)
+
+func TestCheckDrift(t *testing.T) {
+	requireNode(t)
+	root := moduleRoot(t)
+
+	t.Run("committed fixtures match SampleApp", func(t *testing.T) {
+		before := fixtureSnapshots(t, root)
+		stdout := new(bytes.Buffer)
+		err := CheckDrift(context.Background(), DriftOptions{
+			WorkDir: root,
+			Stdout:  stdout,
+			Stderr:  ioDiscard{},
+		})
+		if err != nil {
+			t.Fatalf("CheckDrift() error = %v, want nil", err)
+		}
+		if !strings.Contains(stdout.String(), "no contract drift") {
+			t.Fatalf("stdout = %q, want no contract drift", stdout.String())
+		}
+		after := fixtureSnapshots(t, root)
+		if before != after {
+			t.Fatal("CheckDrift() mutated committed sample fixtures")
+		}
+	})
+
+	t.Run("handler change without regen fails", func(t *testing.T) {
+		app, err := SampleApp()
+		if err != nil {
+			t.Fatalf("SampleApp() error = %v", err)
+		}
+		huma.Register(app.API(), huma.Operation{
+			OperationID: "list-gadgets",
+			Method:      http.MethodGet,
+			Path:        app.Config().API.Prefix + "/gadgets",
+			Summary:     "List gadgets",
+		}, func(ctx context.Context, input *struct{}) (*struct {
+			Body contract.Data[[]string]
+		}, error) {
+			return &struct {
+				Body contract.Data[[]string]
+			}{Body: contract.Data[[]string]{Data: []string{"gadget-1"}}}, nil
+		})
+
+		before := fixtureSnapshots(t, root)
+		err = CheckDrift(context.Background(), DriftOptions{
+			WorkDir: root,
+			API:     app.API(),
+			Stderr:  ioDiscard{},
+		})
+		if err == nil {
+			t.Fatal("CheckDrift() error = nil, want drift after extra Huma path")
+		}
+		if !strings.Contains(err.Error(), "contract drift") {
+			t.Fatalf("CheckDrift() error = %q, want contract drift", err)
+		}
+		if !strings.Contains(err.Error(), "openapi.json") && !strings.Contains(err.Error(), "schema.ts") {
+			t.Fatalf("CheckDrift() error = %q, want spec or schema path", err)
+		}
+		after := fixtureSnapshots(t, root)
+		if before != after {
+			t.Fatal("CheckDrift() mutated committed sample fixtures")
+		}
+	})
+
+	t.Run("whitespace-only JSON is not drift", func(t *testing.T) {
+		workDir := t.TempDir()
+		copySampleFixtures(t, root, workDir)
+
+		specPath := filepath.Join(workDir, "openapi.json")
+		pretty := readFile(t, specPath)
+		var compact bytes.Buffer
+		if err := json.Compact(&compact, []byte(pretty)); err != nil {
+			t.Fatalf("json.Compact: %v", err)
+		}
+		if compact.Len() == 0 || compact.String() == pretty {
+			t.Fatal("compacted spec is not a whitespace-only change")
+		}
+		writeFile(t, specPath, compact.String())
+
+		err := CheckDrift(context.Background(), DriftOptions{
+			WorkDir:  workDir,
+			SpecPath: "openapi.json",
+			OutDir:   "frontend/src/api/generated",
+			Stderr:   ioDiscard{},
+		})
+		if err != nil {
+			t.Fatalf("CheckDrift() error = %v, want nil for whitespace-only spec", err)
+		}
+	})
+
+	t.Run("raw Gin routes absent from regenerated spec", func(t *testing.T) {
+		app, err := SampleApp()
+		if err != nil {
+			t.Fatalf("SampleApp() error = %v", err)
+		}
+		app.Router().GET("/raw/ping", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"data": gin.H{"status": "ok"}})
+		})
+
+		spec, err := contract.OpenAPIJSON(app.API())
+		if err != nil {
+			t.Fatalf("OpenAPIJSON() error = %v", err)
+		}
+		if strings.Contains(string(spec), "/raw/ping") {
+			t.Fatal("raw Gin route /raw/ping unexpectedly appears in regenerated spec")
+		}
+
+		err = CheckDrift(context.Background(), DriftOptions{
+			WorkDir: root,
+			API:     app.API(),
+			Stderr:  ioDiscard{},
+		})
+		if err != nil {
+			t.Fatalf("CheckDrift() error = %v, want nil when only a raw Gin route is added", err)
+		}
+	})
+}
+
+func TestCheckDriftWriteRegeneratesFixtures(t *testing.T) {
+	requireNode(t)
+
+	workDir := t.TempDir()
+	stdout := new(bytes.Buffer)
+	err := CheckDrift(context.Background(), DriftOptions{
+		WorkDir:  workDir,
+		SpecPath: "openapi.json",
+		OutDir:   "frontend/src/api/generated",
+		Write:    true,
+		Stdout:   stdout,
+		Stderr:   ioDiscard{},
+	})
+	if err != nil {
+		t.Fatalf("CheckDrift(write) error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "openapi.json") {
+		t.Fatalf("stdout = %q, want wrote openapi.json", stdout.String())
+	}
+	for _, name := range sampleClientFiles {
+		path := filepath.Join(workDir, "frontend", "src", "api", "generated", name)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("missing generated %s: %v", name, err)
+		}
+	}
+
+	err = CheckDrift(context.Background(), DriftOptions{
+		WorkDir:  workDir,
+		SpecPath: "openapi.json",
+		OutDir:   "frontend/src/api/generated",
+		Stderr:   ioDiscard{},
+	})
+	if err != nil {
+		t.Fatalf("CheckDrift() after write error = %v, want nil", err)
+	}
+}
+
+func TestCheckDriftRequiresCommittedSpec(t *testing.T) {
+	err := CheckDrift(context.Background(), DriftOptions{
+		WorkDir:  t.TempDir(),
+		SpecPath: "missing.json",
+		OutDir:   "generated",
+	})
+	if err == nil {
+		t.Fatal("CheckDrift() error = nil, want missing spec")
+	}
+	if !strings.Contains(err.Error(), "committed spec") {
+		t.Fatalf("CheckDrift() error = %q, want committed spec", err)
+	}
+}
+
+func TestCheckDriftNilContext(t *testing.T) {
+	err := CheckDrift(nil, DriftOptions{})
+	if err == nil {
+		t.Fatal("CheckDrift(nil) error = nil, want error")
+	}
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), ".."))
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("module root %s: %v", root, err)
+	}
+	return root
+}
+
+func copySampleFixtures(t *testing.T, root, dest string) {
+	t.Helper()
+	copyFile(t, filepath.Join(root, SampleSpecPath), filepath.Join(dest, "openapi.json"))
+	for _, name := range sampleClientFiles {
+		copyFile(t,
+			filepath.Join(root, SampleOutDir, name),
+			filepath.Join(dest, "frontend", "src", "api", "generated", name),
+		)
+	}
+}
+
+func copyFile(t *testing.T, src, dest string) {
+	t.Helper()
+	writeFile(t, dest, readFile(t, src))
+}
+
+func fixtureSnapshots(t *testing.T, root string) string {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString(readFile(t, filepath.Join(root, SampleSpecPath)))
+	for _, name := range sampleClientFiles {
+		b.WriteString(readFile(t, filepath.Join(root, SampleOutDir, name)))
+	}
+	return b.String()
+}

--- a/cmd/gombit/client.go
+++ b/cmd/gombit/client.go
@@ -15,11 +15,15 @@ func runClient(ctx context.Context, args []string, stdout io.Writer, stderr io.W
 		clientUsage(stderr)
 		return errors.New("gombit client: subcommand is required")
 	}
-	if args[0] != "generate" {
+	switch args[0] {
+	case "generate":
+		return runClientGenerate(ctx, args[1:], stdout, stderr)
+	case "check":
+		return runClientCheck(ctx, args[1:], stdout, stderr)
+	default:
 		clientUsage(stderr)
 		return fmt.Errorf("gombit client: unknown subcommand %q", args[0])
 	}
-	return runClientGenerate(ctx, args[1:], stdout, stderr)
 }
 
 func runClientGenerate(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
@@ -50,7 +54,34 @@ func runClientGenerate(ctx context.Context, args []string, stdout io.Writer, std
 	})
 }
 
+func runClientCheck(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) error {
+	flags := flag.NewFlagSet("gombit client check", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	spec := flags.String("spec", client.SampleSpecPath, "committed OpenAPI 3.1 document path")
+	out := flags.String("out", client.SampleOutDir, "committed generated TypeScript directory")
+	write := flags.Bool("write", false, "rewrite committed fixtures instead of reporting drift")
+	npx := flags.String("npx", "npx", "npx binary used to run openapi-typescript")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		flags.Usage()
+		return fmt.Errorf("gombit client check: unexpected argument %q", flags.Arg(0))
+	}
+
+	return client.CheckDrift(ctx, client.DriftOptions{
+		WorkDir:   ".",
+		SpecPath:  *spec,
+		OutDir:    *out,
+		Write:     *write,
+		NPXBinary: *npx,
+		Stdout:    stdout,
+		Stderr:    stderr,
+	})
+}
+
 func clientUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "available client subcommands:")
 	_, _ = fmt.Fprintln(w, "  generate [--spec openapi.json] [--out frontend/src/api/generated] [--dry-run] [--force] [--npx npx]")
+	_, _ = fmt.Fprintln(w, "  check [--write] [--spec examples/client/openapi.json] [--out examples/client/frontend/src/api/generated] [--npx npx]")
 }

--- a/cmd/gombit/main.go
+++ b/cmd/gombit/main.go
@@ -247,6 +247,7 @@ func usage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  db <subcommand>   see gombit db")
 	_, _ = fmt.Fprintln(w, "  openapi generate [--out openapi.json] [--url http://127.0.0.1:8080/openapi.json]")
 	_, _ = fmt.Fprintln(w, "  client generate [--spec openapi.json] [--out frontend/src/api/generated] [--dry-run] [--force]")
+	_, _ = fmt.Fprintln(w, "  client check [--write] [--spec examples/client/openapi.json] [--out examples/client/frontend/src/api/generated]")
 }
 
 func dbUsage(w io.Writer) {

--- a/cmd/gombit/main_test.go
+++ b/cmd/gombit/main_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -286,6 +287,9 @@ func TestRunRejectsUnknownCommandUsageListsFamilies(t *testing.T) {
 	if !strings.Contains(got, "client generate") {
 		t.Fatalf("usage = %q, want client generate", got)
 	}
+	if !strings.Contains(got, "client check") {
+		t.Fatalf("usage = %q, want client check", got)
+	}
 	if !strings.Contains(got, "see gombit db") {
 		t.Fatalf("usage = %q, want pointer to gombit db", got)
 	}
@@ -345,6 +349,89 @@ func TestRunClientGenerateDryRun(t *testing.T) {
 	}
 }
 
+func TestRunClientCheckDetectsHandlerDrift(t *testing.T) {
+	requireNodeCLI(t)
+
+	root := cmdModuleRoot(t)
+	workDir := t.TempDir()
+	copyFile(t, filepath.Join(root, clientpkg.SampleSpecPath), filepath.Join(workDir, "openapi.json"))
+	for _, name := range []string{"schema.ts", "client.ts", "error.ts"} {
+		copyFile(t,
+			filepath.Join(root, clientpkg.SampleOutDir, name),
+			filepath.Join(workDir, "frontend", "src", "api", "generated", name),
+		)
+	}
+
+	spec := readFileString(t, filepath.Join(workDir, "openapi.json"))
+	tampered := strings.Replace(spec, "/api/v1/widgets", "/api/v1/stale-widgets", 1)
+	if tampered == spec {
+		t.Fatal("failed to tamper committed spec")
+	}
+	writeFile(t, filepath.Join(workDir, "openapi.json"), tampered)
+
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+
+	err = run(context.Background(), []string{
+		"client", "check",
+		"--spec", "openapi.json",
+		"--out", "frontend/src/api/generated",
+	}, ioDiscard{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("run() error = nil, want contract drift")
+	}
+	if !strings.Contains(err.Error(), "contract drift") {
+		t.Fatalf("run() error = %q, want contract drift", err)
+	}
+}
+
+func TestRunClientCheckWriteThenClean(t *testing.T) {
+	requireNodeCLI(t)
+
+	workDir := t.TempDir()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+
+	stdout := new(bytes.Buffer)
+	err = run(context.Background(), []string{
+		"client", "check",
+		"--write",
+		"--spec", "openapi.json",
+		"--out", "frontend/src/api/generated",
+	}, stdout, ioDiscard{})
+	if err != nil {
+		t.Fatalf("run(check --write) error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "openapi.json") {
+		t.Fatalf("stdout = %q, want wrote openapi.json", stdout.String())
+	}
+
+	stdout.Reset()
+	err = run(context.Background(), []string{
+		"client", "check",
+		"--spec", "openapi.json",
+		"--out", "frontend/src/api/generated",
+	}, stdout, ioDiscard{})
+	if err != nil {
+		t.Fatalf("run(check) error = %v, want nil after write", err)
+	}
+	if !strings.Contains(stdout.String(), "no contract drift") {
+		t.Fatalf("stdout = %q, want no contract drift", stdout.String())
+	}
+}
+
 func TestRunRejectsUnknownClientSubcommand(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	err := run(context.Background(), []string{"client", "unknown"}, ioDiscard{}, stderr)
@@ -356,6 +443,9 @@ func TestRunRejectsUnknownClientSubcommand(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "--npx") {
 		t.Fatalf("client usage = %q, want --npx", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "check") {
+		t.Fatalf("client usage = %q, want check", stderr.String())
 	}
 }
 
@@ -555,6 +645,47 @@ func writeFile(t *testing.T, path string, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func copyFile(t *testing.T, src, dest string) {
+	t.Helper()
+	writeFile(t, dest, readFileString(t, src))
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	// #nosec G304 -- test fixture path
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func requireNodeCLI(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("npx openapi-typescript path handling differs on Windows")
+	}
+	if _, err := exec.LookPath("npx"); err != nil {
+		t.Skip("npx not available")
+	}
+	if _, err := exec.LookPath("npm"); err != nil {
+		t.Skip("npm not available")
+	}
+}
+
+func cmdModuleRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("module root %s: %v", root, err)
+	}
+	return root
 }
 
 func fakeAtlas(t *testing.T) string {

--- a/cmd/gombit/main_test.go
+++ b/cmd/gombit/main_test.go
@@ -349,7 +349,7 @@ func TestRunClientGenerateDryRun(t *testing.T) {
 	}
 }
 
-func TestRunClientCheckDetectsHandlerDrift(t *testing.T) {
+func TestRunClientCheckDetectsStaleSpec(t *testing.T) {
 	requireNodeCLI(t)
 
 	root := cmdModuleRoot(t)

--- a/docs/client.md
+++ b/docs/client.md
@@ -73,7 +73,28 @@ if (isD10ErrorBody(body)) {
 `examples/client` ships a sample spec (the contract widget API) and the
 generated client. See that README to typecheck it.
 
+## Contract drift check
+
+`gombit client check` rebuilds the sample widget API with `client.SampleApp()`,
+writes the spec with `contract.WriteOpenAPI`, regenerates the TypeScript client
+with `client.Generate`, and fails if committed artifacts would change. It does
+not fetch a live `/openapi.json` URL.
+
+From the repository root:
+
+```sh
+go run ./cmd/gombit client check
+go run ./cmd/gombit client check --write
+```
+
+`--write` rewrites `examples/client/openapi.json` and
+`examples/client/frontend/src/api/generated`. CI runs `--write` and then
+`git diff --exit-code` on those paths, so a Huma handler change that is not
+regenerated fails the job. Spec comparison in `CheckDrift` is semantic
+(`encoding/json`); whitespace-only JSON is not drift.
+
+`go generate ./client` runs the same rewrite as `--write`.
+
 ## What is not here yet
 
-- CI drift check that fails when the spec or client is stale: M3-5
 - Vite React skeleton that wires this client into forms: M5-1

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -161,11 +161,12 @@ The `validation_error` code is preserved from M3-1 / D10 (not renamed to
 
 `/openapi.json` is served from the Huma API and reflects the D10
 `ErrorEnvelope` schema. `/docs` is the FastAPI-style Swagger UI (on by default
-in local/dev). `gombit openapi generate` writes the live spec to disk. See
-[`docs/openapi.md`](openapi.md).
+in local/dev). `gombit openapi generate` writes the live spec to disk. CI
+regenerates the sample spec and TypeScript client from `client.SampleApp()`
+and fails on drift — see [`docs/openapi.md`](openapi.md) and
+[`docs/client.md`](client.md).
 
 ## What is not here yet
 
-- CI contract drift check (M3-5)
 - Pagination query DSL / filter/sort helpers (design §42)
 - gRPC status mapping (post-v0.1)

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -71,10 +71,28 @@ return contract.WriteOpenAPI("openapi.json", app.API())
 
 `contract.OpenAPIJSON` is semantically identical to `GET /openapi.json` (same
 document; `OpenAPIJSON` pretty-prints, Huma's route does not). The CLI writes
-the fetched live bytes. Do not treat whitespace-only differences as contract
-drift (M3-5).
+the fetched live bytes. Whitespace-only differences are not contract drift:
+`gombit client check` compares JSON semantically, and CI always rewrites the
+sample fixture with `contract.WriteOpenAPI` so formatting stays stable.
 
-## What is not here yet
+## Contract drift check
 
-- TypeScript client generation: [`docs/client.md`](client.md)
-- CI drift check that fails when the spec is stale: M3-5
+CI regenerates the sample widget spec and TypeScript client in-process from
+`client.SampleApp()` (no running server, no `gombit openapi generate --url`)
+and fails if the committed files would change. An intentional Huma handler
+change without regenerating those fixtures fails CI.
+
+From the repository root:
+
+```sh
+# Report drift without writing (whitespace-only JSON is not drift)
+go run ./cmd/gombit client check
+
+# Rewrite examples/client/openapi.json and the generated TypeScript client
+go run ./cmd/gombit client check --write
+
+# Same rewrite via go generate
+go generate ./client
+```
+
+`CheckDrift` is the reusable Go entry point. See [`docs/client.md`](client.md).

--- a/examples/client/README.md
+++ b/examples/client/README.md
@@ -5,13 +5,24 @@ Sample OpenAPI 3.1 document for the contract widget API, plus the output of
 
 ## Generate
 
-From the repository root:
+From the repository root, regenerate the committed spec and client from
+`client.SampleApp()` (same path CI uses):
+
+```sh
+go run ./cmd/gombit client check --write
+```
+
+`go generate ./client` does the same rewrite. To generate only the TypeScript
+client from the committed spec:
 
 ```sh
 go run ./cmd/gombit client generate \
   --spec examples/client/openapi.json \
   --out examples/client/frontend/src/api/generated
 ```
+
+`gombit client check` (without `--write`) reports drift without touching files.
+Whitespace-only JSON is not drift; an extra or changed Huma route is.
 
 ## Typecheck
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an in-process contract drift check so a Huma handler change that is not regenerated fails CI. `client.CheckDrift` rebuilds `client.SampleApp()`, writes the spec with `contract.WriteOpenAPI`, regenerates the TypeScript client with `client.Generate`, and compares against `examples/client`. Spec comparison is semantic (`encoding/json`); whitespace-only JSON is not drift.

`gombit client check` (stdlib `flag`) reports drift; `--write` rewrites the committed fixtures. CI runs `--write` then `git diff --exit-code` on the sample spec and generated client. No live server is required.

Closes #20

## Acceptance criteria

- [x] Intentional server change without regen fails CI
  - Go test registers an extra Huma path on `SampleApp` and asserts `CheckDrift` fails without rewriting committed files
  - CI job `contract-drift` regenerates fixtures and fails on `git diff --exit-code`
- [x] Whitespace-only JSON difference is not drift (`encoding/json` semantic compare)
- [x] Raw Gin routes do not appear in the regenerated spec; adding `/raw/ping` is not contract drift
- [x] Current committed spec + client match a fresh regen (happy path)

## Scope notes

- Cobra adoption remains M4-1; `client check` uses the existing stdlib `flag` router (ADR-014 / pre-M4 exception).
- `gombit openapi generate` still fetches a live URL; CI does not use it.
- Vite React skeleton that wires the client into forms remains M5-1.
- This check covers the sample widget API (`examples/client`), not generated user apps (M4).

## Validation

- [x] `go test ./client ./cmd/gombit -count=1` — pass
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./client ./cmd/gombit` — 0 issues
- [x] `go run ./cmd/gombit client check` — `no contract drift`
- [x] `go run ./cmd/gombit client check --write` then `git diff --exit-code -- examples/client/openapi.json examples/client/frontend/src/api/generated` — clean
- [x] Project `code-review` skill run against this diff — approve (AC covered, M3-only, reuses SampleApp / WriteOpenAPI / Generate)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix
  - No database changes. Drift tests cover happy path, extra Huma path, whitespace-only JSON, raw Gin absence, and `--write`.
- [x] Stable features ship docs and appear in an example app
  - `docs/openapi.md`, `docs/client.md`, `docs/contract.md`, `examples/client/README.md`, `CONTRIBUTING.md`
- [ ] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests
  - N/A: new drift-check surface; reuses `SampleApp`, `WriteOpenAPI`, and `Generate` without rewriting them.
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators)
  - `--write` calls existing `Generate` (banner / `--force` rules unchanged). Check path writes only to a temp dir.
- [x] API changes regenerate the OpenAPI doc + TS client in this PR
  - No widget API change. Fixtures already matched `SampleApp`; `--write` left a clean tree.
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
  - Drift check does not add frontend secrets or `VITE_*` values.
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7cead8d-780d-4ee8-ae63-2a4e49ca67e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7cead8d-780d-4ee8-ae63-2a4e49ca67e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

