### PR TITLE
[M4-2] gombit dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,10 @@ a generated React+TypeScript frontend, Atlas-backed migrations. Module path
 This repo has completed M0–M3 and started **M4 CLI**. It has typed
 `config.Config`, `framework.App` lifecycle and routing, Huma contract/OpenAPI/
 TypeScript client generation, Atlas-backed migrations, and a Cobra `gombit`
-command tree (`new`, `db`, `openapi`, `client`) that scaffolds apps into a
-temp/user directory. It does not yet have `gombit dev`, `make resource`, a
-full Vite React skeleton (M5-1), or M6 batteries.
+command tree (`new`, `dev`, `db`, `openapi`, `client`) that scaffolds apps
+into a temp/user directory and runs the API + Vite frontend together.
+It does not yet have `make resource`, a full Vite React skeleton (M5-1), or
+M6 batteries.
 Don't assume generated apps are committed in-tree; `gombit new` writes them
 on demand. Check `git log` / `ls` before describing "how the code works."
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Gombit is a Django-for-Go full-stack framework. The current repository has
 typed config, `framework.App` lifecycle, Huma contract/OpenAPI/client
 generation, Atlas-backed `gombit db` migrations, and a Cobra CLI that
-scaffolds apps with `gombit new`.
+scaffolds apps with `gombit new` and runs them with `gombit dev`.
 
 ## Development
 
@@ -24,6 +24,11 @@ Scaffold an application (Cobra CLI; default module `github.com/example/demo`):
 go run ./cmd/gombit new demo --database sqlite
 ```
 
+From the app directory, `gombit dev` runs the Go API and Vite frontend
+together, proxies `/api` (and `/openapi.json`, `/docs`) to the backend,
+regenerates the TypeScript client when the live spec changes, and prints a
+service table including the API docs URL. See [`docs/cli.md`](docs/cli.md).
+
 Write the live app spec (app must be serving `/openapi.json`):
 
 ```sh
@@ -36,7 +41,7 @@ default). See [`docs/openapi.md`](docs/openapi.md).
 The authoritative implementation backlog and architecture decisions live in
 [`docs/GOMBIT_BUILD_PLAN.md`](docs/GOMBIT_BUILD_PLAN.md).
 
-The Cobra command tree and `gombit new` are documented in
+The Cobra command tree, `gombit new`, and `gombit dev` are documented in
 [`docs/cli.md`](docs/cli.md).
 Accepted architecture decisions are recorded under [`docs/adr/`](docs/adr/).
 Runtime configuration is documented in [`docs/config.md`](docs/config.md).

--- a/cmd/gombit/dev.go
+++ b/cmd/gombit/dev.go
@@ -40,9 +40,6 @@ The Vite stub from gombit new is enough to start HMR. The full React
 skeleton (router, React Hook Form, auth pages) is M5-1.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := dev.ValidateFlags(dev.DefaultHTTPAddr, frontendHost, frontendPort, poll, clientOut); err != nil {
-				return fmt.Errorf("gombit %w", err)
-			}
 			if !cmd.Flags().Changed("http") {
 				cfg, err := loadConfig()
 				if err != nil {

--- a/cmd/gombit/dev.go
+++ b/cmd/gombit/dev.go
@@ -32,9 +32,9 @@ OpenAPI document changes, gombit regenerates frontend/src/api/generated
 
 A service table is printed at startup, including the API docs URL (/docs).
 
-SIGINT/SIGTERM stops the child processes. air/watchexec and Node.js are
-optional for reload/HMR; a missing frontend/package.json is an error
-(backend-only is not supported).
+SIGINT/SIGTERM stops the child processes. air and watchexec are optional
+(go run fallback). Node.js is required for Vite HMR; a missing
+frontend/package.json is an error (backend-only is not supported).
 
 The Vite stub from gombit new is enough to start HMR. The full React
 skeleton (router, React Hook Form, auth pages) is M5-1.`,

--- a/cmd/gombit/dev.go
+++ b/cmd/gombit/dev.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/dev"
+	"github.com/spf13/cobra"
+)
+
+func newDevCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
+	var (
+		httpAddr     string
+		frontendHost string
+		frontendPort int
+		clientOut    string
+		poll         time.Duration
+	)
+	cmd := silence(&cobra.Command{
+		Use:   "dev",
+		Short: "Run the API and Vite frontend together",
+		Long: `Run the Go API and Vite frontend with HMR from an application directory.
+
+Backend reload uses air when it is on PATH, then watchexec, then falls back
+to go run ./cmd/server (with a hint). The frontend uses pnpm when available
+(or when frontend/pnpm-lock.yaml exists), otherwise npm.
+
+Vite proxies /api, /openapi.json, and /docs to the Go origin. When the live
+OpenAPI document changes, gombit regenerates frontend/src/api/generated
+(the same output as gombit client generate).
+
+A service table is printed at startup, including the API docs URL (/docs).
+
+SIGINT/SIGTERM stops the child processes. air/watchexec and Node.js are
+optional for reload/HMR; a missing frontend/package.json is an error
+(backend-only is not supported).
+
+The Vite stub from gombit new is enough to start HMR. The full React
+skeleton (router, React Hook Form, auth pages) is M5-1.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := dev.ValidateFlags(dev.DefaultHTTPAddr, frontendHost, frontendPort, poll, clientOut); err != nil {
+				return fmt.Errorf("gombit %w", err)
+			}
+			if !cmd.Flags().Changed("http") {
+				cfg, err := loadConfig()
+				if err != nil {
+					return fmt.Errorf("gombit dev: %w", err)
+				}
+				httpAddr = dev.HTTPAddrFromConfig(cfg)
+			}
+			if err := dev.ValidateFlags(httpAddr, frontendHost, frontendPort, poll, clientOut); err != nil {
+				return fmt.Errorf("gombit %w", err)
+			}
+			err := runDev(cmd.Context(), dev.Options{
+				WorkDir:      ".",
+				HTTPAddr:     httpAddr,
+				FrontendHost: frontendHost,
+				FrontendPort: frontendPort,
+				ClientOut:    clientOut,
+				PollInterval: poll,
+				Stdout:       stdout,
+				Stderr:       stderr,
+			})
+			if err != nil {
+				return fmt.Errorf("gombit %w", err)
+			}
+			return nil
+		},
+	})
+	cmd.Flags().StringVar(&httpAddr, "http", dev.DefaultHTTPAddr, "Go API listen address (default GOMBIT_HTTP_ADDR or :8080)")
+	cmd.Flags().StringVar(&frontendHost, "frontend-host", dev.DefaultFrontendHost, "Vite bind host")
+	cmd.Flags().IntVar(&frontendPort, "frontend-port", dev.DefaultFrontendPort, "Vite port")
+	cmd.Flags().StringVar(&clientOut, "client-out", dev.DefaultClientOut, "TypeScript client output directory")
+	cmd.Flags().DurationVar(&poll, "poll", dev.DefaultPollInterval, "OpenAPI poll interval")
+	return cmd
+}
+
+var runDev = dev.Run

--- a/cmd/gombit/dev_test.go
+++ b/cmd/gombit/dev_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/dev"
+)
+
+func TestRunHelpListsDev(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	err := run(context.Background(), []string{"--help"}, stdout, ioDiscard{})
+	if err != nil {
+		t.Fatalf("run(--help) error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "dev") {
+		t.Fatalf("root help missing dev:\n%s", stdout.String())
+	}
+}
+
+func TestRunDevHelp(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	err := run(context.Background(), []string{"dev", "--help"}, stdout, ioDiscard{})
+	if err != nil {
+		t.Fatalf("run(dev --help) error = %v", err)
+	}
+	got := stdout.String()
+	for _, want := range []string{"--http", "--frontend-port", "--frontend-host", "--poll", "--client-out", "/docs"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("dev help missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunDevFlagValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "zero frontend port", args: []string{"dev", "--frontend-port", "0"}, want: "--frontend-port"},
+		{name: "negative frontend port", args: []string{"dev", "--frontend-port", "-1"}, want: "--frontend-port"},
+		{name: "frontend port too large", args: []string{"dev", "--frontend-port", "70000"}, want: "--frontend-port"},
+		{name: "empty http", args: []string{"dev", "--http", " "}, want: "--http"},
+		{name: "zero poll", args: []string{"dev", "--poll", "0s"}, want: "--poll"},
+		{name: "empty client out", args: []string{"dev", "--client-out", " "}, want: "--client-out"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := run(context.Background(), tt.args, ioDiscard{}, ioDiscard{})
+			if err == nil {
+				t.Fatal("run() error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("run() error = %q, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunDevMissingFrontendPackageJSON(t *testing.T) {
+	chdir(t, t.TempDir())
+	if err := os.MkdirAll(filepath.Join("cmd", "server"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	err := run(context.Background(), []string{"dev"}, ioDiscard{}, ioDiscard{})
+	if err == nil {
+		t.Fatal("run() error = nil, want missing frontend/package.json")
+	}
+	if !strings.Contains(err.Error(), "frontend/package.json") {
+		t.Fatalf("run() error = %q, want frontend/package.json", err)
+	}
+}
+
+func TestRunDevUsesConfiguredHTTPAddr(t *testing.T) {
+	cfg := config.Default()
+	cfg.HTTP.Addr = "127.0.0.1:19090"
+	stubConfig(t, cfg)
+
+	var got dev.Options
+	previous := runDev
+	runDev = func(ctx context.Context, opts dev.Options) error {
+		got = opts
+		return errors.New("stopped")
+	}
+	t.Cleanup(func() { runDev = previous })
+
+	chdir(t, t.TempDir())
+	err := run(context.Background(), []string{"dev"}, ioDiscard{}, ioDiscard{})
+	if err == nil || !strings.Contains(err.Error(), "stopped") {
+		t.Fatalf("run() error = %v, want stopped", err)
+	}
+	if got.HTTPAddr != "127.0.0.1:19090" {
+		t.Fatalf("HTTPAddr = %q, want configured addr", got.HTTPAddr)
+	}
+}
+
+func TestRunDevHTTPFlagOverridesConfig(t *testing.T) {
+	cfg := config.Default()
+	cfg.HTTP.Addr = ":8080"
+	stubConfig(t, cfg)
+
+	var got dev.Options
+	previous := runDev
+	runDev = func(ctx context.Context, opts dev.Options) error {
+		got = opts
+		return errors.New("stopped")
+	}
+	t.Cleanup(func() { runDev = previous })
+
+	chdir(t, t.TempDir())
+	err := run(context.Background(), []string{"dev", "--http", ":9090"}, ioDiscard{}, ioDiscard{})
+	if err == nil || !strings.Contains(err.Error(), "stopped") {
+		t.Fatalf("run() error = %v, want stopped", err)
+	}
+	if got.HTTPAddr != ":9090" {
+		t.Fatalf("HTTPAddr = %q, want :9090", got.HTTPAddr)
+	}
+	if got.PollInterval != time.Second {
+		t.Fatalf("PollInterval = %s, want 1s", got.PollInterval)
+	}
+}
+
+func TestRunRejectsUnknownCommandUsageListsDev(t *testing.T) {
+	stderr := new(bytes.Buffer)
+	err := run(context.Background(), []string{"unknown"}, ioDiscard{}, stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want unknown command error")
+	}
+	if !strings.Contains(stderr.String(), "dev") {
+		t.Fatalf("usage = %q, want dev", stderr.String())
+	}
+}

--- a/cmd/gombit/main.go
+++ b/cmd/gombit/main.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/LAA-Software-Engineering/gombit/config"
 	"github.com/spf13/cobra"
@@ -15,7 +17,12 @@ import (
 var loadConfig = config.Load
 
 func main() {
-	if err := run(context.Background(), os.Args[1:], os.Stdout, os.Stderr); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := run(ctx, os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -47,6 +54,7 @@ func newRootCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
 	root.SetErr(stderr)
 	root.CompletionOptions.DisableDefaultCmd = true
 	root.AddCommand(newNewCommand(stdout, stderr))
+	root.AddCommand(newDevCommand(stdout, stderr))
 	root.AddCommand(newDBCommand(stdout, stderr))
 	root.AddCommand(newOpenAPICommand(stdout, stderr))
 	root.AddCommand(newClientCommand(stdout, stderr))
@@ -59,6 +67,7 @@ func rootLongHelp() string {
 		"",
 		"Command families:",
 		"  new       Scaffold a new application",
+		"  dev       Run the API and Vite frontend together",
 		"  db        Database migrations (makemigrations, migrate, rollback, status, seed, reset)",
 		"  openapi   Write the live OpenAPI 3.1 document",
 		"  client    Generate and check the TypeScript client",
@@ -69,6 +78,7 @@ func usage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "usage: gombit <command>")
 	_, _ = fmt.Fprintln(w, "available commands:")
 	_, _ = fmt.Fprintln(w, "  new [name]        scaffold a new Gombit application")
+	_, _ = fmt.Fprintln(w, "  dev               run the API and Vite frontend together")
 	_, _ = fmt.Fprintln(w, "  db <subcommand>   see gombit db")
 	_, _ = fmt.Fprintln(w, "  openapi generate [--out openapi.json] [--url http://127.0.0.1:8080/openapi.json]")
 	_, _ = fmt.Fprintln(w, "  client generate [--spec openapi.json] [--out frontend/src/api/generated] [--dry-run] [--force]")

--- a/cmd/gombit/new_test.go
+++ b/cmd/gombit/new_test.go
@@ -17,7 +17,7 @@ func TestRunHelpListsCommandFamilies(t *testing.T) {
 		t.Fatalf("run(--help) error = %v", err)
 	}
 	got := stdout.String()
-	for _, family := range []string{"new", "db", "openapi", "client"} {
+	for _, family := range []string{"new", "dev", "db", "openapi", "client"} {
 		if !strings.Contains(got, family) {
 			t.Fatalf("root help missing %q:\n%s", family, got)
 		}

--- a/dev/detect.go
+++ b/dev/detect.go
@@ -1,0 +1,76 @@
+package dev
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	reloadHint = "air and watchexec not found; running go run ./cmd/server without reload. Install air (https://github.com/air-verse/air) or watchexec for backend reload."
+)
+
+type backendPlan struct {
+	Name string
+	Path string
+	Args []string
+	Hint string
+}
+
+type frontendPlan struct {
+	Manager string
+	Path    string
+	Args    []string
+}
+
+func planBackend(workDir string, lookPath LookPathFunc) (backendPlan, error) {
+	if path, err := lookPath("air"); err == nil {
+		args := []string{}
+		if _, statErr := os.Stat(filepath.Join(workDir, ".air.toml")); statErr == nil {
+			args = []string{"-c", ".air.toml"}
+		}
+		return backendPlan{Name: "air", Path: path, Args: args}, nil
+	}
+	if path, err := lookPath("watchexec"); err == nil {
+		return backendPlan{
+			Name: "watchexec",
+			Path: path,
+			Args: []string{"-r", "-e", "go", "--", "go", "run", "./cmd/server"},
+		}, nil
+	}
+	goBin, err := lookPath("go")
+	if err != nil {
+		return backendPlan{}, fmt.Errorf("dev: go not found in PATH")
+	}
+	return backendPlan{
+		Name: "go",
+		Path: goBin,
+		Args: []string{"run", "./cmd/server"},
+		Hint: reloadHint,
+	}, nil
+}
+
+func planFrontend(workDir string, lookPath LookPathFunc, host string, port int) (frontendPlan, error) {
+	manager, path, err := detectPackageManager(workDir, lookPath)
+	if err != nil {
+		return frontendPlan{}, err
+	}
+	args := []string{"run", "dev", "--", "--host", host, "--port", fmt.Sprintf("%d", port)}
+	return frontendPlan{Manager: manager, Path: path, Args: args}, nil
+}
+
+func detectPackageManager(workDir string, lookPath LookPathFunc) (name, path string, err error) {
+	frontendDir := filepath.Join(workDir, "frontend")
+	if _, statErr := os.Stat(filepath.Join(frontendDir, "pnpm-lock.yaml")); statErr == nil {
+		if path, err := lookPath("pnpm"); err == nil {
+			return "pnpm", path, nil
+		}
+	}
+	if path, err := lookPath("pnpm"); err == nil {
+		return "pnpm", path, nil
+	}
+	if path, err := lookPath("npm"); err == nil {
+		return "npm", path, nil
+	}
+	return "", "", fmt.Errorf("dev: npm and pnpm not found; install Node.js to run the Vite frontend")
+}

--- a/dev/doc.go
+++ b/dev/doc.go
@@ -1,0 +1,4 @@
+// Package dev implements `gombit dev`: one command that runs the Go API
+// (with reload when air or watchexec is available), the Vite frontend with
+// HMR, and live OpenAPI → TypeScript client regeneration.
+package dev

--- a/dev/options.go
+++ b/dev/options.go
@@ -1,0 +1,182 @@
+package dev
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/client"
+	"github.com/LAA-Software-Engineering/gombit/config"
+)
+
+const (
+	// DefaultHTTPAddr is the Go API listen address when config and flags omit it.
+	DefaultHTTPAddr = ":8080"
+	// DefaultFrontendHost is the Vite bind host.
+	DefaultFrontendHost = "127.0.0.1"
+	// DefaultFrontendPort is Vite's conventional port.
+	DefaultFrontendPort = 5173
+	// DefaultPollInterval is how often the OpenAPI watcher fetches /openapi.json.
+	DefaultPollInterval = time.Second
+	// DefaultClientOut is the generated TypeScript client directory (design §23.3).
+	DefaultClientOut = client.DefaultOutDir
+)
+
+// CommandFunc starts a subprocess. Tests replace this with short-lived fakes.
+type CommandFunc func(name string, args ...string) *exec.Cmd
+
+// LookPathFunc locates an executable. Tests replace this to simulate air/pnpm.
+type LookPathFunc func(file string) (string, error)
+
+// HTTPGetFunc fetches a URL. Tests replace this to stub /openapi.json.
+type HTTPGetFunc func(ctx context.Context, rawURL string) ([]byte, error)
+
+// GenerateFunc regenerates the TypeScript client from an OpenAPI document.
+type GenerateFunc func(ctx context.Context, spec []byte) error
+
+// Options configures `gombit dev`.
+type Options struct {
+	WorkDir      string
+	HTTPAddr     string
+	FrontendHost string
+	FrontendPort int
+	ClientOut    string
+	PollInterval time.Duration
+	Stdout       io.Writer
+	Stderr       io.Writer
+	LookPath     LookPathFunc
+	Command      CommandFunc
+	HTTPGet      HTTPGetFunc
+	Generate     GenerateFunc
+	ShutdownWait time.Duration
+}
+
+func (opts *Options) normalize() error {
+	if opts.Stdout == nil {
+		opts.Stdout = io.Discard
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = io.Discard
+	}
+	if opts.LookPath == nil {
+		opts.LookPath = exec.LookPath
+	}
+	if opts.Command == nil {
+		opts.Command = exec.Command
+	}
+	if opts.WorkDir == "" {
+		opts.WorkDir = "."
+	}
+	abs, err := filepath.Abs(opts.WorkDir)
+	if err != nil {
+		return fmt.Errorf("dev: resolve work dir: %w", err)
+	}
+	opts.WorkDir = abs
+	if opts.HTTPAddr == "" {
+		opts.HTTPAddr = DefaultHTTPAddr
+	}
+	if opts.FrontendHost == "" {
+		opts.FrontendHost = DefaultFrontendHost
+	}
+	if opts.FrontendPort == 0 {
+		opts.FrontendPort = DefaultFrontendPort
+	}
+	if opts.ClientOut == "" {
+		opts.ClientOut = DefaultClientOut
+	}
+	if opts.PollInterval == 0 {
+		opts.PollInterval = DefaultPollInterval
+	}
+	if opts.ShutdownWait == 0 {
+		opts.ShutdownWait = 3 * time.Second
+	}
+	return nil
+}
+
+// ValidateFlags reports user-facing errors for `gombit dev` flag values
+// before defaults are applied.
+func ValidateFlags(httpAddr string, frontendHost string, frontendPort int, poll time.Duration, clientOut string) error {
+	if strings.TrimSpace(httpAddr) == "" {
+		return errors.New("dev: --http must not be empty")
+	}
+	if _, err := parseListenAddr(httpAddr); err != nil {
+		return fmt.Errorf("dev: --http: %w", err)
+	}
+	if strings.TrimSpace(frontendHost) == "" {
+		return errors.New("dev: --frontend-host must not be empty")
+	}
+	if frontendPort < 1 || frontendPort > 65535 {
+		return fmt.Errorf("dev: --frontend-port must be between 1 and 65535, got %d", frontendPort)
+	}
+	if poll <= 0 {
+		return errors.New("dev: --poll must be greater than zero")
+	}
+	if strings.TrimSpace(clientOut) == "" {
+		return errors.New("dev: --client-out must not be empty")
+	}
+	return nil
+}
+
+func (opts Options) validate() error {
+	return ValidateFlags(opts.HTTPAddr, opts.FrontendHost, opts.FrontendPort, opts.PollInterval, opts.ClientOut)
+}
+
+// HTTPAddrFromConfig returns the listen address from cfg, or DefaultHTTPAddr.
+func HTTPAddrFromConfig(cfg config.Config) string {
+	addr := strings.TrimSpace(cfg.HTTP.Addr)
+	if addr == "" {
+		return DefaultHTTPAddr
+	}
+	return addr
+}
+
+func parseListenAddr(addr string) (hostPort string, err error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return "", errors.New("address must not be empty")
+	}
+	if !strings.Contains(addr, ":") {
+		addr = ":" + addr
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", err
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return "", fmt.Errorf("invalid port %q", port)
+	}
+	if host == "" && port == "" {
+		return "", errors.New("address must not be empty")
+	}
+	return addr, nil
+}
+
+func originFromAddr(addr string) string {
+	normalized, err := parseListenAddr(addr)
+	if err != nil {
+		normalized = DefaultHTTPAddr
+	}
+	host, port, err := net.SplitHostPort(normalized)
+	if err != nil {
+		return "http://127.0.0.1:8080"
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" || host == "[::]" {
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, port)
+}
+
+func frontendOrigin(host string, port int) string {
+	display := host
+	if display == "" || display == "0.0.0.0" || display == "::" || display == "[::]" {
+		display = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(display, strconv.Itoa(port))
+}

--- a/dev/options_test.go
+++ b/dev/options_test.go
@@ -1,0 +1,115 @@
+package dev
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		httpAddr     string
+		frontendHost string
+		frontendPort int
+		poll         time.Duration
+		clientOut    string
+		want         string
+	}{
+		{
+			name:         "empty http",
+			httpAddr:     "   ",
+			frontendHost: DefaultFrontendHost,
+			frontendPort: DefaultFrontendPort,
+			poll:         DefaultPollInterval,
+			clientOut:    DefaultClientOut,
+			want:         "--http",
+		},
+		{
+			name:         "invalid http",
+			httpAddr:     "not-an-addr",
+			frontendHost: DefaultFrontendHost,
+			frontendPort: DefaultFrontendPort,
+			poll:         DefaultPollInterval,
+			clientOut:    DefaultClientOut,
+			want:         "--http",
+		},
+		{
+			name:         "empty frontend host",
+			httpAddr:     DefaultHTTPAddr,
+			frontendHost: " ",
+			frontendPort: DefaultFrontendPort,
+			poll:         DefaultPollInterval,
+			clientOut:    DefaultClientOut,
+			want:         "--frontend-host",
+		},
+		{
+			name:         "zero frontend port",
+			httpAddr:     DefaultHTTPAddr,
+			frontendHost: DefaultFrontendHost,
+			frontendPort: 0,
+			poll:         DefaultPollInterval,
+			clientOut:    DefaultClientOut,
+			want:         "--frontend-port",
+		},
+		{
+			name:         "negative frontend port",
+			httpAddr:     DefaultHTTPAddr,
+			frontendHost: DefaultFrontendHost,
+			frontendPort: -1,
+			poll:         DefaultPollInterval,
+			clientOut:    DefaultClientOut,
+			want:         "--frontend-port",
+		},
+		{
+			name:         "frontend port too large",
+			httpAddr:     DefaultHTTPAddr,
+			frontendHost: DefaultFrontendHost,
+			frontendPort: 70000,
+			poll:         DefaultPollInterval,
+			clientOut:    DefaultClientOut,
+			want:         "--frontend-port",
+		},
+		{
+			name:         "zero poll",
+			httpAddr:     DefaultHTTPAddr,
+			frontendHost: DefaultFrontendHost,
+			frontendPort: DefaultFrontendPort,
+			poll:         0,
+			clientOut:    DefaultClientOut,
+			want:         "--poll",
+		},
+		{
+			name:         "empty client out",
+			httpAddr:     DefaultHTTPAddr,
+			frontendHost: DefaultFrontendHost,
+			frontendPort: DefaultFrontendPort,
+			poll:         DefaultPollInterval,
+			clientOut:    " ",
+			want:         "--client-out",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateFlags(tt.httpAddr, tt.frontendHost, tt.frontendPort, tt.poll, tt.clientOut)
+			if err == nil {
+				t.Fatal("ValidateFlags() error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ValidateFlags() error = %q, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateFlagsOK(t *testing.T) {
+	t.Parallel()
+	err := ValidateFlags(DefaultHTTPAddr, DefaultFrontendHost, DefaultFrontendPort, DefaultPollInterval, DefaultClientOut)
+	if err != nil {
+		t.Fatalf("ValidateFlags() error = %v", err)
+	}
+}

--- a/dev/run.go
+++ b/dev/run.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -67,7 +69,7 @@ func Run(ctx context.Context, opts Options) error {
 	}
 
 	frontendDir := filepath.Join(opts.WorkDir, "frontend")
-	if _, err := os.Stat(filepath.Join(frontendDir, "node_modules")); os.IsNotExist(err) {
+	if !frontendDepsInstalled(frontendDir) {
 		install := ProcSpec{
 			Name: "frontend-install",
 			Dir:  frontendDir,
@@ -83,13 +85,7 @@ func Run(ctx context.Context, opts Options) error {
 		}
 	}
 
-	childEnv := append([]string{}, os.Environ()...)
-	childEnv = append(childEnv,
-		"GOMBIT_HTTP_ADDR="+opts.HTTPAddr,
-		"GOMBIT_DEV_BACKEND="+services.Backend,
-		"GOMBIT_DEV_FRONTEND_PORT="+strconv.Itoa(opts.FrontendPort),
-		"VITE_API_URL=/api/v1",
-	)
+	env := childEnv(os.Environ(), opts, services.Backend)
 
 	procs := []ProcSpec{
 		{
@@ -97,14 +93,14 @@ func Run(ctx context.Context, opts Options) error {
 			Dir:  opts.WorkDir,
 			Path: backend.Path,
 			Args: backend.Args,
-			Env:  childEnv,
+			Env:  env,
 		},
 		{
 			Name: "frontend",
 			Dir:  frontendDir,
 			Path: frontend.Path,
 			Args: frontend.Args,
-			Env:  childEnv,
+			Env:  env,
 		},
 	}
 
@@ -127,4 +123,44 @@ func Run(ctx context.Context, opts Options) error {
 		return err
 	}
 	return nil
+}
+
+func frontendDepsInstalled(frontendDir string) bool {
+	info, err := os.Stat(filepath.Join(frontendDir, "node_modules"))
+	return err == nil && info.IsDir()
+}
+
+// childEnv copies parent then replaces the keys gombit dev owns so Linux
+// first-wins getenv cannot keep a parent GOMBIT_HTTP_ADDR / VITE_API_URL.
+func childEnv(parent []string, opts Options, backendOrigin string) []string {
+	return overlayEnv(parent,
+		"GOMBIT_HTTP_ADDR="+opts.HTTPAddr,
+		"GOMBIT_DEV_BACKEND="+backendOrigin,
+		"GOMBIT_DEV_FRONTEND_HOST="+opts.FrontendHost,
+		"GOMBIT_DEV_FRONTEND_PORT="+strconv.Itoa(opts.FrontendPort),
+		"VITE_API_URL=/api/v1",
+	)
+}
+
+func overlayEnv(parent []string, pairs ...string) []string {
+	drop := make(map[string]struct{}, len(pairs))
+	for _, pair := range pairs {
+		drop[envKey(pair)] = struct{}{}
+	}
+	out := make([]string, 0, len(parent)+len(pairs))
+	for _, entry := range parent {
+		if _, skip := drop[envKey(entry)]; skip {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return append(out, pairs...)
+}
+
+func envKey(entry string) string {
+	key, _, _ := strings.Cut(entry, "=")
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(key)
+	}
+	return key
 }

--- a/dev/run.go
+++ b/dev/run.go
@@ -1,0 +1,130 @@
+package dev
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+const (
+	errMissingFrontend = "dev: missing frontend/package.json; gombit dev requires the Vite frontend (backend-only is not supported). Re-run gombit new or add a frontend/package.json"
+	errMissingServer   = "dev: missing cmd/server; run gombit dev from a Gombit application directory"
+)
+
+// Run starts the backend, Vite frontend, and OpenAPI client watcher until ctx is cancelled.
+func Run(ctx context.Context, opts Options) error {
+	if ctx == nil {
+		return errors.New("dev: nil context")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := opts.normalize(); err != nil {
+		return err
+	}
+	if err := opts.validate(); err != nil {
+		return err
+	}
+
+	frontendPkg := filepath.Join(opts.WorkDir, "frontend", "package.json")
+	if _, err := os.Stat(frontendPkg); err != nil {
+		if os.IsNotExist(err) {
+			return errors.New(errMissingFrontend)
+		}
+		return fmt.Errorf("dev: stat frontend/package.json: %w", err)
+	}
+	serverDir := filepath.Join(opts.WorkDir, "cmd", "server")
+	if info, err := os.Stat(serverDir); err != nil || !info.IsDir() {
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("dev: stat cmd/server: %w", err)
+		}
+		return errors.New(errMissingServer)
+	}
+
+	backend, err := planBackend(opts.WorkDir, opts.LookPath)
+	if err != nil {
+		return err
+	}
+	frontend, err := planFrontend(opts.WorkDir, opts.LookPath, opts.FrontendHost, opts.FrontendPort)
+	if err != nil {
+		return err
+	}
+
+	services := Services{
+		Backend:  originFromAddr(opts.HTTPAddr),
+		Frontend: frontendOrigin(opts.FrontendHost, opts.FrontendPort),
+	}
+	if _, err := fmt.Fprint(opts.Stdout, FormatServiceTable(services)); err != nil {
+		return err
+	}
+	if backend.Hint != "" {
+		if _, err := fmt.Fprintln(opts.Stderr, backend.Hint); err != nil {
+			return err
+		}
+	}
+
+	frontendDir := filepath.Join(opts.WorkDir, "frontend")
+	if _, err := os.Stat(filepath.Join(frontendDir, "node_modules")); os.IsNotExist(err) {
+		install := ProcSpec{
+			Name: "frontend-install",
+			Dir:  frontendDir,
+			Path: frontend.Path,
+			Args: []string{"install"},
+			Env:  os.Environ(),
+		}
+		if _, err := fmt.Fprintf(opts.Stdout, "installing frontend dependencies with %s\n", frontend.Manager); err != nil {
+			return err
+		}
+		if err := runOne(ctx, install, opts.Stdout, opts.Stderr, opts.Command); err != nil {
+			return fmt.Errorf("dev: %s install: %w", frontend.Manager, err)
+		}
+	}
+
+	childEnv := append([]string{}, os.Environ()...)
+	childEnv = append(childEnv,
+		"GOMBIT_HTTP_ADDR="+opts.HTTPAddr,
+		"GOMBIT_DEV_BACKEND="+services.Backend,
+		"GOMBIT_DEV_FRONTEND_PORT="+strconv.Itoa(opts.FrontendPort),
+		"VITE_API_URL=/api/v1",
+	)
+
+	procs := []ProcSpec{
+		{
+			Name: "backend",
+			Dir:  opts.WorkDir,
+			Path: backend.Path,
+			Args: backend.Args,
+			Env:  childEnv,
+		},
+		{
+			Name: "frontend",
+			Dir:  frontendDir,
+			Path: frontend.Path,
+			Args: frontend.Args,
+			Env:  childEnv,
+		},
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	watchDone := make(chan struct{})
+	go func() {
+		defer close(watchDone)
+		_ = watchOpenAPI(runCtx, opts, services.Backend+"/openapi.json")
+	}()
+
+	err = runProcesses(runCtx, procs, opts.Stdout, opts.Stderr, opts.Command, opts.ShutdownWait)
+	cancel()
+	<-watchDone
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
+}

--- a/dev/run_test.go
+++ b/dev/run_test.go
@@ -1,0 +1,316 @@
+package dev
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRunMissingFrontendPackageJSON(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workDir, "cmd", "server"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	err := Run(context.Background(), Options{WorkDir: workDir})
+	if err == nil {
+		t.Fatal("Run() error = nil, want missing frontend/package.json")
+	}
+	if !strings.Contains(err.Error(), "frontend/package.json") {
+		t.Fatalf("Run() error = %q, want frontend/package.json", err)
+	}
+	if !strings.Contains(err.Error(), "backend-only") {
+		t.Fatalf("Run() error = %q, want backend-only hint", err)
+	}
+}
+
+func TestRunMissingServer(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	writeFile(t, filepath.Join(workDir, "frontend", "package.json"), `{"name":"frontend"}`)
+	err := Run(context.Background(), Options{WorkDir: workDir})
+	if err == nil {
+		t.Fatal("Run() error = nil, want missing cmd/server")
+	}
+	if !strings.Contains(err.Error(), "cmd/server") {
+		t.Fatalf("Run() error = %q, want cmd/server", err)
+	}
+}
+
+func TestRunPrintsServiceTableAndShutsDown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX sh process-group shutdown")
+	}
+
+	workDir := writeDevApp(t)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	var started atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	startedCh := make(chan struct{}, 2)
+	opts := Options{
+		WorkDir:      workDir,
+		HTTPAddr:     ":18080",
+		FrontendPort: 15173,
+		PollInterval: 50 * time.Millisecond,
+		ShutdownWait: 2 * time.Second,
+		Stdout:       stdout,
+		Stderr:       stderr,
+		LookPath: func(file string) (string, error) {
+			switch file {
+			case "go", "npm":
+				return file, nil
+			default:
+				return "", errors.New("not found")
+			}
+		},
+		Command: func(name string, args ...string) *exec.Cmd {
+			started.Add(1)
+			startedCh <- struct{}{}
+			return exec.Command("sh", "-c", "echo ready; trap 'exit 0' TERM; sleep 60")
+		},
+		HTTPGet: func(ctx context.Context, rawURL string) ([]byte, error) {
+			return nil, errors.New("backend not ready")
+		},
+		Generate: func(ctx context.Context, spec []byte) error {
+			t.Fatal("Generate should not run when HTTPGet fails")
+			return nil
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(ctx, opts)
+	}()
+
+	waitStarts(t, startedCh, 2)
+	got := stdout.String()
+	if !strings.Contains(got, "/docs") || !strings.Contains(got, "/openapi.json") {
+		t.Fatalf("stdout missing service table:\n%s", got)
+	}
+	if !strings.Contains(got, "http://127.0.0.1:18080") {
+		t.Fatalf("stdout missing backend URL:\n%s", got)
+	}
+	if !strings.Contains(got, "http://127.0.0.1:15173") {
+		t.Fatalf("stdout missing frontend URL:\n%s", got)
+	}
+	if !strings.Contains(stderr.String(), "without reload") {
+		t.Fatalf("stderr = %q, want reload hint", stderr.String())
+	}
+	if started.Load() < 2 {
+		t.Fatalf("started %d child commands, want at least 2", started.Load())
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run() error = %v, want nil after cancel", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not return after cancel")
+	}
+}
+
+func TestRunProcessesShutdownOnCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX sh process-group shutdown")
+	}
+
+	var started atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	startedCh := make(chan struct{}, 2)
+	specs := []ProcSpec{
+		{Name: "backend", Path: "sh", Args: []string{"-c", "echo ready; trap 'exit 0' TERM; sleep 60"}},
+		{Name: "frontend", Path: "sh", Args: []string{"-c", "echo ready; trap 'exit 0' TERM; sleep 60"}},
+	}
+	command := func(name string, args ...string) *exec.Cmd {
+		started.Add(1)
+		startedCh <- struct{}{}
+		return exec.Command(name, args...) //nolint:gosec // test helper rebuilds the injected sh command
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runProcesses(ctx, specs, ioDiscard{}, ioDiscard{}, command, 2*time.Second)
+	}()
+
+	waitStarts(t, startedCh, 2)
+	if started.Load() != 2 {
+		t.Fatalf("started = %d, want 2", started.Load())
+	}
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("runProcesses() error = %v, want nil after cancel", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runProcesses() did not return after cancel")
+	}
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func writeDevApp(t *testing.T) string {
+	t.Helper()
+	workDir := t.TempDir()
+	writeFile(t, filepath.Join(workDir, "frontend", "package.json"), `{"name":"frontend","scripts":{"dev":"vite"}}`)
+	if err := os.MkdirAll(filepath.Join(workDir, "frontend", "node_modules"), 0o750); err != nil {
+		t.Fatalf("mkdir node_modules: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workDir, "cmd", "server"), 0o750); err != nil {
+		t.Fatalf("mkdir cmd/server: %v", err)
+	}
+	writeFile(t, filepath.Join(workDir, "cmd", "server", "main.go"), "package main\nfunc main() {}\n")
+	return workDir
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func waitStarts(t *testing.T, startedCh <-chan struct{}, n int) {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for i := 0; i < n; i++ {
+		select {
+		case <-startedCh:
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d child starts (got %d)", n, i)
+		}
+	}
+}
+
+func TestPlanBackendPrefersAir(t *testing.T) {
+	t.Parallel()
+	plan, err := planBackend(t.TempDir(), func(file string) (string, error) {
+		if file == "air" {
+			return "/usr/bin/air", nil
+		}
+		return "", errors.New("missing")
+	})
+	if err != nil {
+		t.Fatalf("planBackend() error = %v", err)
+	}
+	if plan.Name != "air" {
+		t.Fatalf("plan.Name = %q, want air", plan.Name)
+	}
+	if plan.Hint != "" {
+		t.Fatalf("plan.Hint = %q, want empty", plan.Hint)
+	}
+}
+
+func TestPlanBackendPrefersWatchexecOverGoRun(t *testing.T) {
+	t.Parallel()
+	plan, err := planBackend(t.TempDir(), func(file string) (string, error) {
+		switch file {
+		case "watchexec":
+			return "/usr/bin/watchexec", nil
+		case "go":
+			return "/usr/bin/go", nil
+		default:
+			return "", errors.New("missing")
+		}
+	})
+	if err != nil {
+		t.Fatalf("planBackend() error = %v", err)
+	}
+	if plan.Name != "watchexec" {
+		t.Fatalf("plan.Name = %q, want watchexec", plan.Name)
+	}
+}
+
+func TestPlanBackendUsesAirConfigWhenPresent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".air.toml"), "root = \".\"\n")
+	plan, err := planBackend(dir, func(file string) (string, error) {
+		if file == "air" {
+			return "/usr/bin/air", nil
+		}
+		return "", errors.New("missing")
+	})
+	if err != nil {
+		t.Fatalf("planBackend() error = %v", err)
+	}
+	if len(plan.Args) != 2 || plan.Args[0] != "-c" || plan.Args[1] != ".air.toml" {
+		t.Fatalf("plan.Args = %v, want -c .air.toml", plan.Args)
+	}
+}
+
+func TestPlanBackendFallsBackToGoRun(t *testing.T) {
+	t.Parallel()
+	plan, err := planBackend(t.TempDir(), func(file string) (string, error) {
+		if file == "go" {
+			return "/usr/bin/go", nil
+		}
+		return "", errors.New("missing")
+	})
+	if err != nil {
+		t.Fatalf("planBackend() error = %v", err)
+	}
+	if plan.Name != "go" {
+		t.Fatalf("plan.Name = %q, want go", plan.Name)
+	}
+	if !strings.Contains(plan.Hint, "air and watchexec") {
+		t.Fatalf("plan.Hint = %q, want reload hint", plan.Hint)
+	}
+}
+
+func TestDetectPackageManagerPrefersPnpm(t *testing.T) {
+	t.Parallel()
+	name, _, err := detectPackageManager(t.TempDir(), func(file string) (string, error) {
+		switch file {
+		case "pnpm":
+			return "/usr/bin/pnpm", nil
+		case "npm":
+			return "/usr/bin/npm", nil
+		default:
+			return "", errors.New("missing")
+		}
+	})
+	if err != nil {
+		t.Fatalf("detectPackageManager() error = %v", err)
+	}
+	if name != "pnpm" {
+		t.Fatalf("manager = %q, want pnpm", name)
+	}
+}
+
+func TestDetectPackageManagerRequiresNode(t *testing.T) {
+	t.Parallel()
+	_, _, err := detectPackageManager(t.TempDir(), func(string) (string, error) {
+		return "", errors.New("missing")
+	})
+	if err == nil {
+		t.Fatal("detectPackageManager() error = nil, want npm/pnpm missing")
+	}
+	if !strings.Contains(err.Error(), "npm and pnpm") {
+		t.Fatalf("error = %q, want npm and pnpm", err)
+	}
+}

--- a/dev/run_test.go
+++ b/dev/run_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -313,4 +314,223 @@ func TestDetectPackageManagerRequiresNode(t *testing.T) {
 	if !strings.Contains(err.Error(), "npm and pnpm") {
 		t.Fatalf("error = %q, want npm and pnpm", err)
 	}
+}
+
+func TestDetectPackageManagerFallsBackToNpm(t *testing.T) {
+	t.Parallel()
+	name, path, err := detectPackageManager(t.TempDir(), func(file string) (string, error) {
+		if file == "npm" {
+			return "/usr/bin/npm", nil
+		}
+		return "", errors.New("missing")
+	})
+	if err != nil {
+		t.Fatalf("detectPackageManager() error = %v", err)
+	}
+	if name != "npm" {
+		t.Fatalf("manager = %q, want npm", name)
+	}
+	if path != "/usr/bin/npm" {
+		t.Fatalf("path = %q, want /usr/bin/npm", path)
+	}
+}
+
+func TestPlanFrontendUsesHostPortAndPnpm(t *testing.T) {
+	t.Parallel()
+	plan, err := planFrontend(t.TempDir(), func(file string) (string, error) {
+		if file == "pnpm" {
+			return "/usr/bin/pnpm", nil
+		}
+		return "", errors.New("missing")
+	}, "0.0.0.0", 4173)
+	if err != nil {
+		t.Fatalf("planFrontend() error = %v", err)
+	}
+	if plan.Manager != "pnpm" {
+		t.Fatalf("plan.Manager = %q, want pnpm", plan.Manager)
+	}
+	want := []string{"run", "dev", "--", "--host", "0.0.0.0", "--port", "4173"}
+	if strings.Join(plan.Args, " ") != strings.Join(want, " ") {
+		t.Fatalf("plan.Args = %v, want %v", plan.Args, want)
+	}
+}
+
+func TestPlanFrontendFallsBackToNpm(t *testing.T) {
+	t.Parallel()
+	plan, err := planFrontend(t.TempDir(), func(file string) (string, error) {
+		if file == "npm" {
+			return "/usr/bin/npm", nil
+		}
+		return "", errors.New("missing")
+	}, "127.0.0.1", 5173)
+	if err != nil {
+		t.Fatalf("planFrontend() error = %v", err)
+	}
+	if plan.Manager != "npm" {
+		t.Fatalf("plan.Manager = %q, want npm", plan.Manager)
+	}
+	if plan.Path != "/usr/bin/npm" {
+		t.Fatalf("plan.Path = %q, want /usr/bin/npm", plan.Path)
+	}
+	want := []string{"run", "dev", "--", "--host", "127.0.0.1", "--port", "5173"}
+	if strings.Join(plan.Args, " ") != strings.Join(want, " ") {
+		t.Fatalf("plan.Args = %v, want %v", plan.Args, want)
+	}
+}
+
+func TestFrontendDepsInstalledRequiresDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if frontendDepsInstalled(dir) {
+		t.Fatal("missing node_modules reported as installed")
+	}
+	writeFile(t, filepath.Join(dir, "node_modules"), "not a directory")
+	if frontendDepsInstalled(dir) {
+		t.Fatal("node_modules file reported as installed")
+	}
+	if err := os.Remove(filepath.Join(dir, "node_modules")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "node_modules"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if !frontendDepsInstalled(dir) {
+		t.Fatal("node_modules directory reported as missing")
+	}
+}
+
+func TestOverlayEnvReplacesParentKeys(t *testing.T) {
+	t.Parallel()
+	parent := []string{
+		"PATH=/usr/bin",
+		"GOMBIT_HTTP_ADDR=:8080",
+		"VITE_API_URL=http://localhost:8080/api/v1",
+		"GOMBIT_HTTP_ADDR=:8080",
+		"HOME=/tmp",
+	}
+	got := overlayEnv(parent, "GOMBIT_HTTP_ADDR=:9090", "VITE_API_URL=/api/v1")
+	if values := envKeyValues(got, "GOMBIT_HTTP_ADDR"); len(values) != 1 || values[0] != ":9090" {
+		t.Fatalf("GOMBIT_HTTP_ADDR = %v, want single :9090", values)
+	}
+	if values := envKeyValues(got, "VITE_API_URL"); len(values) != 1 || values[0] != "/api/v1" {
+		t.Fatalf("VITE_API_URL = %v, want single /api/v1", values)
+	}
+	if values := envKeyValues(got, "PATH"); len(values) != 1 || values[0] != "/usr/bin" {
+		t.Fatalf("PATH = %v, want preserved /usr/bin", values)
+	}
+}
+
+func TestChildEnvReplacesParentKeysOnProcSpec(t *testing.T) {
+	t.Parallel()
+	parent := []string{
+		"GOMBIT_HTTP_ADDR=:8080",
+		"VITE_API_URL=http://localhost:8080/api/v1",
+		"GOMBIT_DEV_FRONTEND_HOST=0.0.0.0",
+	}
+	opts := Options{
+		HTTPAddr:     ":9090",
+		FrontendHost: "127.0.0.1",
+		FrontendPort: 4173,
+	}
+	spec := ProcSpec{Name: "backend", Env: childEnv(parent, opts, "http://127.0.0.1:9090")}
+	if values := envKeyValues(spec.Env, "GOMBIT_HTTP_ADDR"); len(values) != 1 || values[0] != opts.HTTPAddr {
+		t.Fatalf("ProcSpec.Env GOMBIT_HTTP_ADDR = %v, want single %s", values, opts.HTTPAddr)
+	}
+	if values := envKeyValues(spec.Env, "VITE_API_URL"); len(values) != 1 || values[0] != "/api/v1" {
+		t.Fatalf("ProcSpec.Env VITE_API_URL = %v, want single /api/v1", values)
+	}
+	if values := envKeyValues(spec.Env, "GOMBIT_DEV_FRONTEND_HOST"); len(values) != 1 || values[0] != "127.0.0.1" {
+		t.Fatalf("ProcSpec.Env GOMBIT_DEV_FRONTEND_HOST = %v, want 127.0.0.1", values)
+	}
+}
+
+func TestRunChildEnvReplacesParentHTTPAddr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX sh process-group shutdown")
+	}
+
+	t.Setenv("GOMBIT_HTTP_ADDR", ":8080")
+	t.Setenv("VITE_API_URL", "http://localhost:8080/api/v1")
+
+	workDir := writeDevApp(t)
+	stdout := new(bytes.Buffer)
+	var mu sync.Mutex
+	var cmds []*exec.Cmd
+	startedCh := make(chan struct{}, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	opts := Options{
+		WorkDir:      workDir,
+		HTTPAddr:     ":9090",
+		FrontendPort: 15174,
+		PollInterval: 50 * time.Millisecond,
+		ShutdownWait: 2 * time.Second,
+		Stdout:       stdout,
+		Stderr:       ioDiscard{},
+		LookPath: func(file string) (string, error) {
+			switch file {
+			case "go", "npm":
+				return file, nil
+			default:
+				return "", errors.New("not found")
+			}
+		},
+		Command: func(name string, args ...string) *exec.Cmd {
+			cmd := exec.Command("sh", "-c", "echo ready; trap 'exit 0' TERM; sleep 60")
+			mu.Lock()
+			cmds = append(cmds, cmd)
+			mu.Unlock()
+			startedCh <- struct{}{}
+			return cmd
+		},
+		HTTPGet: func(ctx context.Context, rawURL string) ([]byte, error) {
+			return nil, errors.New("backend not ready")
+		},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(ctx, opts)
+	}()
+
+	waitStarts(t, startedCh, 2)
+	mu.Lock()
+	captured := append([]*exec.Cmd(nil), cmds...)
+	mu.Unlock()
+	if len(captured) < 2 {
+		t.Fatalf("started %d commands, want 2", len(captured))
+	}
+	for _, cmd := range captured {
+		if values := envKeyValues(cmd.Env, "GOMBIT_HTTP_ADDR"); len(values) != 1 || values[0] != ":9090" {
+			t.Fatalf("child Env GOMBIT_HTTP_ADDR = %v, want single :9090", values)
+		}
+		if values := envKeyValues(cmd.Env, "VITE_API_URL"); len(values) != 1 || values[0] != "/api/v1" {
+			t.Fatalf("child Env VITE_API_URL = %v, want single /api/v1", values)
+		}
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run() error = %v, want nil after cancel", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not return after cancel")
+	}
+}
+
+func envKeyValues(env []string, key string) []string {
+	var values []string
+	for _, entry := range env {
+		k, v, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		if k == key || (runtime.GOOS == "windows" && strings.EqualFold(k, key)) {
+			values = append(values, v)
+		}
+	}
+	return values
 }

--- a/dev/supervisor.go
+++ b/dev/supervisor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -37,7 +38,7 @@ func runProcesses(ctx context.Context, specs []ProcSpec, stdout, stderr io.Write
 		cmd := command(spec.Path, spec.Args...) //nolint:gosec // path/args come from LookPath and fixed flags
 		if cmd == nil {
 			cancel()
-			waitAll(&wg, &mu, running, wait)
+			_ = waitAll(&wg, &mu, running, wait)
 			return fmt.Errorf("dev: nil command for %s", spec.Name)
 		}
 		cmd.Dir = spec.Dir
@@ -53,7 +54,7 @@ func runProcesses(ctx context.Context, specs []ProcSpec, stdout, stderr io.Write
 		prepareProcessGroup(cmd)
 		if err := cmd.Start(); err != nil {
 			cancel()
-			waitAll(&wg, &mu, running, wait)
+			_ = waitAll(&wg, &mu, running, wait)
 			return fmt.Errorf("dev: start %s: %w", spec.Name, err)
 		}
 		mu.Lock()
@@ -79,11 +80,13 @@ func runProcesses(ctx context.Context, specs []ProcSpec, stdout, stderr io.Write
 	case <-runCtx.Done():
 	case err := <-errCh:
 		cancel()
-		waitAll(&wg, &mu, running, wait)
+		_ = waitAll(&wg, &mu, running, wait)
 		return err
 	}
 
-	waitAll(&wg, &mu, running, wait)
+	if err := waitAll(&wg, &mu, running, wait); err != nil {
+		return err
+	}
 	select {
 	case err := <-errCh:
 		return err
@@ -92,7 +95,7 @@ func runProcesses(ctx context.Context, specs []ProcSpec, stdout, stderr io.Write
 	}
 }
 
-func waitAll(wg *sync.WaitGroup, mu *sync.Mutex, running []*exec.Cmd, wait time.Duration) {
+func waitAll(wg *sync.WaitGroup, mu *sync.Mutex, running []*exec.Cmd, wait time.Duration) error {
 	mu.Lock()
 	cmds := append([]*exec.Cmd(nil), running...)
 	mu.Unlock()
@@ -107,15 +110,30 @@ func waitAll(wg *sync.WaitGroup, mu *sync.Mutex, running []*exec.Cmd, wait time.
 	}()
 	select {
 	case <-done:
-		return
+		return nil
 	case <-time.After(wait):
 		mu.Lock()
 		for _, cmd := range running {
 			_ = killProcessGroup(cmd)
 		}
 		mu.Unlock()
-		<-done
+		select {
+		case <-done:
+			return nil
+		case <-time.After(wait):
+			return fmt.Errorf("dev: timed out waiting for child processes to exit")
+		}
 	}
+}
+
+// windowsTaskkillArgs builds `taskkill` flags that terminate a PID and its
+// descendants. Used by the Windows supervisor; tested on all platforms.
+func windowsTaskkillArgs(pid int, force bool) []string {
+	args := []string{"/T"}
+	if force {
+		args = append(args, "/F")
+	}
+	return append(args, "/PID", strconv.Itoa(pid))
 }
 
 func runOne(ctx context.Context, spec ProcSpec, stdout, stderr io.Writer, command CommandFunc) error {
@@ -153,7 +171,10 @@ func runOne(ctx context.Context, spec ProcSpec, stdout, stderr io.Writer, comman
 		case <-done:
 		case <-time.After(2 * time.Second):
 			_ = killProcessGroup(cmd)
-			<-done
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+			}
 		}
 		return ctx.Err()
 	}

--- a/dev/supervisor.go
+++ b/dev/supervisor.go
@@ -1,0 +1,160 @@
+package dev
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// ProcSpec is one supervised child process.
+type ProcSpec struct {
+	Name string
+	Dir  string
+	Env  []string
+	Path string
+	Args []string
+}
+
+func runProcesses(ctx context.Context, specs []ProcSpec, stdout, stderr io.Writer, command CommandFunc, wait time.Duration) error {
+	if command == nil {
+		command = exec.Command
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var mu sync.Mutex
+	running := make([]*exec.Cmd, 0, len(specs))
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(specs))
+
+	for _, spec := range specs {
+		if err := runCtx.Err(); err != nil {
+			break
+		}
+		cmd := command(spec.Path, spec.Args...) //nolint:gosec // path/args come from LookPath and fixed flags
+		if cmd == nil {
+			cancel()
+			waitAll(&wg, &mu, running, wait)
+			return fmt.Errorf("dev: nil command for %s", spec.Name)
+		}
+		cmd.Dir = spec.Dir
+		if len(spec.Env) > 0 {
+			cmd.Env = spec.Env
+		}
+		if cmd.Stdout == nil {
+			cmd.Stdout = stdout
+		}
+		if cmd.Stderr == nil {
+			cmd.Stderr = stderr
+		}
+		prepareProcessGroup(cmd)
+		if err := cmd.Start(); err != nil {
+			cancel()
+			waitAll(&wg, &mu, running, wait)
+			return fmt.Errorf("dev: start %s: %w", spec.Name, err)
+		}
+		mu.Lock()
+		running = append(running, cmd)
+		mu.Unlock()
+		wg.Add(1)
+		go func(name string, cmd *exec.Cmd) {
+			defer wg.Done()
+			err := cmd.Wait()
+			if runCtx.Err() != nil {
+				return
+			}
+			if err != nil {
+				errCh <- fmt.Errorf("dev: %s: %w", name, err)
+			} else {
+				errCh <- fmt.Errorf("dev: %s exited unexpectedly", name)
+			}
+			cancel()
+		}(spec.Name, cmd)
+	}
+
+	select {
+	case <-runCtx.Done():
+	case err := <-errCh:
+		cancel()
+		waitAll(&wg, &mu, running, wait)
+		return err
+	}
+
+	waitAll(&wg, &mu, running, wait)
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return nil
+	}
+}
+
+func waitAll(wg *sync.WaitGroup, mu *sync.Mutex, running []*exec.Cmd, wait time.Duration) {
+	mu.Lock()
+	cmds := append([]*exec.Cmd(nil), running...)
+	mu.Unlock()
+	for _, cmd := range cmds {
+		_ = signalProcessGroup(cmd)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return
+	case <-time.After(wait):
+		mu.Lock()
+		for _, cmd := range running {
+			_ = killProcessGroup(cmd)
+		}
+		mu.Unlock()
+		<-done
+	}
+}
+
+func runOne(ctx context.Context, spec ProcSpec, stdout, stderr io.Writer, command CommandFunc) error {
+	if command == nil {
+		command = exec.Command
+	}
+	cmd := command(spec.Path, spec.Args...) //nolint:gosec // path/args come from LookPath and fixed flags
+	if cmd == nil {
+		return fmt.Errorf("dev: nil command for %s", spec.Name)
+	}
+	cmd.Dir = spec.Dir
+	if len(spec.Env) > 0 {
+		cmd.Env = spec.Env
+	}
+	if cmd.Stdout == nil {
+		cmd.Stdout = stdout
+	}
+	if cmd.Stderr == nil {
+		cmd.Stderr = stderr
+	}
+	prepareProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("dev: start %s: %w", spec.Name, err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		_ = signalProcessGroup(cmd)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			_ = killProcessGroup(cmd)
+			<-done
+		}
+		return ctx.Err()
+	}
+}

--- a/dev/supervisor_test.go
+++ b/dev/supervisor_test.go
@@ -1,0 +1,45 @@
+package dev
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWaitAllTimesOutAfterKill(t *testing.T) {
+	t.Parallel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	start := time.Now()
+	err := waitAll(&wg, &sync.Mutex{}, nil, 50*time.Millisecond)
+	wg.Done()
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("waitAll() error = nil, want timeout after kill")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("waitAll() error = %q, want timed out", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("waitAll() hung for %s, want ~100ms cap", elapsed)
+	}
+}
+
+func TestWindowsTaskkillArgs(t *testing.T) {
+	t.Parallel()
+
+	got := windowsTaskkillArgs(4242, false)
+	want := []string{"/T", "/PID", "4242"}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("windowsTaskkillArgs(force=false) = %v, want %v", got, want)
+	}
+
+	got = windowsTaskkillArgs(4242, true)
+	want = []string{"/T", "/F", "/PID", "4242"}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("windowsTaskkillArgs(force=true) = %v, want %v", got, want)
+	}
+}

--- a/dev/supervisor_unix.go
+++ b/dev/supervisor_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package dev
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func prepareProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+func signalProcessGroup(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+}
+
+func killProcessGroup(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}

--- a/dev/supervisor_windows.go
+++ b/dev/supervisor_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package dev
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func prepareProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags = syscall.CREATE_NEW_PROCESS_GROUP
+}
+
+func signalProcessGroup(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}
+
+func killProcessGroup(cmd *exec.Cmd) error {
+	return signalProcessGroup(cmd)
+}

--- a/dev/supervisor_windows.go
+++ b/dev/supervisor_windows.go
@@ -4,23 +4,27 @@ package dev
 
 import (
 	"os/exec"
-	"syscall"
 )
 
-func prepareProcessGroup(cmd *exec.Cmd) {
-	if cmd.SysProcAttr == nil {
-		cmd.SysProcAttr = &syscall.SysProcAttr{}
-	}
-	cmd.SysProcAttr.CreationFlags = syscall.CREATE_NEW_PROCESS_GROUP
-}
+// Windows has no POSIX process groups. Teardown uses `taskkill /T` so
+// grandchildren (air rebuilds, npm/pnpm → node/vite) exit with the child.
+// CREATE_NEW_PROCESS_GROUP is not used; it does not make Process.Kill
+// terminate the tree.
+
+func prepareProcessGroup(_ *exec.Cmd) {}
 
 func signalProcessGroup(cmd *exec.Cmd) error {
-	if cmd == nil || cmd.Process == nil {
-		return nil
-	}
-	return cmd.Process.Kill()
+	return taskkillTree(cmd, false)
 }
 
 func killProcessGroup(cmd *exec.Cmd) error {
-	return signalProcessGroup(cmd)
+	return taskkillTree(cmd, true)
+}
+
+func taskkillTree(cmd *exec.Cmd, force bool) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	args := windowsTaskkillArgs(cmd.Process.Pid, force)
+	return exec.Command("taskkill", args...).Run() //nolint:gosec // fixed taskkill invocation
 }

--- a/dev/table.go
+++ b/dev/table.go
@@ -1,0 +1,33 @@
+package dev
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Services holds the URLs printed in the startup service table.
+type Services struct {
+	Backend  string
+	Frontend string
+}
+
+// FormatServiceTable renders the Backend / Frontend / OpenAPI / API docs table.
+func FormatServiceTable(services Services) string {
+	rows := [][2]string{
+		{"Backend", services.Backend},
+		{"Frontend", services.Frontend},
+		{"OpenAPI", services.Backend + "/openapi.json"},
+		{"API docs", services.Backend + "/docs"},
+	}
+	width := 0
+	for _, row := range rows {
+		if n := len(row[0]); n > width {
+			width = n
+		}
+	}
+	var b strings.Builder
+	for _, row := range rows {
+		fmt.Fprintf(&b, "%-*s  %s\n", width, row[0], row[1])
+	}
+	return b.String()
+}

--- a/dev/table_test.go
+++ b/dev/table_test.go
@@ -1,0 +1,58 @@
+package dev
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatServiceTableIncludesDocsAndOpenAPI(t *testing.T) {
+	t.Parallel()
+
+	got := FormatServiceTable(Services{
+		Backend:  "http://127.0.0.1:8080",
+		Frontend: "http://127.0.0.1:5173",
+	})
+	wants := []string{
+		"Backend",
+		"http://127.0.0.1:8080",
+		"Frontend",
+		"http://127.0.0.1:5173",
+		"/openapi.json",
+		"/docs",
+		"API docs",
+		"OpenAPI",
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Fatalf("service table missing %q:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "http://127.0.0.1:8080/docs") {
+		t.Fatalf("service table missing API docs URL:\n%s", got)
+	}
+	if !strings.Contains(got, "http://127.0.0.1:8080/openapi.json") {
+		t.Fatalf("service table missing OpenAPI URL:\n%s", got)
+	}
+}
+
+func TestOriginFromAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		addr string
+		want string
+	}{
+		{addr: ":8080", want: "http://127.0.0.1:8080"},
+		{addr: "127.0.0.1:8080", want: "http://127.0.0.1:8080"},
+		{addr: "0.0.0.0:9000", want: "http://127.0.0.1:9000"},
+		{addr: "8080", want: "http://127.0.0.1:8080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			t.Parallel()
+			if got := originFromAddr(tt.addr); got != tt.want {
+				t.Fatalf("originFromAddr(%q) = %q, want %q", tt.addr, got, tt.want)
+			}
+		})
+	}
+}

--- a/dev/watcher.go
+++ b/dev/watcher.go
@@ -1,0 +1,98 @@
+package dev
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/client"
+)
+
+func watchOpenAPI(ctx context.Context, opts Options, specURL string) error {
+	get := opts.HTTPGet
+	if get == nil {
+		get = defaultHTTPGet
+	}
+	generate := opts.Generate
+	if generate == nil {
+		generate = func(ctx context.Context, spec []byte) error {
+			return generateClient(ctx, opts, spec)
+		}
+	}
+
+	var last []byte
+	ticker := time.NewTicker(opts.PollInterval)
+	defer ticker.Stop()
+
+	try := func() {
+		spec, err := get(ctx, specURL)
+		if err != nil {
+			return
+		}
+		if len(spec) == 0 || bytes.Equal(spec, last) {
+			return
+		}
+		if err := generate(ctx, spec); err != nil {
+			_, _ = fmt.Fprintf(opts.Stderr, "gombit dev: regenerate TypeScript client: %v\n", err)
+			return
+		}
+		last = append([]byte(nil), spec...)
+	}
+
+	try()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			try()
+		}
+	}
+}
+
+func generateClient(ctx context.Context, opts Options, spec []byte) error {
+	dir := filepath.Join(opts.WorkDir, ".gombit")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+	specPath := filepath.Join(dir, "openapi.json")
+	if err := os.WriteFile(specPath, spec, 0o600); err != nil {
+		return fmt.Errorf("write spec: %w", err)
+	}
+	return client.Generate(ctx, client.Options{
+		WorkDir:  opts.WorkDir,
+		SpecPath: specPath,
+		OutDir:   opts.ClientOut,
+		Stdout:   opts.Stdout,
+		Stderr:   opts.Stderr,
+	})
+}
+
+func defaultHTTPGet(ctx context.Context, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	httpClient := &http.Client{Timeout: 2 * time.Second}
+	resp, err := httpClient.Do(req) //nolint:gosec // URL is the local Go server's /openapi.json
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: status %d", rawURL, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > 8<<20 {
+		return nil, fmt.Errorf("spec exceeds 8MiB")
+	}
+	return body, nil
+}

--- a/dev/watcher_test.go
+++ b/dev/watcher_test.go
@@ -1,0 +1,120 @@
+package dev
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWatchOpenAPIGeneratesOnChange(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	n := 0
+	var generated []string
+	get := func(ctx context.Context, rawURL string) ([]byte, error) {
+		if rawURL != "http://127.0.0.1:8080/openapi.json" {
+			t.Errorf("unexpected URL %q", rawURL)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		n++
+		if n == 1 {
+			return []byte(`{"openapi":"3.1.0","info":{"title":"one"}}`), nil
+		}
+		return []byte(`{"openapi":"3.1.0","info":{"title":"two"}}`), nil
+	}
+	generate := func(ctx context.Context, spec []byte) error {
+		mu.Lock()
+		generated = append(generated, string(spec))
+		mu.Unlock()
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- watchOpenAPI(ctx, Options{
+			PollInterval: 10 * time.Millisecond,
+			HTTPGet:      get,
+			Generate:     generate,
+			Stderr:       &bytes.Buffer{},
+		}, "http://127.0.0.1:8080/openapi.json")
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		count := len(generated)
+		mu.Unlock()
+		if count >= 2 {
+			cancel()
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("watchOpenAPI() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchOpenAPI() did not return after cancel")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(generated) < 2 {
+		t.Fatalf("generated %d times, want at least 2: %v", len(generated), generated)
+	}
+	if generated[0] == generated[1] {
+		t.Fatal("expected different spec bytes to trigger a second generate")
+	}
+}
+
+func TestWatchOpenAPISkipsUnchangedSpec(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	calls := 0
+	generate := func(ctx context.Context, spec []byte) error {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return nil
+	}
+	get := func(ctx context.Context, rawURL string) ([]byte, error) {
+		return []byte(`{"openapi":"3.1.0"}`), nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- watchOpenAPI(ctx, Options{
+			PollInterval: 10 * time.Millisecond,
+			HTTPGet:      get,
+			Generate:     generate,
+			Stderr:       &bytes.Buffer{},
+		}, "http://127.0.0.1:8080/openapi.json")
+	}()
+
+	time.Sleep(80 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchOpenAPI() did not return after cancel")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("Generate called %d times, want 1 for unchanged spec", calls)
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,11 +14,12 @@ go run ./cmd/gombit --help
 | Family | Role | Milestone |
 | --- | --- | --- |
 | `gombit new` | Scaffold an application | M4-1 |
+| `gombit dev` | Run API + Vite with HMR and live client regen | M4-2 |
 | `gombit db …` | Atlas-backed migrations | M2, migrated onto Cobra in M4-1 |
 | `gombit openapi generate` | Write the live OpenAPI 3.1 document | M3-3 |
 | `gombit client generate` / `check` | TypeScript client + drift | M3-4, M3-5 |
 
-Not in this milestone: `gombit dev` (M4-2), `gombit make resource` (M4-3),
+Not in this milestone: `gombit make resource` (M4-3),
 `routes` / `doctor` / `config show` (M4-4), `createsuperuser` (M4-6),
 `make command` (M4-7).
 
@@ -62,7 +63,8 @@ replace github.com/LAA-Software-Engineering/gombit => /path/to/gombit
 
 `--auth cookie` and `--ui mui` are recorded in `gombit.yaml` only. Cookie/CSRF
 is M5-3; the MUI CRUD preset is M5-4. The generated `frontend/` directory is a
-split-deploy placeholder (M5-1 owns the Vite React skeleton).
+minimal Vite + TypeScript stub so `gombit dev` can start HMR; M5-1 owns the
+full React skeleton (router, React Hook Form, auth pages).
 
 If the project name is omitted and stdin is a TTY, `gombit new` prompts for
 name and the choices above. Tests and CI pass flags so the command never
@@ -85,8 +87,9 @@ demo/
 ├── database/migrations/
 ├── database/seeds/
 ├── config/
-├── frontend/
+├── frontend/             # Vite stub (package.json, vite.config.ts, src/main.ts)
 ├── gombit.yaml
+├── .air.toml
 ├── .env.example
 ├── go.mod
 └── README.md
@@ -101,6 +104,49 @@ Public product routes are Huma-typed under `/api/v1`. There is no generated
 and public `VITE_API_URL`. `VITE_*` is baked into the browser bundle — never
 put secrets there. Access tokens stay in memory; generated source does not
 use `localStorage`.
+
+## `gombit dev`
+
+From an application directory (the output of `gombit new`):
+
+```sh
+gombit dev
+```
+
+One command starts:
+
+1. The Go API with reload when `air` or `watchexec` is on `PATH`. If neither
+   is installed, Gombit runs `go run ./cmd/server` and prints a hint.
+2. The Vite frontend with HMR (`pnpm` when available, otherwise `npm`). Vite
+   proxies `/api`, `/openapi.json`, and `/docs` to the Go origin.
+3. An OpenAPI watcher that regenerates `frontend/src/api/generated` when the
+   live `/openapi.json` document changes (`gombit client generate`).
+
+A service table is printed at startup:
+
+```text
+Backend      http://127.0.0.1:8080
+Frontend     http://127.0.0.1:5173
+OpenAPI      http://127.0.0.1:8080/openapi.json
+API docs     http://127.0.0.1:8080/docs
+```
+
+### Flags
+
+| Flag | Default | Role |
+| --- | --- | --- |
+| `--http` | `GOMBIT_HTTP_ADDR` or `:8080` | Go API listen address |
+| `--frontend-host` | `127.0.0.1` | Vite bind host |
+| `--frontend-port` | `5173` | Vite port |
+| `--client-out` | `frontend/src/api/generated` | TypeScript client output |
+| `--poll` | `1s` | OpenAPI poll interval |
+
+`frontend/package.json` is required. A missing file is an error — backend-only
+mode is not supported. Node.js is required for Vite. SIGINT/SIGTERM stops the
+child processes.
+
+The scaffold's Vite stub is enough to start HMR. M5-1 replaces it with the
+React skeleton.
 
 ## `gombit db`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -142,8 +142,16 @@ API docs     http://127.0.0.1:8080/docs
 | `--poll` | `1s` | OpenAPI poll interval |
 
 `frontend/package.json` is required. A missing file is an error — backend-only
-mode is not supported. Node.js is required for Vite. SIGINT/SIGTERM stops the
-child processes.
+mode is not supported. Node.js is required for Vite.
+
+`--http` and the Vite proxy origin are written into the child environment
+(`GOMBIT_HTTP_ADDR`, `GOMBIT_DEV_BACKEND`, `VITE_API_URL=/api/v1`), replacing
+any parent values so a shell-exported `.env.example` cannot keep the API on
+`:8080` while the service table prints `--http :9090`.
+
+SIGINT/SIGTERM stops the child processes. On Unix, Gombit signals the process
+group so air/npm grandchildren exit. On Windows, teardown uses
+`taskkill /T /F /PID` for the same process tree.
 
 The scaffold's Vite stub is enough to start HMR. M5-1 replaces it with the
 React skeleton.

--- a/scaffold/generate.go
+++ b/scaffold/generate.go
@@ -157,6 +157,8 @@ func rewriteTemplateName(rel string) string {
 		return ".env.example"
 	case "gitignore":
 		return ".gitignore"
+	case "air.toml":
+		return ".air.toml"
 	default:
 		return rel
 	}

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -89,9 +89,9 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	}
 
 	viteConfig := readFile(t, filepath.Join(dest, "frontend", "vite.config.ts"))
-	for _, want := range []string{"/api", "/openapi.json", "/docs"} {
+	for _, want := range []string{"/api", "/openapi.json", "/docs", "GOMBIT_DEV_FRONTEND_HOST"} {
 		if !strings.Contains(viteConfig, want) {
-			t.Fatalf("vite.config.ts missing proxy %q:\n%s", want, viteConfig)
+			t.Fatalf("vite.config.ts missing %q:\n%s", want, viteConfig)
 		}
 	}
 	pkg := readFile(t, filepath.Join(dest, "frontend", "package.json"))

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -32,7 +32,14 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 		"database/migrations/.gitkeep",
 		"database/seeds/.gitkeep",
 		"config/README.md",
+		"frontend/package.json",
+		"frontend/vite.config.ts",
+		"frontend/index.html",
+		"frontend/src/main.ts",
+		"frontend/src/vite-env.d.ts",
+		"frontend/tsconfig.json",
 		"frontend/README.md",
+		".air.toml",
 		"gombit.yaml",
 		".env.example",
 		"go.mod",
@@ -79,6 +86,24 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "create demo/go.mod") {
 		t.Fatalf("stdout = %q, want created file list", stdout.String())
+	}
+
+	viteConfig := readFile(t, filepath.Join(dest, "frontend", "vite.config.ts"))
+	for _, want := range []string{"/api", "/openapi.json", "/docs"} {
+		if !strings.Contains(viteConfig, want) {
+			t.Fatalf("vite.config.ts missing proxy %q:\n%s", want, viteConfig)
+		}
+	}
+	pkg := readFile(t, filepath.Join(dest, "frontend", "package.json"))
+	if !strings.Contains(pkg, "vite") {
+		t.Fatalf("frontend/package.json missing vite:\n%s", pkg)
+	}
+	if strings.Contains(pkg, "react-router") || strings.Contains(pkg, "react-hook-form") {
+		t.Fatal("frontend stub must not include React Router or React Hook Form (M5-1)")
+	}
+	mainTS := readFile(t, filepath.Join(dest, "frontend", "src", "main.ts"))
+	if strings.Contains(strings.ToLower(mainTS), "localstorage") {
+		t.Fatal("frontend/src/main.ts uses localStorage")
 	}
 }
 
@@ -303,7 +328,7 @@ func TestGenerateInteractivePromptsOnTTY(t *testing.T) {
 func isGeneratedSource(path string) bool {
 	base := filepath.Base(path)
 	switch strings.ToLower(filepath.Ext(path)) {
-	case ".go", ".ts", ".tsx", ".js", ".jsx":
+	case ".go", ".ts", ".tsx", ".js", ".jsx", ".json", ".html", ".mjs":
 		return true
 	}
 	return base == ".env.example" || base == "gombit.yaml"

--- a/scaffold/templates/README.md.tmpl
+++ b/scaffold/templates/README.md.tmpl
@@ -14,6 +14,19 @@ routes are under `{{.APIPrefix}}`. Interactive docs are at `/docs` when
 `GOMBIT_DOCS_ENABLED` is on. The live OpenAPI 3.1 document is
 `/openapi.json`.
 
+For local development, one command runs the API, Vite HMR, and live
+TypeScript client regeneration:
+
+```sh
+gombit dev
+```
+
+`gombit dev` prints a service table (Backend, Frontend, OpenAPI, API docs).
+Backend reload uses `air` or `watchexec` when installed; otherwise it falls
+back to `go run ./cmd/server`. The frontend uses `pnpm` when available,
+otherwise `npm`. Node.js is required for Vite HMR. The Vite stub here is
+enough to start HMR; the full React skeleton is M5-1.
+
 This module requires [`github.com/LAA-Software-Engineering/gombit`](https://github.com/LAA-Software-Engineering/gombit).
 After scaffolding, pin a released version:
 
@@ -42,7 +55,7 @@ Runtime still reads `GOMBIT_*` environment variables, not `gombit.yaml`.
 - `internal/product` — model, Huma handlers, routes (no `service.go` / `repo.go`)
 - `internal/platform` — database open + AutoMigrate for the example product
 - `database/migrations`, `database/seeds` — Atlas SQL (see `gombit db`)
-- `frontend/` — split-deploy placeholder; the Vite React skeleton is M5-1
+- `frontend/` — minimal Vite + TypeScript stub for `gombit dev` (M5-1 owns the React skeleton)
 
 ## Migrations
 

--- a/scaffold/templates/air.toml.tmpl
+++ b/scaffold/templates/air.toml.tmpl
@@ -1,0 +1,14 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  bin = "./tmp/server"
+  cmd = "go build -o ./tmp/server ./cmd/server"
+  delay = 200
+  exclude_dir = ["tmp", "frontend", "node_modules", "vendor", "database", "testdata"]
+  exclude_regex = ["_test.go"]
+  include_ext = ["go"]
+  send_interrupt = true
+
+[log]
+  time = false

--- a/scaffold/templates/frontend/README.md.tmpl
+++ b/scaffold/templates/frontend/README.md.tmpl
@@ -1,9 +1,16 @@
-# Frontend placeholder
+# Frontend (minimal Vite stub)
 
 This directory is the split-deploy frontend root (build plan C5 / §3.2).
-`gombit new` does not scaffold a Vite React app; that is **M5-1**.
+`gombit new` writes a **minimal Vite + TypeScript stub** so `gombit dev` can
+start Vite HMR and proxy `/api`, `/openapi.json`, and `/docs` to the Go
+server. The full React skeleton (router, React Hook Form, auth pages, MUI)
+is **M5-1**.
 
-Public API origin for a future client:
+```sh
+gombit dev
+```
+
+Public API origin:
 
 ```
 VITE_API_URL

--- a/scaffold/templates/frontend/index.html.tmpl
+++ b/scaffold/templates/frontend/index.html.tmpl
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{.Name}}</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/scaffold/templates/frontend/package.json.tmpl
+++ b/scaffold/templates/frontend/package.json.tmpl
@@ -1,0 +1,17 @@
+{
+  "name": "frontend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "openapi-fetch": "0.17.0"
+  },
+  "devDependencies": {
+    "typescript": "~5.7.3",
+    "vite": "^6.1.0"
+  }
+}

--- a/scaffold/templates/frontend/src/main.ts.tmpl
+++ b/scaffold/templates/frontend/src/main.ts.tmpl
@@ -1,0 +1,18 @@
+const app = document.querySelector("#app");
+if (!app) {
+  throw new Error("missing #app");
+}
+
+const apiBase = import.meta.env.VITE_API_URL || "/api/v1";
+
+app.textContent = "Loading products…";
+
+void fetch(`${apiBase}/products`)
+  .then(async (response) => {
+    const body: unknown = await response.json();
+    app.textContent = JSON.stringify(body, null, 2);
+  })
+  .catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : "request failed";
+    app.textContent = message;
+  });

--- a/scaffold/templates/frontend/src/vite-env.d.ts.tmpl
+++ b/scaffold/templates/frontend/src/vite-env.d.ts.tmpl
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/scaffold/templates/frontend/tsconfig.json.tmpl
+++ b/scaffold/templates/frontend/tsconfig.json.tmpl
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/scaffold/templates/frontend/vite.config.ts.tmpl
+++ b/scaffold/templates/frontend/vite.config.ts.tmpl
@@ -1,11 +1,12 @@
 import { defineConfig } from "vite";
 
 const backend = process.env.GOMBIT_DEV_BACKEND ?? "http://127.0.0.1:8080";
+const host = process.env.GOMBIT_DEV_FRONTEND_HOST ?? "127.0.0.1";
 const port = Number(process.env.GOMBIT_DEV_FRONTEND_PORT ?? "5173");
 
 export default defineConfig({
   server: {
-    host: "127.0.0.1",
+    host,
     port,
     strictPort: true,
     proxy: {

--- a/scaffold/templates/frontend/vite.config.ts.tmpl
+++ b/scaffold/templates/frontend/vite.config.ts.tmpl
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+
+const backend = process.env.GOMBIT_DEV_BACKEND ?? "http://127.0.0.1:8080";
+const port = Number(process.env.GOMBIT_DEV_FRONTEND_PORT ?? "5173");
+
+export default defineConfig({
+  server: {
+    host: "127.0.0.1",
+    port,
+    strictPort: true,
+    proxy: {
+      "/api": { target: backend, changeOrigin: true },
+      "/openapi.json": { target: backend, changeOrigin: true },
+      "/docs": { target: backend, changeOrigin: true },
+    },
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `gombit dev` (Cobra `AddCommand`) so one command from a `gombit new` app directory runs the Go API, Vite HMR, and live OpenAPI → TypeScript client regeneration. The scaffold now includes a minimal Vite stub (not the M5-1 React skeleton) so the AC is actually runnable.

Closes #22

## Acceptance criteria

- [x] one command runs backend+frontend with HMR and live contract regen
- [x] service table prints Backend, Frontend, OpenAPI (`/openapi.json`), and API docs (`/docs`) URLs

## Scope notes

- Full Vite React skeleton (router, RHF, auth pages, MUI) remains **M5-1**. This PR only adds a vanilla TS Vite stub (`index.html` + `vite.config` proxy + `package.json`) so Vite HMR can start.
- Not in this PR: `gombit make resource` (M4-3), `routes` / `doctor` / `config show` (M4-4), `createsuperuser` (M4-6), `make command` (M4-7), M6 batteries.
- Backend reload uses `air` if present, then `watchexec`, then `go run ./cmd/server` with a hint. Missing air/watchexec is not a hard failure.
- `frontend/package.json` is required; backend-only is refused.

## Validation

- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [x] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix
  - No DB-touching changes in this PR. New tests cover help, flags, service table, process supervisor (fake `sh` children, cancel via context), OpenAPI watch → generate, missing `frontend/package.json`, and existing `gombit new demo --database sqlite` compile AC.
- [x] Stable features ship docs and appear in an example app
  - `docs/cli.md` + README; the `gombit new` scaffold is the example app.
- [ ] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests
  - N/A: new CLI surface, not a template extraction.
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators)
  - Scaffold still honors `--dry-run` / `--force`; no AST edits (no Go source rewriting).
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR
  - N/A: no framework HTTP contract change. `gombit dev` calls the existing `client.Generate` path at runtime.
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
  - Stub uses public `VITE_API_URL`; no `localStorage` / `sessionStorage`.
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7cead8d-780d-4ee8-ae63-2a4e49ca67e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7cead8d-780d-4ee8-ae63-2a4e49ca67e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

