### PR TITLE
[ADMIN-0] ADR-013: runtime generic admin over an introspection API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,17 @@ a generated React+TypeScript frontend, Atlas-backed migrations. Module path
 
 ## Current state
 
-This repo has completed M0–M4 and started **M5 frontend**. It has typed
+This repo has completed M0–M5. It has typed
 `config.Config`, `framework.App` lifecycle and routing, Huma contract/OpenAPI/
 TypeScript client generation, Atlas-backed migrations, a Cobra `gombit`
 command tree (`new`, `dev`, `build --embed`, `make resource`, `make command`,
 `db`, `openapi`, `client`), and a Vite + React + TypeScript minimal skeleton
 (router, generated client, React Hook Form). Bearer login (M5-2), cookie/CSRF
 (M5-3), the MUI preset (M5-4, `--ui mui`), and optional `gombit build --embed`
-(M5-5) are in. M6 batteries are not here yet.
+(M5-5) are in. **ADMIN-0 (ADR-013) is accepted**: the admin is a
+framework-owned React app driven by a Huma introspection API, not `--admin`
+scaffolded pages. ADMIN-1+ (registry, generic SPA, groups/permissions) are
+not implemented. Other M6 batteries are not here yet.
 Don't assume generated apps are committed in-tree; `gombit new` writes them
 on demand. Check `git log` / `ls` before describing "how the code works."
 
@@ -53,6 +56,9 @@ on demand. Check `git log` / `ls` before describing "how the code works."
   Nested families and M4-7 app-registered management commands use Cobra
   `AddCommand`. Do not introduce Kong or a parallel hand-rolled router as the
   long-term CLI architecture; pre-M4 stdlib `flag` is temporary until M4-1.
+- **Admin (ADR-013):** runtime generic admin over an explicit registry + Huma
+  introspection API; framework-owned React app under `/admin/`. Never
+  `--admin` generated pages, never request-time reflection over GORM models.
 
 ## Agent working agreement (definition of done — build plan §5)
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Optional `go:embed` production is documented in [`docs/build.md`](docs/build.md)
 Bearer JWT login is documented in [`docs/auth.md`](docs/auth.md); cookie/session
 auth (`--auth cookie`) and its CSRF threat model are documented in
 [`docs/auth-cookie.md`](docs/auth-cookie.md).
+The post-v0.1 admin architecture is [ADR-013](docs/adr/013-runtime-generic-admin.md);
+see [`docs/admin.md`](docs/admin.md).
 Database runtime support is documented in [`docs/database.md`](docs/database.md).
 Cache runtime support is documented in [`docs/cache.md`](docs/cache.md).
 Runtime logging is documented in [`docs/logging.md`](docs/logging.md).

--- a/docs/GOMBIT_BUILD_PLAN.md
+++ b/docs/GOMBIT_BUILD_PLAN.md
@@ -204,7 +204,7 @@ One issue per seam. Each must keep the existing tests green (see §5).
 
 ### M6-Admin — Django-style admin (POST-v0.1 flagship)
 
-The single biggest differentiator — **no Go web framework has a real Django-style admin** (not Gin/Echo/Fiber/Encore). This is the headline of the first release *after* v0.1, not part of the v0.1 loop. Architecture follows the §3.3 law: the admin is a **runtime** surface, not generated pages.
+The single biggest differentiator — **no Go web framework has a real Django-style admin** (not Gin/Echo/Fiber/Encore). This is the headline of the first release *after* v0.1, not part of the v0.1 loop. Architecture follows the §3.3 law: the admin is a **runtime** surface, not generated pages. Accepted decision: [ADR-013](adr/013-runtime-generic-admin.md).
 
 - **[ADMIN-0] ADR-013: runtime generic admin over an introspection API** — decide the model-registry/introspection contract (models, fields, relations, permissions a feature-package registers) and confirm the admin is a framework-owned React app driven by that metadata endpoint — **not** `--admin` scaffolded pages. Prerequisite: session auth (C3). deps: M5-3. size: M. labels: `adr`, `admin`.
 - **[ADMIN-1] Model registry + introspection endpoint** — explicit `admin.Register(Model, opts)`; framework serves the metadata (no deep runtime reflection — principle 6.2). AC: registered models expose fields/permissions over the endpoint. deps: ADMIN-0. size: L. labels: `admin`, `runtime`.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -1,0 +1,19 @@
+# Admin (post-v0.1)
+
+Gombit's Django-style admin is the prioritized post-v0.1 flagship (build plan
+M6-Admin). Implementation has not started.
+
+The accepted architecture is **[ADR-013](adr/013-runtime-generic-admin.md)**:
+a framework-owned React app over an explicit model registry and a Huma
+introspection API. Not `--admin` scaffolded pages.
+
+| Issue | What it ships |
+| --- | --- |
+| ADMIN-0 (#33) | This decision (ADR-013). Done when the ADR is merged. |
+| ADMIN-1 | `admin.Register` + `GET /api/v1/admin/meta` + generic `/api/v1/admin/resources/{slug}` |
+| ADMIN-2 | Framework-owned SPA under `/admin/` |
+| ADMIN-3 | Groups/permissions on top of `IsSuperuser` |
+
+Do not add a runtime `admin` package, admin HTTP routes, or an admin React
+app until ADMIN-1. Session/cookie auth (`--auth cookie`) is a hard
+prerequisite; see [auth-cookie.md](auth-cookie.md).

--- a/docs/adr/013-runtime-generic-admin.md
+++ b/docs/adr/013-runtime-generic-admin.md
@@ -1,0 +1,354 @@
+# ADR-013: Runtime Generic Admin over an Introspection API
+
+## Status
+
+Accepted.
+
+## Context
+
+Gombit's post-v0.1 flagship is a Django-style admin: register a model, get a
+working staff UI. No Go web framework (Gin, Echo, Fiber, Encore) ships a real
+one. Build plan M6-Admin is that surface. It is **not** part of the v0.1 CRUD
+loop.
+
+The generate-vs-runtime rule (build plan §3.3) decides the shape:
+
+> Behavior lives in the versioned runtime. Generated code is a thin, one-time
+> scaffold the user owns. The framework never rewrites user-owned files.
+
+If admin screens were `--admin` / `gombit make resource --admin` pages copied
+into every generated `frontend/`, `gombit upgrade` could not evolve them, each
+app would own a fork of the UI, and ADMIN-2's acceptance criterion ("zero
+per-model frontend code") would be impossible.
+
+The other locked constraints this ADR must encode, not reopen:
+
+- **Principle 6.2 (explicit Go, minimal magic):** no Django metaclasses, no
+  request-time walking of arbitrary Go types, no reflection discovery of every
+  GORM model / AutoMigrate list. ADMIN-1 is explicit
+  `admin.Register(Model, opts)`.
+- **C2:** generated apps stay feature-packages under `internal/<feature>/`. A
+  feature registers its models from `routes.go` or an `admin.go` beside the
+  model — never Laravel `app/models` / `app/admin`.
+- **C1:** the public HTTP contract is Huma-typed and appears in OpenAPI 3.1.
+  Success and error bodies are D10.
+- **C3:** Bearer JWT remains the v0.1 **API** default (access token in memory,
+  never `localStorage`). Session/cookie (`--auth cookie` /
+  `AuthModeCookie`) is first-class and a **hard prerequisite** of the admin.
+  The admin UI uses HttpOnly session cookies + CSRF (M5-3). Superuser
+  (`User.IsSuperuser`, seeded by M4-6 `gombit createsuperuser`) is the
+  bootstrap admin; groups/permissions land in ADMIN-3.
+- **C4:** the default generated app UI stays minimal/headless. `--ui mui` is
+  an opt-in preset for **application** screens, not the admin.
+- **M5-5:** optional `go:embed` + SPA fallback is the pattern for serving a
+  framework- or app-owned React bundle from Gin without putting those routes
+  in OpenAPI.
+- **Scope guard:** jobs, events, scheduler, mail, storage, gRPC, multi-tenancy,
+  and i18n stay out. This ADR does not implement ADMIN-1, ADMIN-2, or ADMIN-3.
+
+M5-3 (issue #30) is done, so the session/CSRF prerequisite is met. ADMIN-0's
+job is to lock the registry/introspection contract and the "framework-owned
+SPA" decision so ADMIN-1 is not blocked.
+
+Names below (`admin.Register`, `/api/v1/admin/meta`, field type strings) are
+**provisional**. They are documentation for implementers. This ADR does not
+add a runtime `admin` package.
+
+## Decision
+
+Gombit's admin is a **runtime generic admin** driven by an **explicit model
+registry** and a **Huma introspection API**. A framework-owned React app
+renders list/detail/create/edit/delete from that metadata. Generated apps do
+not receive `--admin` pages.
+
+### 1. Registration API (ADMIN-1)
+
+A feature-package registers models **explicitly** at startup, typically from
+`internal/<feature>/routes.go` or `internal/<feature>/admin.go`:
+
+```go
+// internal/product/admin.go — sketch, not a shipped API
+func RegisterAdmin(app *framework.App) {
+    admin.Register(app, Product{}, admin.Options{
+        Slug:    "products",
+        Singular: "Product",
+        Plural:  "Products",
+        Fields: []admin.Field{
+            {Name: "id", Type: "uuid", ReadOnly: true},
+            {Name: "name", Type: "string", Required: true},
+            {
+                Name: "category_id",
+                Type: "relation",
+                Related: &admin.Relation{
+                    Slug:       "categories",
+                    Kind:       "belongs_to",
+                    LabelField: "name",
+                },
+            },
+        },
+        List:     []string{"name", "category_id"},
+        Search:   []string{"name"},
+        Filter:   []string{"category_id"},
+        Ordering: []string{"name", "created_at"},
+        Actions: admin.Actions{
+            List: true, Detail: true, Create: true, Update: true, Delete: true,
+        },
+        // Permission keys are declared here; ADMIN-3 enforces them.
+        // Until then the runtime gates on User.IsSuperuser only.
+        Permissions: admin.Permissions{
+            View:   "admin.products.view",
+            Create: "admin.products.create",
+            Update: "admin.products.update",
+            Delete: "admin.products.delete",
+        },
+    })
+}
+```
+
+`Options` is the **source of truth** for what the introspection endpoint and
+the generic data plane expose:
+
+| Field | Role |
+| --- | --- |
+| `Slug` | URL key (`products`). Stable, lowercase, unique per app. |
+| `Singular` / `Plural` | UI labels. |
+| `Fields` | Concrete field list: `name`, `type`, `required`, `readonly`, optional `related`. |
+| `List` | Columns on the list view. |
+| `Search` | Fields the list `search` query param applies to. |
+| `Filter` | Fields the list may filter on. |
+| `Ordering` | Fields the list may order by. |
+| `Actions` | Which of list / detail / create / update / delete are enabled. |
+| `Permissions` | String keys for ADMIN-3. ADMIN-1 stores them on the registry and echoes them in meta; it does not invent a groups table. |
+
+Closed field-type set for v1 of the admin (ADMIN-1 may add members with a
+docs bump, not a parallel type system):
+
+`string`, `text`, `integer`, `float`, `decimal`, `boolean`, `datetime`,
+`date`, `uuid`, `json`, `relation`.
+
+Relation `kind` is `belongs_to` or `has_many` for the first cut. Many-to-many
+is deferred until a later admin issue needs it.
+
+**How fields get onto the registry without request-time reflection:**
+
+- Callers pass `Options.Fields` explicitly. That list is what HTTP handlers
+  read.
+- `admin.Register` may offer a **registration-time** convenience, e.g.
+  `admin.FieldsFrom(Product{})` or "empty `Fields` derives a default from the
+  struct once," analogous to passing a model into GORM. That helper may use
+  `reflect` **only inside `Register`**, on the one type being registered, to
+  produce a concrete `[]Field` stored on the registry. It must be documented
+  as registration-time only and covered by tests in ADMIN-1.
+- After `Register` returns, the registry holds values (slug, field slice,
+  action flags, a constructor `func() any` / generic `Register[T]` so GORM
+  can `Create`/`Find` that type). Request handlers **must not** walk
+  arbitrary Go types, scan `AutoMigrate` lists, or discover models by
+  package crawl.
+
+Missing `Slug` is an error at `Register`. Duplicate slugs are an error at
+`Register`. Unregistered models do not appear in admin.
+
+### 2. Introspection HTTP (ADMIN-1)
+
+Mounted on `app.API()` as Huma operations under `config.API.Prefix`
+(default `/api/v1`). They appear in OpenAPI 3.1. D10 envelopes.
+
+| Method | Path | Body |
+| --- | --- | --- |
+| `GET` | `/api/v1/admin/meta` | `{ "data": { "models": [ ... ] }, "meta"?: { ... } }` |
+| `GET` | `/api/v1/admin/meta/{slug}` | `{ "data": { /* one model */ } }` — 404 D10 `not_found` if unknown |
+
+Both require a cookie session (C3). Until ADMIN-3, they also require
+`IsSuperuser`. Unauthenticated → D10 `authentication` (401). Authenticated
+non-superuser → D10 `authorization` (403). Mutating admin routes additionally
+go through the existing M5-3 CSRF middleware (`X-CSRF-Token`).
+
+Catalog `data` sketch (normative field names for ADMIN-1; see
+[`testdata/admin-meta.json`](testdata/admin-meta.json)):
+
+```json
+{
+  "data": {
+    "models": [
+      {
+        "slug": "products",
+        "singular": "Product",
+        "plural": "Products",
+        "pk": "id",
+        "fields": [
+          {"name": "id", "type": "uuid", "required": false, "readonly": true},
+          {"name": "name", "type": "string", "required": true, "readonly": false},
+          {
+            "name": "category_id",
+            "type": "relation",
+            "required": false,
+            "readonly": false,
+            "related": {"slug": "categories", "kind": "belongs_to", "label_field": "name"}
+          }
+        ],
+        "list": ["name", "category_id"],
+        "search": ["name"],
+        "filter": ["category_id"],
+        "ordering": ["name", "created_at"],
+        "actions": {
+          "list": true,
+          "detail": true,
+          "create": true,
+          "update": true,
+          "delete": true
+        },
+        "permissions": {
+          "view": "admin.products.view",
+          "create": "admin.products.create",
+          "update": "admin.products.update",
+          "delete": "admin.products.delete"
+        }
+      }
+    ]
+  },
+  "meta": {
+    "auth": {"mode": "cookie", "bootstrap": "is_superuser"}
+  }
+}
+```
+
+`meta.auth` on the catalog tells the SPA which bootstrap rule is in force
+before ADMIN-3 lands groups. ADMIN-1 may omit `meta` if it has nothing to
+add; `data.models` is required (empty array when nothing is registered).
+
+Raw `*gin.Engine` (`app.Router()`) is **not** used for these endpoints. The
+escape hatch is reserved for the admin SPA static files and `/admin/`
+fallback, which must stay **out** of OpenAPI (same reason M5-5 SPA fallback
+is raw Gin).
+
+### 3. CRUD data plane (ADMIN-1 / ADMIN-2)
+
+The React admin must have **zero per-model frontend code** (ADMIN-2 AC).
+Therefore the runtime, not each feature-package, implements a **generic
+admin data plane** from the registry:
+
+| Method | Path |
+| --- | --- |
+| `GET` | `/api/v1/admin/resources/{slug}` |
+| `POST` | `/api/v1/admin/resources/{slug}` |
+| `GET` | `/api/v1/admin/resources/{slug}/{id}` |
+| `PATCH` | `/api/v1/admin/resources/{slug}/{id}` |
+| `DELETE` | `/api/v1/admin/resources/{slug}/{id}` |
+
+These are Huma-typed operations on `app.API()`, session-required, CSRF on
+unsafe methods, D10 envelopes. List uses `contract.PageMeta`
+(`page`, `per_page`, `total`). List query parameters ADMIN-1 should honor:
+
+- `page`, `per_page`
+- `search` (applied to `Options.Search`)
+- `ordering` (a field from `Options.Ordering`, optional `-` prefix for DESC)
+- one query key per `Options.Filter` field
+
+Create/update bodies are JSON objects of writable fields. Unknown slugs,
+disabled actions, and unknown ids are D10 `not_found` or `authorization` as
+appropriate. Validation failures use D10 `validation_error` with `fields`.
+
+Row payloads are JSON objects keyed by the registered field names. The
+OpenAPI schema for a row is necessarily generic (`object`); that is
+accepted. The application's **public** CRUD API stays the feature's own
+typed Huma routes. Admin does not replace those routes and does not require
+the feature to write a second handler set.
+
+**Why not reuse per-model public Huma routes?** The SPA would then need a
+per-slug client and would break ADMIN-2's "zero per-model frontend code"
+rule. Public DTOs also omit admin-only columns and use different auth
+(Bearer by default). A registry-driven data plane keeps one client in the
+admin SPA and one authorization story (session + superuser / ADMIN-3).
+
+ADMIN-1 implements meta + the data plane. ADMIN-2 consumes them. This ADR
+does not ship either.
+
+### 4. Admin SPA (ADMIN-2)
+
+The admin UI is a **framework-owned** Vite + React + TypeScript app, versioned
+with the Gombit module (path TBD in ADMIN-2; e.g. `internal/adminui`). It is
+**not** copied into generated `frontend/`.
+
+Serving follows M5-5: the built assets live in a framework `embed.FS` and
+are mounted on raw Gin with SPA fallback under **`/admin/`** (assets under
+`/admin/assets/…`). Those GET routes stay out of OpenAPI. API calls go to
+`/api/v1/admin/…` and the existing cookie auth endpoints
+(`/api/v1/auth/csrf`, `/auth/login`, `/auth/logout`, `/me`) on the same
+origin, so HttpOnly cookies attach and CSRF double-submit works as in
+[`docs/auth-cookie.md`](../auth-cookie.md).
+
+The admin SPA may use MUI internally. That does **not** couple generated apps
+to `--ui mui` (C4). Default app screens stay minimal; `--ui mui` remains the
+application-CRUD preset.
+
+Auth tokens never go in `localStorage` / `sessionStorage`. Cookie mode
+already keeps access/refresh in HttpOnly cookies; the admin SPA may hold
+only the CSRF token in memory (same as the generated cookie frontend).
+
+`gombit new` does not scaffold admin pages. `gombit make resource` does not
+gain `--admin`. A later issue may AST-append an `admin.Register` call in the
+feature package; it still must not emit React pages.
+
+Optional later (not ADMIN-2 AC): `gombit dev` prints an Admin URL in the
+service table. Out of this ADR.
+
+Mounting: introspection, data plane, and `/admin/` SPA mount only when
+`Config.Auth.EffectiveMode() == AuthModeCookie` and auth is enabled.
+Bearer-only apps keep the v0.1 API default and do not grow an admin. Dual
+Bearer-API + cookie-admin in one process is not introduced here; cookie mode
+is already mutually exclusive with JWT mode (M5-3). Apps that want admin use
+`--auth cookie`.
+
+### 5. Rejected alternatives
+
+- **`--admin` / `gombit make resource --admin` generated CRUD pages.**
+  Violates §3.3; forks the UI per app; fails ADMIN-2's zero per-model
+  frontend code.
+- **Deep reflection over all GORM models or the AutoMigrate list.**
+  Violates principle 6.2; would expose models the app never opted into
+  admin; request-time type walking is the Django-metaclass path Gombit
+  refused.
+- **Laravel-style `app/admin` (or `app/models`) tree.** Violates C2.
+  Registration lives in the feature package.
+- **Making `--ui mui` generated screens the admin.** Violates C4. MUI
+  application screens are a preset for the user's app, not the staff UI.
+- **Per-model admin Huma handlers written by each feature.** Duplicates the
+  public API, forces per-model frontend code, and blocks a single generic
+  SPA.
+
+## Consequences
+
+- ADMIN-1 implements `admin.Register`, the in-memory registry, Huma
+  `GET /api/v1/admin/meta` (+ `/{slug}`), and the generic
+  `/api/v1/admin/resources/{slug}` data plane. No request-time reflection.
+  Tests cover registration errors, meta JSON, session/superuser gates, and
+  CRUD against a registered fixture model (SQLite + PostgreSQL + MySQL when
+  the data plane touches the DB).
+- ADMIN-2 implements the framework-owned React app, `embed.FS` serving under
+  `/admin/`, and screens driven only by meta + the generic data plane.
+- ADMIN-3 enforces groups/permissions using the keys stored on the registry.
+  Until then, `IsSuperuser` is the only admin principal. `/auth/register`
+  still never sets `IsSuperuser`.
+- Generated `frontend/` and `--ui mui` are unchanged by this ADR. No golden
+  template updates belong in ADMIN-0.
+- Agents must not re-litigate "generated admin pages vs runtime SPA," must
+  not add `app/admin`, and must not walk GORM models without `Register`.
+- No jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, or i18n
+  work hides under "admin."
+
+## References
+
+- Issue #33: `[ADMIN-0] ADR-013: runtime generic admin over an introspection API`
+- Issue #30: `[M5-3] Cookie/session + CSRF preset (--auth cookie)` (prerequisite)
+- Issue #34: `[ADMIN-1] Model registry + introspection endpoint`
+- Issue #35: `[ADMIN-2] Generic React admin app`
+- Issue #36: `[ADMIN-3] Admin auth + authorization`
+- Issue #26: `[M4-6] gombit createsuperuser` (`IsSuperuser` bootstrap)
+- Issue #32: `[M5-5] Optional go:embed build` (SPA embed pattern)
+- Build plan §3.3, C1–C4, M6-Admin (`docs/GOMBIT_BUILD_PLAN.md`)
+- Design doc §6.2 (explicit Go, minimal magic) — rationale only
+- [`docs/admin.md`](../admin.md)
+- [`docs/auth-cookie.md`](../auth-cookie.md)
+- [`docs/build.md`](../build.md)
+- [`docs/adr/011-contract-layer-huma.md`](011-contract-layer-huma.md)
+- Fixture: [`testdata/admin-meta.json`](testdata/admin-meta.json)

--- a/docs/adr/admin_meta_test.go
+++ b/docs/adr/admin_meta_test.go
@@ -68,7 +68,7 @@ func TestAdminMetaFixtureUnmarshal(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join("testdata", "admin-meta.json")
-	raw, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path) // #nosec G304 -- test fixture path
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)
 	}

--- a/docs/adr/admin_meta_test.go
+++ b/docs/adr/admin_meta_test.go
@@ -1,0 +1,131 @@
+package adr_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Types below document the ADMIN-0 introspection envelope sketched in
+// ADR-013. They are test-only and are not a public admin API.
+
+type metaEnvelope struct {
+	Data metaData `json:"data"`
+	Meta *metaAux `json:"meta"`
+}
+
+type metaData struct {
+	Models []metaModel `json:"models"`
+}
+
+type metaAux struct {
+	Auth *metaAuth `json:"auth"`
+}
+
+type metaAuth struct {
+	Mode      string `json:"mode"`
+	Bootstrap string `json:"bootstrap"`
+}
+
+type metaModel struct {
+	Slug        string            `json:"slug"`
+	Singular    string            `json:"singular"`
+	Plural      string            `json:"plural"`
+	PK          string            `json:"pk"`
+	Fields      []metaField       `json:"fields"`
+	List        []string          `json:"list"`
+	Search      []string          `json:"search"`
+	Filter      []string          `json:"filter"`
+	Ordering    []string          `json:"ordering"`
+	Actions     metaActions       `json:"actions"`
+	Permissions map[string]string `json:"permissions"`
+}
+
+type metaField struct {
+	Name     string       `json:"name"`
+	Type     string       `json:"type"`
+	Required bool         `json:"required"`
+	ReadOnly bool         `json:"readonly"`
+	Related  *metaRelated `json:"related"`
+}
+
+type metaRelated struct {
+	Slug       string `json:"slug"`
+	Kind       string `json:"kind"`
+	LabelField string `json:"label_field"`
+}
+
+type metaActions struct {
+	List   bool `json:"list"`
+	Detail bool `json:"detail"`
+	Create bool `json:"create"`
+	Update bool `json:"update"`
+	Delete bool `json:"delete"`
+}
+
+func TestAdminMetaFixtureUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "admin-meta.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var env metaEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("json.Unmarshal(%s): %v", path, err)
+	}
+
+	if len(env.Data.Models) != 2 {
+		t.Fatalf("data.models len = %d, want 2", len(env.Data.Models))
+	}
+	if env.Meta == nil || env.Meta.Auth == nil {
+		t.Fatal("meta.auth is nil")
+	}
+	if env.Meta.Auth.Mode != "cookie" {
+		t.Errorf("meta.auth.mode = %q, want %q", env.Meta.Auth.Mode, "cookie")
+	}
+	if env.Meta.Auth.Bootstrap != "is_superuser" {
+		t.Errorf("meta.auth.bootstrap = %q, want %q", env.Meta.Auth.Bootstrap, "is_superuser")
+	}
+
+	products := env.Data.Models[0]
+	if products.Slug != "products" {
+		t.Errorf("models[0].slug = %q, want %q", products.Slug, "products")
+	}
+	if products.PK != "id" {
+		t.Errorf("models[0].pk = %q, want %q", products.PK, "id")
+	}
+	if !products.Actions.List || !products.Actions.Create {
+		t.Errorf("models[0].actions = %+v, want list and create enabled", products.Actions)
+	}
+	if got := products.Permissions["view"]; got != "admin.products.view" {
+		t.Errorf("models[0].permissions.view = %q, want %q", got, "admin.products.view")
+	}
+
+	var relation *metaField
+	for i := range products.Fields {
+		if products.Fields[i].Name == "category_id" {
+			relation = &products.Fields[i]
+			break
+		}
+	}
+	if relation == nil {
+		t.Fatal("models[0] missing category_id field")
+	}
+	if relation.Type != "relation" {
+		t.Errorf("category_id.type = %q, want %q", relation.Type, "relation")
+	}
+	if relation.Related == nil {
+		t.Fatal("category_id.related is nil")
+	}
+	if relation.Related.Slug != "categories" || relation.Related.Kind != "belongs_to" {
+		t.Errorf("category_id.related = %+v, want slug=categories kind=belongs_to", relation.Related)
+	}
+
+	if env.Data.Models[1].Slug != "categories" {
+		t.Errorf("models[1].slug = %q, want %q", env.Data.Models[1].Slug, "categories")
+	}
+}

--- a/docs/adr/testdata/admin-meta.json
+++ b/docs/adr/testdata/admin-meta.json
@@ -1,0 +1,103 @@
+{
+  "data": {
+    "models": [
+      {
+        "slug": "products",
+        "singular": "Product",
+        "plural": "Products",
+        "pk": "id",
+        "fields": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "required": false,
+            "readonly": true
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "readonly": false
+          },
+          {
+            "name": "price",
+            "type": "decimal",
+            "required": true,
+            "readonly": false
+          },
+          {
+            "name": "category_id",
+            "type": "relation",
+            "required": false,
+            "readonly": false,
+            "related": {
+              "slug": "categories",
+              "kind": "belongs_to",
+              "label_field": "name"
+            }
+          }
+        ],
+        "list": ["name", "category_id", "price"],
+        "search": ["name"],
+        "filter": ["category_id"],
+        "ordering": ["name", "created_at"],
+        "actions": {
+          "list": true,
+          "detail": true,
+          "create": true,
+          "update": true,
+          "delete": true
+        },
+        "permissions": {
+          "view": "admin.products.view",
+          "create": "admin.products.create",
+          "update": "admin.products.update",
+          "delete": "admin.products.delete"
+        }
+      },
+      {
+        "slug": "categories",
+        "singular": "Category",
+        "plural": "Categories",
+        "pk": "id",
+        "fields": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "required": false,
+            "readonly": true
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "readonly": false
+          }
+        ],
+        "list": ["name"],
+        "search": ["name"],
+        "filter": [],
+        "ordering": ["name"],
+        "actions": {
+          "list": true,
+          "detail": true,
+          "create": true,
+          "update": true,
+          "delete": true
+        },
+        "permissions": {
+          "view": "admin.categories.view",
+          "create": "admin.categories.create",
+          "update": "admin.categories.update",
+          "delete": "admin.categories.delete"
+        }
+      }
+    ]
+  },
+  "meta": {
+    "auth": {
+      "mode": "cookie",
+      "bootstrap": "is_superuser"
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Accepts **ADR-013**: Gombit’s post-v0.1 admin is a **runtime generic admin** — an explicit feature-package registry, Huma introspection + generic data plane, and a **framework-owned** React SPA under `/admin/` — not `--admin` scaffolded pages.

Closes #33

## Acceptance criteria

GitHub AC was empty; build-plan ADMIN-0 scope is the AC:

- [x] Decide the model-registry / introspection contract (models, fields, relations, permissions a feature-package registers)
- [x] Confirm the admin is a **framework-owned React app** driven by that metadata endpoint
- [x] **Not** `--admin` scaffolded pages
- [x] Session auth (C3 / M5-3 #30) treated as a hard prerequisite

## Scope notes

- **ADMIN-1** (#34): `admin.Register`, registry, `GET /api/v1/admin/meta`, generic `/api/v1/admin/resources/{slug}` — not implemented
- **ADMIN-2** (#35): framework-owned SPA + `embed.FS` under `/admin/` — not implemented
- **ADMIN-3** (#36): groups/permissions — not implemented (`IsSuperuser` remains the bootstrap gate)
- Dual Bearer-API + cookie-admin in one process is **not** introduced (cookie vs JWT stays mutually exclusive per M5-3)
- Many-to-many relations deferred; first cut is `belongs_to` / `has_many`
- Optional later: `gombit dev` Admin URL in the service table
- No M6 batteries (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)

## Validation

- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [x] Project `code-review` skill run against this diff

## Working agreement checklist

- [ ] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — **N/A:** ADR has no runtime behavior. Optional fixture unmarshal test only; no DB matrix.
- [x] Stable features ship docs and appear in an example app — docs shipped (ADR + `docs/admin.md`). Example app **N/A until ADMIN-1** (no runtime to demonstrate).
- [ ] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests — **N/A:** no extraction.
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — **N/A:** generators/templates untouched; no golden updates.
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — **N/A:** no HTTP/runtime API change.
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public — **N/A:** no generated frontend.
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7cead8d-780d-4ee8-ae63-2a4e49ca67e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7cead8d-780d-4ee8-ae63-2a4e49ca67e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

