### PR TITLE
[M4-4] gombit routes, doctor, and config show

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,9 @@ go test ./...
 golangci-lint run
 go run ./cmd/gombit --help
 go run ./cmd/gombit client check
+go run ./cmd/gombit doctor
+go run ./cmd/gombit config show
+go run ./cmd/gombit routes
 ```
 
 `gombit new demo --database sqlite` scaffolds a compiling app. See

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ default). See [`docs/openapi.md`](docs/openapi.md).
 The authoritative implementation backlog and architecture decisions live in
 [`docs/GOMBIT_BUILD_PLAN.md`](docs/GOMBIT_BUILD_PLAN.md).
 
-The Cobra command tree, `gombit new`, and `gombit dev` are documented in
+The Cobra command tree, `gombit new`, `gombit dev`, `gombit routes`,
+`gombit doctor`, and `gombit config show` are documented in
 [`docs/cli.md`](docs/cli.md).
 Accepted architecture decisions are recorded under [`docs/adr/`](docs/adr/).
 Runtime configuration is documented in [`docs/config.md`](docs/config.md).

--- a/cmd/gombit/config.go
+++ b/cmd/gombit/config.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/spf13/cobra"
+)
+
+func newConfigCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
+	cmd := silence(&cobra.Command{
+		Use:   "config",
+		Short: "Show typed configuration",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configUsage(stderr)
+			if len(args) == 0 {
+				return fmt.Errorf("gombit config: subcommand is required")
+			}
+			return fmt.Errorf("gombit config: unknown subcommand %q", args[0])
+		},
+	})
+	cmd.AddCommand(newConfigShowCommand(stdout))
+	return cmd
+}
+
+func newConfigShowCommand(stdout io.Writer) *cobra.Command {
+	return silence(&cobra.Command{
+		Use:   "show",
+		Short: "Print the typed configuration with secrets redacted",
+		Long: `Print the configuration returned by config.Load() as aligned
+key=value lines. Database DSN userinfo/passwords and the Redis password
+are replaced with ***** and never printed.
+
+JWT secret, cookie, and CORS fields are not shown until those typed
+config fields exist (M5 auth). Appendix C checks for those settings
+land with the features that introduce them.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return fmt.Errorf("gombit config show: %w", err)
+			}
+			return writeConfigShow(stdout, cfg.Redacted())
+		},
+	})
+}
+
+func writeConfigShow(w io.Writer, cfg config.Config) error {
+	rows := [][2]string{
+		{"AppName", cfg.AppName},
+		{"Environment", string(cfg.Environment)},
+		{"HTTP.Addr", cfg.HTTP.Addr},
+		{"HTTP.TrustedProxies", formatStringList(cfg.HTTP.TrustedProxies)},
+		{"HTTP.RequestTimeout", cfg.HTTP.RequestTimeout.String()},
+		{"API.Prefix", cfg.API.Prefix},
+		{"API.DocsEnabled", strconv.FormatBool(cfg.API.DocsEnabled)},
+		{"Database.Driver", string(cfg.Database.Driver)},
+		{"Database.DSN", cfg.Database.DSN},
+		{"Database.MaxOpenConns", strconv.Itoa(cfg.Database.MaxOpenConns)},
+		{"Database.MaxIdleConns", strconv.Itoa(cfg.Database.MaxIdleConns)},
+		{"Database.ConnMaxLifetime", formatDuration(cfg.Database.ConnMaxLifetime)},
+		{"Cache.Driver", string(cfg.Cache.Driver)},
+		{"Cache.Namespace", cfg.Cache.Namespace},
+		{"Cache.Redis.Addr", cfg.Cache.Redis.Addr},
+		{"Cache.Redis.Username", cfg.Cache.Redis.Username},
+		{"Cache.Redis.Password", cfg.Cache.Redis.Password},
+		{"Cache.Redis.DB", strconv.Itoa(cfg.Cache.Redis.DB)},
+		{"Cache.Redis.DialTimeout", cfg.Cache.Redis.DialTimeout.String()},
+		{"Cache.Redis.ReadTimeout", cfg.Cache.Redis.ReadTimeout.String()},
+		{"Cache.Redis.WriteTimeout", cfg.Cache.Redis.WriteTimeout.String()},
+		{"Cache.Redis.TLS", strconv.FormatBool(cfg.Cache.Redis.TLS)},
+		{"Cache.Redis.TLSInsecure", strconv.FormatBool(cfg.Cache.Redis.TLSInsecure)},
+		{"Logging.Level", string(cfg.Logging.Level)},
+		{"Logging.Sink", string(cfg.Logging.Sink)},
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	for _, row := range rows {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\n", row[0], row[1]); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func formatStringList(values []string) string {
+	if len(values) == 0 {
+		return "[]"
+	}
+	return strings.Join(values, ",")
+}
+
+func formatDuration(value time.Duration) string {
+	if value == 0 {
+		return "0s"
+	}
+	return value.String()
+}

--- a/cmd/gombit/doctor.go
+++ b/cmd/gombit/doctor.go
@@ -1,0 +1,437 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/cache"
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+	"github.com/LAA-Software-Engineering/gombit/migrations"
+	"github.com/spf13/cobra"
+)
+
+const (
+	doctorStatusOK   = "ok"
+	doctorStatusWarn = "warn"
+	doctorStatusFail = "FAIL"
+	doctorStatusSkip = "skip"
+)
+
+var doctorCheckTimeout = 3 * time.Second
+
+type doctorCheck struct {
+	Name    string
+	Status  string
+	Message string
+}
+
+func newDoctorCommand(stdout io.Writer) *cobra.Command {
+	cmd := silence(&cobra.Command{
+		Use:   "doctor",
+		Short: "Check Go, Node, config, database, Redis, migrations, and ports",
+		Long: `Run local environment checks and print a status table.
+
+Checks:
+  go           go is on PATH (go version)
+  node         node is on PATH (warn if missing; required for gombit dev)
+  config       config.Load() validates
+  database     database.Open + ping when a driver/DSN is set
+  redis        ping when GOMBIT_CACHE_DRIVER=redis
+  migrations   pending Atlas SQL files in --dir (warn)
+  http         GOMBIT_HTTP_ADDR parses; warn if the port is in use
+  insecure     existing production/docs and unwritable SQLite path issues
+
+Network checks use a short timeout so CI cannot hang. Appendix C JWT,
+cookie, and CORS production checks land with the auth fields that
+introduce them (M5).`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			migrationDir, err := cmd.Flags().GetString("dir")
+			if err != nil {
+				return err
+			}
+			checks := runDoctorChecks(cmd.Context(), doctorOptions{MigrationDir: migrationDir})
+			if err := writeDoctorTable(stdout, checks); err != nil {
+				return err
+			}
+			if doctorFailed(checks) {
+				return errors.New("gombit doctor: one or more checks failed")
+			}
+			return nil
+		},
+	})
+	cmd.Flags().String("dir", "database/migrations", "migration directory to inspect for pending SQL")
+	return cmd
+}
+
+type doctorOptions struct {
+	MigrationDir string
+}
+
+func runDoctorChecks(ctx context.Context, opts doctorOptions) []doctorCheck {
+	checks := []doctorCheck{
+		checkGo(ctx),
+		checkNode(ctx),
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		checks = append(checks, doctorCheck{
+			Name:    "config",
+			Status:  doctorStatusFail,
+			Message: config.SanitizeSecretText(err.Error(), config.Config{}),
+		})
+		checks = append(checks,
+			skippedCheck("database", "skipped: config is invalid"),
+			skippedCheck("redis", "skipped: config is invalid"),
+			skippedCheck("migrations", "skipped: config is invalid"),
+			skippedCheck("http", "skipped: config is invalid"),
+			skippedCheck("insecure", "skipped: config is invalid"),
+		)
+		return checks
+	}
+
+	checks = append(checks, doctorCheck{
+		Name:    "config",
+		Status:  doctorStatusOK,
+		Message: fmt.Sprintf("valid (%s)", cfg.Environment),
+	})
+	checks = append(checks, checkDatabase(ctx, cfg))
+	checks = append(checks, checkRedis(ctx, cfg))
+	checks = append(checks, checkMigrations(ctx, cfg, opts.MigrationDir))
+	checks = append(checks, checkHTTPAddr(cfg))
+	checks = append(checks, checkInsecure(cfg))
+	return checks
+}
+
+func checkGo(ctx context.Context) doctorCheck {
+	path, err := exec.LookPath("go")
+	if err != nil {
+		return doctorCheck{Name: "go", Status: doctorStatusFail, Message: "go not found on PATH"}
+	}
+	// #nosec G204 -- path is exec.LookPath("go"); arguments are the fixed "version" flag.
+	cmd := exec.CommandContext(ctx, path, "version")
+	out, err := cmd.Output()
+	if err != nil {
+		return doctorCheck{Name: "go", Status: doctorStatusFail, Message: err.Error()}
+	}
+	return doctorCheck{Name: "go", Status: doctorStatusOK, Message: strings.TrimSpace(string(out))}
+}
+
+func checkNode(ctx context.Context) doctorCheck {
+	path, err := exec.LookPath("node")
+	if err != nil {
+		return doctorCheck{
+			Name:    "node",
+			Status:  doctorStatusWarn,
+			Message: "node not found on PATH (required for gombit dev)",
+		}
+	}
+	// #nosec G204 -- path is exec.LookPath("node"); arguments are the fixed "--version" flag.
+	cmd := exec.CommandContext(ctx, path, "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		return doctorCheck{
+			Name:    "node",
+			Status:  doctorStatusWarn,
+			Message: "node --version failed: " + err.Error(),
+		}
+	}
+	return doctorCheck{Name: "node", Status: doctorStatusOK, Message: strings.TrimSpace(string(out))}
+}
+
+func checkDatabase(ctx context.Context, cfg config.Config) doctorCheck {
+	if strings.TrimSpace(string(cfg.Database.Driver)) == "" && strings.TrimSpace(cfg.Database.DSN) == "" {
+		return skippedCheck("database", "no database driver or DSN configured")
+	}
+
+	err := runWithTimeout(ctx, doctorCheckTimeout, func(ctx context.Context) error {
+		db, err := database.Open(cfg.Database)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = db.Close() }()
+		sqlDB, err := db.SQLDB()
+		if err != nil {
+			return err
+		}
+		return sqlDB.PingContext(ctx)
+	})
+	if err != nil {
+		return doctorCheck{
+			Name:    "database",
+			Status:  doctorStatusFail,
+			Message: config.SanitizeError(err, cfg),
+		}
+	}
+	return doctorCheck{
+		Name:    "database",
+		Status:  doctorStatusOK,
+		Message: fmt.Sprintf("%s reachable", cfg.Database.Driver),
+	}
+}
+
+func checkRedis(ctx context.Context, cfg config.Config) doctorCheck {
+	if cfg.Cache.Driver != config.CacheDriverRedis {
+		return skippedCheck("redis", fmt.Sprintf("cache driver is %s", cfg.Cache.Driver))
+	}
+
+	redisCfg := cfg.Cache.Redis
+	if redisCfg.DialTimeout <= 0 || redisCfg.DialTimeout > doctorCheckTimeout {
+		redisCfg.DialTimeout = doctorCheckTimeout
+	}
+
+	err := runWithTimeout(ctx, doctorCheckTimeout, func(ctx context.Context) error {
+		client, err := cache.NewRedisClient(redisCfg)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+		return client.Ping(ctx).Err()
+	})
+	if err != nil {
+		return doctorCheck{
+			Name:    "redis",
+			Status:  doctorStatusFail,
+			Message: config.SanitizeError(err, cfg),
+		}
+	}
+	return doctorCheck{
+		Name:    "redis",
+		Status:  doctorStatusOK,
+		Message: fmt.Sprintf("reachable at %s", cfg.Cache.Redis.Addr),
+	}
+}
+
+func checkMigrations(ctx context.Context, cfg config.Config, migrationDir string) doctorCheck {
+	if strings.TrimSpace(migrationDir) == "" {
+		migrationDir = "database/migrations"
+	}
+	info, err := os.Stat(migrationDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return skippedCheck("migrations", fmt.Sprintf("%s not present", migrationDir))
+		}
+		return doctorCheck{Name: "migrations", Status: doctorStatusFail, Message: err.Error()}
+	}
+	if !info.IsDir() {
+		return doctorCheck{Name: "migrations", Status: doctorStatusFail, Message: migrationDir + " is not a directory"}
+	}
+
+	files, err := migrations.ListMigrationFiles(migrationDir)
+	if err != nil {
+		return doctorCheck{Name: "migrations", Status: doctorStatusFail, Message: err.Error()}
+	}
+	if len(files) == 0 {
+		return doctorCheck{Name: "migrations", Status: doctorStatusOK, Message: "no migration files"}
+	}
+
+	pending, err := pendingMigrationFiles(ctx, cfg, files)
+	if err != nil {
+		return doctorCheck{
+			Name:    "migrations",
+			Status:  doctorStatusWarn,
+			Message: fmt.Sprintf("%d file(s) on disk; could not compare revisions: %s", len(files), config.SanitizeError(err, cfg)),
+		}
+	}
+	if len(pending) == 0 {
+		return doctorCheck{
+			Name:    "migrations",
+			Status:  doctorStatusOK,
+			Message: fmt.Sprintf("%d applied, none pending", len(files)),
+		}
+	}
+	names := make([]string, 0, len(pending))
+	for _, file := range pending {
+		names = append(names, file.Version+"_"+file.Name)
+	}
+	return doctorCheck{
+		Name:    "migrations",
+		Status:  doctorStatusWarn,
+		Message: fmt.Sprintf("%d pending: %s", len(pending), strings.Join(names, ", ")),
+	}
+}
+
+func pendingMigrationFiles(ctx context.Context, cfg config.Config, files []migrations.MigrationFile) ([]migrations.MigrationFile, error) {
+	var pending []migrations.MigrationFile
+	err := runWithTimeout(ctx, doctorCheckTimeout, func(ctx context.Context) error {
+		db, err := database.Open(cfg.Database)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = db.Close() }()
+		if err := db.WithContext(ctx).AutoMigrate(&migrations.Revision{}); err != nil {
+			return err
+		}
+		var revisions []migrations.Revision
+		if err := db.WithContext(ctx).Order("version asc").Find(&revisions).Error; err != nil {
+			return err
+		}
+		applied := make(map[string]struct{}, len(revisions))
+		for _, rev := range revisions {
+			applied[rev.Version] = struct{}{}
+		}
+		pending = pending[:0]
+		for _, file := range files {
+			if _, ok := applied[file.Version]; !ok {
+				pending = append(pending, file)
+			}
+		}
+		return nil
+	})
+	return pending, err
+}
+
+func checkHTTPAddr(cfg config.Config) doctorCheck {
+	addr := strings.TrimSpace(cfg.HTTP.Addr)
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return doctorCheck{
+			Name:    "http",
+			Status:  doctorStatusFail,
+			Message: fmt.Sprintf("invalid listen address %q: %s", addr, err.Error()),
+		}
+	}
+	if port == "0" {
+		return doctorCheck{Name: "http", Status: doctorStatusOK, Message: addr + " (ephemeral)"}
+	}
+	dialHost := host
+	if dialHost == "" || dialHost == "0.0.0.0" || dialHost == "::" {
+		dialHost = "127.0.0.1"
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(dialHost, port), 200*time.Millisecond)
+	if err != nil {
+		return doctorCheck{Name: "http", Status: doctorStatusOK, Message: addr + " parses, not in use"}
+	}
+	_ = conn.Close()
+	return doctorCheck{
+		Name:    "http",
+		Status:  doctorStatusWarn,
+		Message: addr + " is in use",
+	}
+}
+
+func checkInsecure(cfg config.Config) doctorCheck {
+	var issues []string
+	if cfg.Environment == config.EnvironmentProduction && cfg.API.DocsEnabled {
+		issues = append(issues, "production has API docs enabled (/docs)")
+	}
+	if cfg.Database.Driver == config.DatabaseDriverSQLite {
+		if err := sqliteDSNWritable(cfg.Database.DSN); err != nil {
+			issues = append(issues, err.Error())
+		}
+	}
+	if len(issues) == 0 {
+		return doctorCheck{Name: "insecure", Status: doctorStatusOK, Message: "no issues in current config fields"}
+	}
+	return doctorCheck{
+		Name:    "insecure",
+		Status:  doctorStatusFail,
+		Message: strings.Join(issues, "; "),
+	}
+}
+
+func sqliteDSNWritable(dsn string) error {
+	path, memory := sqlitePathFromDSN(dsn)
+	if memory {
+		return nil
+	}
+	if strings.TrimSpace(path) == "" {
+		return errors.New("sqlite DSN path is empty")
+	}
+	dir := filepath.Dir(path)
+	if dir == "" || dir == "." {
+		dir = "."
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("sqlite path %s: parent directory does not exist", path)
+		}
+		return fmt.Errorf("sqlite path %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("sqlite path %s is not writable: parent is not a directory", path)
+	}
+	file, err := os.CreateTemp(dir, ".gombit-doctor-*")
+	if err != nil {
+		return fmt.Errorf("sqlite path %s is not writable", path)
+	}
+	name := file.Name()
+	_ = file.Close()
+	_ = os.Remove(name)
+	return nil
+}
+
+func sqlitePathFromDSN(dsn string) (path string, memory bool) {
+	trimmed := strings.TrimSpace(dsn)
+	base, query, _ := strings.Cut(trimmed, "?")
+	if base == ":memory:" || strings.Contains(base, ":memory:") || strings.Contains(query, "mode=memory") {
+		return "", true
+	}
+	if strings.HasPrefix(base, "file://") {
+		parsed, err := url.Parse(base)
+		if err == nil && parsed.Path != "" {
+			return parsed.Path, false
+		}
+	}
+	return strings.TrimPrefix(base, "file:"), false
+}
+
+func skippedCheck(name, message string) doctorCheck {
+	return doctorCheck{Name: name, Status: doctorStatusSkip, Message: message}
+}
+
+func doctorFailed(checks []doctorCheck) bool {
+	for _, check := range checks {
+		if check.Status == doctorStatusFail {
+			return true
+		}
+	}
+	return false
+}
+
+func writeDoctorTable(w io.Writer, checks []doctorCheck) error {
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "STATUS\tCHECK\tDETAIL"); err != nil {
+		return err
+	}
+	for _, check := range checks {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", check.Status, check.Name, check.Message); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func runWithTimeout(ctx context.Context, timeout time.Duration, fn func(context.Context) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- fn(ctx)
+	}()
+	select {
+	case err := <-done:
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) && err == nil {
+			return context.DeadlineExceeded
+		}
+		return err
+	case <-ctx.Done():
+		return fmt.Errorf("%w after %s", context.DeadlineExceeded, timeout)
+	}
+}

--- a/cmd/gombit/doctor.go
+++ b/cmd/gombit/doctor.go
@@ -282,15 +282,19 @@ func pendingMigrationFiles(ctx context.Context, cfg config.Config, files []migra
 		for _, rev := range revisions {
 			applied[rev.Version] = struct{}{}
 		}
-		pending = pending[:0]
+		found := make([]migrations.MigrationFile, 0)
 		for _, file := range files {
 			if _, ok := applied[file.Version]; !ok {
-				pending = append(pending, file)
+				found = append(found, file)
 			}
 		}
+		pending = found
 		return nil
 	})
-	return pending, err
+	if err != nil {
+		return nil, err
+	}
+	return pending, nil
 }
 
 func checkHTTPAddr(cfg config.Config) doctorCheck {

--- a/cmd/gombit/introspect_test.go
+++ b/cmd/gombit/introspect_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+)
+
+func TestRunHelpListsIntrospectionCommands(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	err := run(context.Background(), []string{"--help"}, stdout, ioDiscard{})
+	if err != nil {
+		t.Fatalf("run(--help) error = %v", err)
+	}
+	got := stdout.String()
+	for _, name := range []string{"routes", "doctor", "config"} {
+		if !strings.Contains(got, name) {
+			t.Fatalf("root help missing %q:\n%s", name, got)
+		}
+	}
+}
+
+func TestRunRejectsUnknownCommandUsageListsIntrospection(t *testing.T) {
+	stderr := new(bytes.Buffer)
+	err := run(context.Background(), []string{"unknown"}, ioDiscard{}, stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want unknown command error")
+	}
+	got := stderr.String()
+	for _, want := range []string{"routes", "doctor", "config show"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("usage = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestRunConfigShowRedactsSecrets(t *testing.T) {
+	cfg := config.Default()
+	cfg.Database.Driver = config.DatabaseDriverPostgres
+	cfg.Database.DSN = "postgres://gombit:db-super-secret@127.0.0.1:5432/gombit?sslmode=disable"
+	cfg.Cache.Redis.Password = "redis-super-secret"
+	stubConfig(t, cfg)
+
+	stdout := new(bytes.Buffer)
+	err := run(context.Background(), []string{"config", "show"}, stdout, ioDiscard{})
+	if err != nil {
+		t.Fatalf("run(config show) error = %v", err)
+	}
+	got := stdout.String()
+	if strings.Contains(got, "db-super-secret") || strings.Contains(got, "redis-super-secret") {
+		t.Fatalf("config show leaked secrets:\n%s", got)
+	}
+	if !strings.Contains(got, config.RedactedSecret) {
+		t.Fatalf("config show = %q, want redacted placeholder", got)
+	}
+	if !strings.Contains(got, "Database.DSN") {
+		t.Fatalf("config show = %q, want Database.DSN", got)
+	}
+	if !strings.Contains(got, "Cache.Redis.Password") {
+		t.Fatalf("config show = %q, want Cache.Redis.Password", got)
+	}
+}
+
+func TestRunRejectsUnknownConfigSubcommand(t *testing.T) {
+	stderr := new(bytes.Buffer)
+	err := run(context.Background(), []string{"config", "unknown"}, ioDiscard{}, stderr)
+	if err == nil {
+		t.Fatal("run() error = nil, want unknown subcommand error")
+	}
+	if !strings.Contains(err.Error(), "unknown subcommand") {
+		t.Fatalf("run() error = %q, want unknown subcommand", err)
+	}
+	if !strings.Contains(stderr.String(), "show") {
+		t.Fatalf("config usage = %q, want show", stderr.String())
+	}
+}
+
+func TestRunRoutesListsFrameworkPaths(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err := run(context.Background(), []string{"routes"}, stdout, stderr)
+	if err != nil {
+		t.Fatalf("run(routes) error = %v; stderr=%q", err, stderr.String())
+	}
+	got := stdout.String()
+	for _, path := range []string{"/openapi.json", "/docs", "/livez"} {
+		if !strings.Contains(got, path) {
+			t.Fatalf("routes output missing %q:\n%s", path, got)
+		}
+	}
+	if !strings.Contains(got, "GET") {
+		t.Fatalf("routes output missing GET:\n%s", got)
+	}
+}
+
+func TestRunRoutesURLListsOpenAPIPaths(t *testing.T) {
+	spec := `{
+  "openapi": "3.1.0",
+  "info": {"title": "Gombit", "version": "0.0.0"},
+  "paths": {
+    "/api/v1/widgets": {
+      "get": {"operationId": "list-widgets", "responses": {"200": {"description": "OK"}}}
+    }
+  }
+}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/openapi.json" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(spec))
+	}))
+	t.Cleanup(server.Close)
+
+	stdout := new(bytes.Buffer)
+	err := run(context.Background(), []string{"routes", "--url", server.URL}, stdout, ioDiscard{})
+	if err != nil {
+		t.Fatalf("run(routes --url) error = %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "/api/v1/widgets") {
+		t.Fatalf("routes --url = %q, want /api/v1/widgets", got)
+	}
+	if !strings.Contains(got, "GET") {
+		t.Fatalf("routes --url = %q, want GET", got)
+	}
+}
+
+func TestRunDoctorFlagsBrokenConfig(t *testing.T) {
+	t.Setenv("GOMBIT_DATABASE_DRIVER", "not-a-driver")
+
+	stdout := new(bytes.Buffer)
+	err := run(context.Background(), []string{"doctor"}, stdout, ioDiscard{})
+	if err == nil {
+		t.Fatal("run(doctor) error = nil, want non-zero for broken config")
+	}
+	if !strings.Contains(err.Error(), "gombit doctor: one or more checks failed") {
+		t.Fatalf("run(doctor) error = %q, want doctor failure", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "FAIL") {
+		t.Fatalf("doctor output = %q, want FAIL", got)
+	}
+	if !strings.Contains(got, "config") {
+		t.Fatalf("doctor output = %q, want named config check", got)
+	}
+	if !strings.Contains(got, "GOMBIT_DATABASE_DRIVER") && !strings.Contains(got, "Database.Driver") {
+		t.Fatalf("doctor output = %q, want driver field error", got)
+	}
+}
+
+func TestRunDoctorFlagsUnwritableSQLitePath(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocked, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	cfg := config.Default()
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.Database.Driver = config.DatabaseDriverSQLite
+	cfg.Database.DSN = "file:" + blocked + "/app.db?cache=shared&_fk=1"
+	stubConfig(t, cfg)
+
+	stdout := new(bytes.Buffer)
+	err := run(context.Background(), []string{"doctor"}, stdout, ioDiscard{})
+	if err == nil {
+		t.Fatal("run(doctor) error = nil, want failure for unwritable sqlite path")
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "FAIL") {
+		t.Fatalf("doctor output = %q, want FAIL", got)
+	}
+	if !strings.Contains(got, "insecure") && !strings.Contains(got, "database") {
+		t.Fatalf("doctor output = %q, want named insecure or database failure", got)
+	}
+}
+
+func TestRunDoctorHealthySQLiteMemory(t *testing.T) {
+	cfg := config.Default()
+	cfg.Environment = config.EnvironmentTest
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.Database.Driver = config.DatabaseDriverSQLite
+	cfg.Database.DSN = "file::memory:?cache=shared&_fk=1"
+	cfg.Cache.Driver = config.CacheDriverMemory
+	stubConfig(t, cfg)
+
+	stdout := new(bytes.Buffer)
+	err := run(context.Background(), []string{"doctor"}, stdout, ioDiscard{})
+	if err != nil {
+		t.Fatalf("run(doctor) error = %v; output=%q", err, stdout.String())
+	}
+	got := stdout.String()
+	if strings.Contains(got, "FAIL") {
+		t.Fatalf("doctor output = %q, did not want FAIL", got)
+	}
+	if !strings.Contains(got, "config") || !strings.Contains(got, "database") {
+		t.Fatalf("doctor output = %q, want config and database checks", got)
+	}
+}

--- a/cmd/gombit/introspect_test.go
+++ b/cmd/gombit/introspect_test.go
@@ -44,7 +44,7 @@ func TestRunRejectsUnknownCommandUsageListsIntrospection(t *testing.T) {
 func TestRunConfigShowRedactsSecrets(t *testing.T) {
 	cfg := config.Default()
 	cfg.Database.Driver = config.DatabaseDriverPostgres
-	cfg.Database.DSN = "postgres://gombit:db-super-secret@127.0.0.1:5432/gombit?sslmode=disable"
+	cfg.Database.DSN = "postgres://gombit:db-super-secret@127.0.0.1:5432/gombit?sslmode=disable" // #nosec G101 -- fake local test DSN.
 	cfg.Cache.Redis.Password = "redis-super-secret"
 	stubConfig(t, cfg)
 

--- a/cmd/gombit/main.go
+++ b/cmd/gombit/main.go
@@ -59,6 +59,9 @@ func newRootCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
 	root.AddCommand(newDBCommand(stdout, stderr))
 	root.AddCommand(newOpenAPICommand(stdout, stderr))
 	root.AddCommand(newClientCommand(stdout, stderr))
+	root.AddCommand(newRoutesCommand(stdout, stderr))
+	root.AddCommand(newDoctorCommand(stdout))
+	root.AddCommand(newConfigCommand(stdout, stderr))
 	return root
 }
 
@@ -73,6 +76,9 @@ func rootLongHelp() string {
 		"  db        Database migrations (makemigrations, migrate, rollback, status, seed, reset)",
 		"  openapi   Write the live OpenAPI 3.1 document",
 		"  client    Generate and check the TypeScript client",
+		"  routes    Print HTTP routes",
+		"  doctor    Check Go, Node, config, database, Redis, migrations, and ports",
+		"  config    Show typed configuration (config show)",
 	}, "\n")
 }
 
@@ -86,6 +92,9 @@ func usage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  openapi generate [--out openapi.json] [--url http://127.0.0.1:8080/openapi.json]")
 	_, _ = fmt.Fprintln(w, "  client generate [--spec openapi.json] [--out frontend/src/api/generated] [--dry-run] [--force]")
 	_, _ = fmt.Fprintln(w, "  client check [--write] [--spec examples/client/openapi.json] [--out examples/client/frontend/src/api/generated]")
+	_, _ = fmt.Fprintln(w, "  routes [--url http://127.0.0.1:8080]")
+	_, _ = fmt.Fprintln(w, "  doctor [--dir database/migrations]")
+	_, _ = fmt.Fprintln(w, "  config show")
 }
 
 func dbUsage(w io.Writer) {
@@ -107,6 +116,11 @@ func clientUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "available client subcommands:")
 	_, _ = fmt.Fprintln(w, "  generate [--spec openapi.json] [--out frontend/src/api/generated] [--dry-run] [--force] [--npx npx]")
 	_, _ = fmt.Fprintln(w, "  check [--write] [--spec examples/client/openapi.json] [--out examples/client/frontend/src/api/generated] [--npx npx]")
+}
+
+func configUsage(w io.Writer) {
+	_, _ = fmt.Fprintln(w, "available config subcommands:")
+	_, _ = fmt.Fprintln(w, "  show    print typed configuration with secrets redacted")
 }
 
 func silence(cmd *cobra.Command) *cobra.Command {

--- a/cmd/gombit/new_test.go
+++ b/cmd/gombit/new_test.go
@@ -17,7 +17,7 @@ func TestRunHelpListsCommandFamilies(t *testing.T) {
 		t.Fatalf("run(--help) error = %v", err)
 	}
 	got := stdout.String()
-	for _, family := range []string{"new", "dev", "make", "db", "openapi", "client"} {
+	for _, family := range []string{"new", "dev", "make", "db", "openapi", "client", "routes", "doctor", "config"} {
 		if !strings.Contains(got, family) {
 			t.Fatalf("root help missing %q:\n%s", family, got)
 		}

--- a/cmd/gombit/routes.go
+++ b/cmd/gombit/routes.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/framework"
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func newRoutesCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
+	cmd := silence(&cobra.Command{
+		Use:   "routes",
+		Short: "Print HTTP routes",
+		Long: `Print a table of HTTP method and path.
+
+By default this constructs an in-process framework.App (memory cache,
+docs enabled) and lists framework-owned routes: probes, metrics,
+OpenAPI, and /docs. Application feature routes are registered by the
+app itself; list the live OpenAPI contract with --url against a
+running server (for example gombit routes --url http://127.0.0.1:8080).`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rawURL, err := cmd.Flags().GetString("url")
+			if err != nil {
+				return err
+			}
+			rows, note, err := collectRoutes(cmd.Context(), rawURL)
+			if err != nil {
+				return fmt.Errorf("gombit routes: %w", err)
+			}
+			if note != "" {
+				_, _ = fmt.Fprintln(stderr, note)
+			}
+			return writeRouteTable(stdout, rows)
+		},
+	})
+	cmd.Flags().String("url", "", "list OpenAPI paths from a running server (http or https origin or /openapi.json URL)")
+	return cmd
+}
+
+type routeRow struct {
+	Method string
+	Path   string
+}
+
+func collectRoutes(ctx context.Context, rawURL string) ([]routeRow, string, error) {
+	if strings.TrimSpace(rawURL) != "" {
+		rows, err := routesFromURL(ctx, rawURL)
+		if err != nil {
+			return nil, "", err
+		}
+		return rows, "OpenAPI contract paths from --url. Probe/metrics routes are raw Gin and are not in the spec.", nil
+	}
+	rows, err := frameworkOwnedRoutes()
+	if err != nil {
+		return nil, "", err
+	}
+	return rows, "Framework-owned routes from an in-process framework.App. Application feature routes require the running app: gombit routes --url http://127.0.0.1:8080", nil
+}
+
+func frameworkOwnedRoutes() ([]routeRow, error) {
+	gin.SetMode(gin.ReleaseMode)
+	cfg := config.DefaultFor(config.EnvironmentTest)
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.API.DocsEnabled = true
+	cfg.Cache.Driver = config.CacheDriverMemory
+	app, err := framework.New(framework.WithConfig(cfg), framework.WithLogger(zap.NewNop()))
+	if err != nil {
+		return nil, err
+	}
+	ginRoutes := app.Router().Routes()
+	rows := make([]routeRow, 0, len(ginRoutes))
+	for _, route := range ginRoutes {
+		rows = append(rows, routeRow{Method: route.Method, Path: route.Path})
+	}
+	sortRouteRows(rows)
+	return rows, nil
+}
+
+func routesFromURL(ctx context.Context, rawURL string) ([]routeRow, error) {
+	specURL, err := openAPIURLFromRoutesFlag(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	spec, err := fetchOpenAPI(ctx, specURL)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := routesFromOpenAPI(spec)
+	if err != nil {
+		return nil, err
+	}
+	sortRouteRows(rows)
+	return rows, nil
+}
+
+func openAPIURLFromRoutesFlag(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("url scheme must be http or https")
+	}
+	if strings.HasSuffix(parsed.Path, "/openapi.json") || parsed.Path == "openapi.json" {
+		return parsed.String(), nil
+	}
+	parsed.Path = strings.TrimSuffix(parsed.Path, "/") + "/openapi.json"
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func routesFromOpenAPI(spec []byte) ([]routeRow, error) {
+	var doc struct {
+		Paths map[string]map[string]json.RawMessage `json:"paths"`
+	}
+	if err := json.Unmarshal(spec, &doc); err != nil {
+		return nil, fmt.Errorf("parse OpenAPI: %w", err)
+	}
+	methods := []string{"get", "post", "put", "patch", "delete", "head", "options", "trace"}
+	rows := make([]routeRow, 0)
+	for path, item := range doc.Paths {
+		for _, method := range methods {
+			if _, ok := item[method]; ok {
+				rows = append(rows, routeRow{
+					Method: strings.ToUpper(method),
+					Path:   path,
+				})
+			}
+		}
+	}
+	return rows, nil
+}
+
+func sortRouteRows(rows []routeRow) {
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Path == rows[j].Path {
+			return rows[i].Method < rows[j].Method
+		}
+		return rows[i].Path < rows[j].Path
+	})
+}
+
+func writeRouteTable(w io.Writer, rows []routeRow) error {
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "METHOD\tPATH"); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\n", row.Method, row.Path); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}

--- a/config/redact.go
+++ b/config/redact.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// RedactedSecret is the placeholder used in place of passwords and DSN userinfo.
+const RedactedSecret = "*****"
+
+var querySecretPattern = regexp.MustCompile(`(?i)((?:password|pwd|pass)=)([^&]*)`)
+
+// Redacted returns a copy of c with secret-bearing fields replaced so it is
+// safe to print (DSN userinfo/passwords and Redis password).
+func (c Config) Redacted() Config {
+	out := c
+	out.Database.DSN = RedactDSN(c.Database.DSN)
+	if strings.TrimSpace(c.Cache.Redis.Password) != "" {
+		out.Cache.Redis.Password = RedactedSecret
+	}
+	return out
+}
+
+// RedactDSN returns dsn with userinfo passwords and password-like query
+// parameters replaced. SQLite file paths without userinfo are unchanged.
+func RedactDSN(dsn string) string {
+	trimmed := strings.TrimSpace(dsn)
+	if trimmed == "" {
+		return dsn
+	}
+
+	if strings.Contains(trimmed, "://") {
+		u, err := url.Parse(trimmed)
+		if err == nil && u.Scheme != "" {
+			if u.User != nil {
+				if _, hasPassword := u.User.Password(); hasPassword {
+					u.User = url.UserPassword(u.User.Username(), RedactedSecret)
+				}
+			}
+			return redactQuerySecrets(u.String())
+		}
+	}
+
+	if !strings.HasPrefix(trimmed, "file:") {
+		if at := strings.Index(trimmed, "@"); at > 0 {
+			userinfo := trimmed[:at]
+			if colon := strings.Index(userinfo, ":"); colon >= 0 {
+				return redactQuerySecrets(userinfo[:colon+1] + RedactedSecret + trimmed[at:])
+			}
+		}
+	}
+
+	return redactQuerySecrets(trimmed)
+}
+
+// SanitizeError returns err.Error() with known secrets from cfg removed.
+func SanitizeError(err error, cfg Config) string {
+	if err == nil {
+		return ""
+	}
+	return SanitizeSecretText(err.Error(), cfg)
+}
+
+// SanitizeSecretText replaces known secrets from cfg inside text.
+func SanitizeSecretText(text string, cfg Config) string {
+	if text == "" {
+		return text
+	}
+	if dsn := strings.TrimSpace(cfg.Database.DSN); dsn != "" {
+		text = strings.ReplaceAll(text, dsn, RedactDSN(dsn))
+		if u, err := url.Parse(dsn); err == nil && u.User != nil {
+			if password, ok := u.User.Password(); ok && password != "" {
+				text = strings.ReplaceAll(text, password, RedactedSecret)
+			}
+		}
+		if !strings.HasPrefix(dsn, "file:") {
+			if at := strings.Index(dsn, "@"); at > 0 {
+				userinfo := dsn[:at]
+				if colon := strings.Index(userinfo, ":"); colon >= 0 {
+					password := userinfo[colon+1:]
+					if password != "" {
+						text = strings.ReplaceAll(text, password, RedactedSecret)
+					}
+				}
+			}
+		}
+	}
+	if password := cfg.Cache.Redis.Password; password != "" {
+		text = strings.ReplaceAll(text, password, RedactedSecret)
+	}
+	return text
+}
+
+func redactQuerySecrets(value string) string {
+	return querySecretPattern.ReplaceAllString(value, "${1}"+RedactedSecret)
+}

--- a/config/redact.go
+++ b/config/redact.go
@@ -33,12 +33,7 @@ func RedactDSN(dsn string) string {
 	if strings.Contains(trimmed, "://") {
 		u, err := url.Parse(trimmed)
 		if err == nil && u.Scheme != "" {
-			if u.User != nil {
-				if _, hasPassword := u.User.Password(); hasPassword {
-					u.User = url.UserPassword(u.User.Username(), RedactedSecret)
-				}
-			}
-			return redactQuerySecrets(u.String())
+			return redactURL(u)
 		}
 	}
 
@@ -74,7 +69,7 @@ func SanitizeSecretText(text string, cfg Config) string {
 				text = strings.ReplaceAll(text, password, RedactedSecret)
 			}
 		}
-		if !strings.HasPrefix(dsn, "file:") {
+		if !strings.Contains(dsn, "://") && !strings.HasPrefix(dsn, "file:") {
 			if at := strings.Index(dsn, "@"); at > 0 {
 				userinfo := dsn[:at]
 				if colon := strings.Index(userinfo, ":"); colon >= 0 {
@@ -94,4 +89,31 @@ func SanitizeSecretText(text string, cfg Config) string {
 
 func redactQuerySecrets(value string) string {
 	return querySecretPattern.ReplaceAllString(value, "${1}"+RedactedSecret)
+}
+
+func redactURL(u *url.URL) string {
+	var b strings.Builder
+	b.WriteString(u.Scheme)
+	b.WriteString("://")
+	if u.User != nil {
+		b.WriteString(u.User.Username())
+		if _, hasPassword := u.User.Password(); hasPassword {
+			b.WriteByte(':')
+			b.WriteString(RedactedSecret)
+		}
+		b.WriteByte('@')
+	}
+	b.WriteString(u.Host)
+	if path := u.EscapedPath(); path != "" {
+		b.WriteString(path)
+	}
+	if u.RawQuery != "" {
+		b.WriteByte('?')
+		b.WriteString(redactQuerySecrets(u.RawQuery))
+	}
+	if u.Fragment != "" {
+		b.WriteByte('#')
+		b.WriteString(u.Fragment)
+	}
+	return b.String()
 }

--- a/config/redact_test.go
+++ b/config/redact_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRedactDSNHidesURLPassword(t *testing.T) {
+	t.Parallel()
+
+	dsn := "postgres://gombit:super-secret@127.0.0.1:5432/gombit?sslmode=disable"
+	got := RedactDSN(dsn)
+	if strings.Contains(got, "super-secret") {
+		t.Fatalf("RedactDSN() = %q, still contains password", got)
+	}
+	if !strings.Contains(got, RedactedSecret) {
+		t.Fatalf("RedactDSN() = %q, want %s placeholder", got, RedactedSecret)
+	}
+	if !strings.Contains(got, "gombit") || !strings.Contains(got, "127.0.0.1") {
+		t.Fatalf("RedactDSN() = %q, want username and host preserved", got)
+	}
+}
+
+func TestRedactDSNHidesMySQLUserinfo(t *testing.T) {
+	t.Parallel()
+
+	dsn := "gombit:mysql-secret@tcp(127.0.0.1:3306)/gombit?parseTime=true"
+	got := RedactDSN(dsn)
+	if strings.Contains(got, "mysql-secret") {
+		t.Fatalf("RedactDSN() = %q, still contains password", got)
+	}
+	if got != "gombit:"+RedactedSecret+"@tcp(127.0.0.1:3306)/gombit?parseTime=true" {
+		t.Fatalf("RedactDSN() = %q, want mysql userinfo redacted", got)
+	}
+}
+
+func TestRedactDSNLeavesSQLiteFilePath(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:gombit.db?cache=shared&_fk=1"
+	if got := RedactDSN(dsn); got != dsn {
+		t.Fatalf("RedactDSN() = %q, want unchanged sqlite DSN", got)
+	}
+}
+
+func TestRedactDSNHidesQueryPassword(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:gombit.db?cache=shared&password=query-secret"
+	got := RedactDSN(dsn)
+	if strings.Contains(got, "query-secret") {
+		t.Fatalf("RedactDSN() = %q, still contains query password", got)
+	}
+	if !strings.Contains(got, "password="+RedactedSecret) {
+		t.Fatalf("RedactDSN() = %q, want password query redacted", got)
+	}
+}
+
+func TestConfigRedactedHidesRedisPassword(t *testing.T) {
+	t.Parallel()
+
+	cfg := Default()
+	cfg.Database.DSN = "postgres://gombit:db-secret@localhost:5432/app"
+	cfg.Cache.Redis.Password = "redis-secret"
+
+	got := cfg.Redacted()
+	if strings.Contains(got.Database.DSN, "db-secret") {
+		t.Fatalf("Redacted DSN = %q, still contains db password", got.Database.DSN)
+	}
+	if got.Cache.Redis.Password != RedactedSecret {
+		t.Fatalf("Redacted Redis password = %q, want %s", got.Cache.Redis.Password, RedactedSecret)
+	}
+	if cfg.Cache.Redis.Password != "redis-secret" {
+		t.Fatal("Redacted() mutated the original Redis password")
+	}
+}
+
+func TestSanitizeErrorRemovesSecrets(t *testing.T) {
+	t.Parallel()
+
+	cfg := Default()
+	cfg.Database.DSN = "postgres://gombit:db-secret@localhost:5432/app"
+	cfg.Cache.Redis.Password = "redis-secret"
+
+	err := errors.New("dial postgres://gombit:db-secret@localhost:5432/app with redis-secret")
+	got := SanitizeError(err, cfg)
+	if strings.Contains(got, "db-secret") || strings.Contains(got, "redis-secret") {
+		t.Fatalf("SanitizeError() = %q, still contains secrets", got)
+	}
+}

--- a/config/redact_test.go
+++ b/config/redact_test.go
@@ -9,7 +9,7 @@ import (
 func TestRedactDSNHidesURLPassword(t *testing.T) {
 	t.Parallel()
 
-	dsn := "postgres://gombit:super-secret@127.0.0.1:5432/gombit?sslmode=disable"
+	dsn := "postgres://gombit:super-secret@127.0.0.1:5432/gombit?sslmode=disable" // #nosec G101 -- fake local test DSN.
 	got := RedactDSN(dsn)
 	if strings.Contains(got, "super-secret") {
 		t.Fatalf("RedactDSN() = %q, still contains password", got)
@@ -61,7 +61,7 @@ func TestConfigRedactedHidesRedisPassword(t *testing.T) {
 	t.Parallel()
 
 	cfg := Default()
-	cfg.Database.DSN = "postgres://gombit:db-secret@localhost:5432/app"
+	cfg.Database.DSN = "postgres://gombit:db-secret@localhost:5432/app" // #nosec G101 -- fake local test DSN.
 	cfg.Cache.Redis.Password = "redis-secret"
 
 	got := cfg.Redacted()
@@ -80,7 +80,7 @@ func TestSanitizeErrorRemovesSecrets(t *testing.T) {
 	t.Parallel()
 
 	cfg := Default()
-	cfg.Database.DSN = "postgres://gombit:db-secret@localhost:5432/app"
+	cfg.Database.DSN = "postgres://gombit:db-secret@localhost:5432/app" // #nosec G101 -- fake local test DSN.
 	cfg.Cache.Redis.Password = "redis-secret"
 
 	err := errors.New("dial postgres://gombit:db-secret@localhost:5432/app with redis-secret")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,10 +19,12 @@ go run ./cmd/gombit --help
 | `gombit db …` | Atlas-backed migrations | M2, migrated onto Cobra in M4-1 |
 | `gombit openapi generate` | Write the live OpenAPI 3.1 document | M3-3 |
 | `gombit client generate` / `check` | TypeScript client + drift | M3-4, M3-5 |
+| `gombit routes` | Print HTTP routes | M4-4 |
+| `gombit doctor` | Environment and config checks | M4-4 |
+| `gombit config show` | Print typed config with secrets redacted | M4-4 |
 
-Not in this milestone: `routes` / `doctor` / `config show` (M4-4),
-`createsuperuser` (M4-6), `make command` (M4-7). Golden tests for generators
-are M4-5; this command still has unit tests.
+Not in this milestone: `createsuperuser` (M4-6), `make command` (M4-7).
+Golden tests for generators are M4-5; these commands still have unit tests.
 
 ## `gombit new`
 
@@ -250,6 +252,64 @@ gombit db reset [--force]
 ```
 
 See [migrations.md](migrations.md) for Atlas behavior.
+
+## `gombit routes`
+
+Print a table of HTTP method and path:
+
+```sh
+gombit routes
+gombit routes --url http://127.0.0.1:8080
+```
+
+Default listing constructs an in-process `framework.App` (memory cache, docs
+on) and prints framework-owned routes: `/livez`, `/readyz`, `/metrics`,
+`/openapi.json` (and Huma siblings), and `/docs`. Application feature routes
+are registered by the app; they are not discovered by reflection. Against a
+running server, `--url` fetches `/openapi.json` and lists the live contract
+paths (probes and other raw Gin routes stay out of that spec).
+
+## `gombit doctor`
+
+```sh
+gombit doctor
+gombit doctor --dir database/migrations
+```
+
+Prints a status table. A `FAIL` row exits non-zero.
+
+| Check | Role |
+| --- | --- |
+| `go` | `go version` on `PATH` |
+| `node` | `node --version`; **warn** if missing (`gombit dev` needs it) |
+| `config` | `config.Load()` / `FieldErrors` |
+| `database` | `database.Open` + ping when a driver/DSN is set (timeout-bounded) |
+| `redis` | ping when `GOMBIT_CACHE_DRIVER=redis` (timeout-bounded) |
+| `migrations` | pending Atlas SQL in `--dir` (**warn**); skip if the directory is absent |
+| `http` | `GOMBIT_HTTP_ADDR` parses; **warn** if the port is in use |
+| `insecure` | existing production issues: `/docs` on in production, SQLite DSN path not writable |
+
+Network checks use a short timeout so CI cannot hang. Doctor does not start
+Postgres/Redis containers; an invalid driver, broken `config.Load()`, or an
+unwritable SQLite path is enough to flag a deliberately-broken config.
+
+Appendix C JWT secret, cookie `Secure`, and CORS+credentials checks wait for
+the typed auth fields (M5). Production trusted-proxy and Redis
+`TLSInsecure` rejections already live in `config.Validate()` and show up on
+the `config` row.
+
+## `gombit config show`
+
+```sh
+gombit config show
+```
+
+Prints the typed `config.Load()` result as aligned `key<TAB>value` lines.
+Database DSN userinfo/passwords and `Cache.Redis.Password` are replaced with
+`*****` and must never appear in the output. JWT/cookie/CORS fields are
+omitted until those typed config fields exist.
+
+See [config.md](config.md).
 
 ## `gombit openapi` and `gombit client`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -84,11 +84,19 @@ external module hook, not a runtime dependency.
 Validation returns `config.FieldErrors`, which names the typed field, the
 environment variable, the invalid value, and the validation message.
 
+`gombit config show` prints this typed result as aligned key/value lines.
+DSN userinfo/passwords and the Redis password are redacted (`*****`);
+`Config.Redacted()` / `RedactDSN` are the helpers. Do not log raw DSNs.
+
 Appendix C production checks, such as JWT secret strength, secure cookies,
 CORS credentials, debug Gin mode, and Redis settings land with the features
-that introduce those typed fields. Future secret-bearing fields must not copy
-secret values into `FieldError.Value`; `Config.Database.DSN` validation does
-not echo the DSN value.
+that introduce those typed fields. JWT/cookie/CORS typed fields do not exist
+yet (M5); `gombit doctor` still flags **existing** insecure or broken cases
+(invalid config, production + `/docs`, unwritable SQLite DSN path, Redis
+selected but unreachable, pending migrations). Future secret-bearing fields
+must not copy secret values into `FieldError.Value`; `Config.Database.DSN`
+validation does not echo the DSN value.
 
 Runtime extraction work should accept `config.Config` values instead of calling
-`os.Getenv` or `os.LookupEnv` directly.
+`os.Getenv` or `os.LookupEnv` directly. The CLI (`gombit doctor`,
+`gombit config show`) may call `config.Load()`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the M4-4 introspection commands on the Cobra tree:

- `gombit routes` — in-process `framework.App` route table (probes, metrics, `/openapi.json`, `/docs`); `--url` lists live OpenAPI paths
- `gombit doctor` — Go/Node, `config.Load()`, DB/Redis connectivity, migration status, HTTP addr, existing insecure settings
- `gombit config show` — typed config as aligned key/value lines, with DSN userinfo and Redis password redacted (`*****`)

Closes #24

## Acceptance criteria

- [x] doctor flags a deliberately-broken config (`GOMBIT_DATABASE_DRIVER=not-a-driver` → non-zero exit, `FAIL` on the named `config` check)
- [x] root help lists `routes`, `doctor`, and `config`
- [x] `gombit config show` does not print DSN/Redis secrets
- [x] `gombit routes` includes framework paths (`/openapi.json`, `/docs`, `/livez`)

## Scope notes

- JWT secret, cookie `Secure`, and CORS+credentials Appendix C checks wait for M5 typed auth fields. Doctor still flags **existing** cases: invalid config, production + `/docs`, unwritable SQLite DSN path, Redis selected but unreachable, pending migrations.
- Not in this PR: M4-5 goldens, M4-6 `createsuperuser`, M4-7 `make command`, M5 auth, M6 batteries.
- Default `gombit routes` lists framework-owned routes from an in-process app (memory cache). Application feature routes are not discovered by reflection; use `--url` against a running server for the live contract.

## Validation

- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [x] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — doctor uses SQLite memory / invalid driver / unwritable path so CI does not hang; no new multi-driver Open/migrate behavior
- [x] Stable features ship docs and appear in an example app — `docs/cli.md`, `docs/config.md`; `examples/config` remains the Load() example
- [ ] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests — N/A (new CLI surface; no template extraction)
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — N/A (no generator changes)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A (no public HTTP contract change)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public — N/A for frontend; `config show` / doctor sanitize DSN and Redis passwords
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7cead8d-780d-4ee8-ae63-2a4e49ca67e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7cead8d-780d-4ee8-ae63-2a4e49ca67e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

