### PR TITLE
[ADMIN-1] Model registry + introspection endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,9 @@ jobs:
           go test -tags integration ./auth \
             -auth.postgres-dsn \
             'postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable'
+          go test -tags integration ./admin \
+            -admin.postgres-dsn \
+            'postgres://gombit:gombit@127.0.0.1:5432/gombit?sslmode=disable'
 
   database-mysql:
     name: Database (mysql)
@@ -183,6 +186,9 @@ jobs:
             'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
           go test -tags integration ./auth \
             -auth.mysql-dsn \
+            'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
+          go test -tags integration ./admin \
+            -admin.mysql-dsn \
             'gombit:gombit@tcp(127.0.0.1:3306)/gombit?parseTime=true'
 
   migrations-sqlite:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,18 @@ a generated React+TypeScript frontend, Atlas-backed migrations. Module path
 
 ## Current state
 
-This repo has completed M0–M5. It has typed
+This repo has completed M0–M5 and **ADMIN-1**. It has typed
 `config.Config`, `framework.App` lifecycle and routing, Huma contract/OpenAPI/
 TypeScript client generation, Atlas-backed migrations, a Cobra `gombit`
 command tree (`new`, `dev`, `build --embed`, `make resource`, `make command`,
 `db`, `openapi`, `client`), and a Vite + React + TypeScript minimal skeleton
 (router, generated client, React Hook Form). Bearer login (M5-2), cookie/CSRF
 (M5-3), the MUI preset (M5-4, `--ui mui`), and optional `gombit build --embed`
-(M5-5) are in. **ADMIN-0 (ADR-013) is accepted**: the admin is a
-framework-owned React app driven by a Huma introspection API, not `--admin`
-scaffolded pages. ADMIN-1+ (registry, generic SPA, groups/permissions) are
-not implemented. Other M6 batteries are not here yet.
+(M5-5) are in. **ADMIN-0 (ADR-013) is accepted** and **ADMIN-1 is in**:
+`admin.Register`, `GET /api/v1/admin/meta`, and the generic
+`/api/v1/admin/resources/{slug}` data plane mount on cookie-auth apps.
+**ADMIN-2 (framework-owned SPA under `/admin/`) is not here.** ADMIN-3
+(groups/permissions) and other M6 batteries are not here yet.
 Don't assume generated apps are committed in-tree; `gombit new` writes them
 on demand. Check `git log` / `ls` before describing "how the code works."
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ Optional `go:embed` production is documented in [`docs/build.md`](docs/build.md)
 Bearer JWT login is documented in [`docs/auth.md`](docs/auth.md); cookie/session
 auth (`--auth cookie`) and its CSRF threat model are documented in
 [`docs/auth-cookie.md`](docs/auth-cookie.md).
-The post-v0.1 admin architecture is [ADR-013](docs/adr/013-runtime-generic-admin.md);
-see [`docs/admin.md`](docs/admin.md).
+The admin registry and introspection API (ADMIN-1) are documented in
+[`docs/admin.md`](docs/admin.md) ([ADR-013](docs/adr/013-runtime-generic-admin.md)).
+The framework-owned admin SPA (ADMIN-2) is not here yet.
 Database runtime support is documented in [`docs/database.md`](docs/database.md).
 Cache runtime support is documented in [`docs/cache.md`](docs/cache.md).
 Runtime logging is documented in [`docs/logging.md`](docs/logging.md).

--- a/admin/convert.go
+++ b/admin/convert.go
@@ -95,6 +95,9 @@ func asInt64(raw any) (int64, error) {
 	case int64:
 		return v, nil
 	case uint:
+		if uint64(v) > math.MaxInt64 {
+			return 0, fmt.Errorf("must be an integer")
+		}
 		return int64(v), nil
 	case uint8:
 		return int64(v), nil

--- a/admin/convert.go
+++ b/admin/convert.go
@@ -1,0 +1,249 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func coerceValue(raw any, ft FieldType) (any, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	switch ft {
+	case TypeString, TypeText, TypeUUID:
+		s, err := asString(raw)
+		if err != nil {
+			return nil, err
+		}
+		if ft == TypeUUID && !validUUID(s) {
+			return nil, fmt.Errorf("must be a UUID")
+		}
+		return s, nil
+	case TypeInteger:
+		return asInt64(raw)
+	case TypeFloat, TypeDecimal:
+		return asFloat64(raw)
+	case TypeBoolean:
+		return asBool(raw)
+	case TypeDateTime:
+		return asDateTime(raw)
+	case TypeDate:
+		return asDate(raw)
+	case TypeJSON:
+		return raw, nil
+	case TypeRelation:
+		// belongs_to stores the FK as integer or string, whichever the
+		// payload used. The setter converts to the Go field type.
+		if s, err := asString(raw); err == nil {
+			if n, nerr := strconv.ParseInt(s, 10, 64); nerr == nil {
+				return n, nil
+			}
+			return s, nil
+		}
+		return asInt64(raw)
+	default:
+		return nil, fmt.Errorf("unsupported field type %q", ft)
+	}
+}
+
+func coerceFilter(raw string, ft FieldType) (any, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	return coerceValue(raw, ft)
+}
+
+func coercePathID(id string, ft FieldType) (any, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, fmt.Errorf("missing id")
+	}
+	if ft == "" {
+		ft = TypeString
+	}
+	return coerceValue(id, ft)
+}
+
+func asString(raw any) (string, error) {
+	switch v := raw.(type) {
+	case string:
+		return v, nil
+	case json.Number:
+		return v.String(), nil
+	case fmt.Stringer:
+		return v.String(), nil
+	default:
+		return "", fmt.Errorf("must be a string")
+	}
+}
+
+func asInt64(raw any) (int64, error) {
+	switch v := raw.(type) {
+	case int:
+		return int64(v), nil
+	case int8:
+		return int64(v), nil
+	case int16:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case uint:
+		return int64(v), nil
+	case uint8:
+		return int64(v), nil
+	case uint16:
+		return int64(v), nil
+	case uint32:
+		return int64(v), nil
+	case uint64:
+		if v > math.MaxInt64 {
+			return 0, fmt.Errorf("must be an integer")
+		}
+		return int64(v), nil
+	case float32:
+		if float32(int64(v)) != v {
+			return 0, fmt.Errorf("must be an integer")
+		}
+		return int64(v), nil
+	case float64:
+		if v != math.Trunc(v) {
+			return 0, fmt.Errorf("must be an integer")
+		}
+		return int64(v), nil
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return 0, fmt.Errorf("must be an integer")
+		}
+		return n, nil
+	case string:
+		n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("must be an integer")
+		}
+		return n, nil
+	default:
+		return 0, fmt.Errorf("must be an integer")
+	}
+}
+
+func asFloat64(raw any) (float64, error) {
+	switch v := raw.(type) {
+	case float64:
+		return v, nil
+	case float32:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case json.Number:
+		n, err := v.Float64()
+		if err != nil {
+			return 0, fmt.Errorf("must be a number")
+		}
+		return n, nil
+	case string:
+		n, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		if err != nil {
+			return 0, fmt.Errorf("must be a number")
+		}
+		return n, nil
+	default:
+		if n, err := asInt64(raw); err == nil {
+			return float64(n), nil
+		}
+		return 0, fmt.Errorf("must be a number")
+	}
+}
+
+func asBool(raw any) (bool, error) {
+	switch v := raw.(type) {
+	case bool:
+		return v, nil
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "true", "1", "yes":
+			return true, nil
+		case "false", "0", "no":
+			return false, nil
+		default:
+			return false, fmt.Errorf("must be a boolean")
+		}
+	default:
+		return false, fmt.Errorf("must be a boolean")
+	}
+}
+
+func asDateTime(raw any) (time.Time, error) {
+	switch v := raw.(type) {
+	case time.Time:
+		return v, nil
+	case string:
+		s := strings.TrimSpace(v)
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			if t, err := time.Parse(layout, s); err == nil {
+				return t, nil
+			}
+		}
+		return time.Time{}, fmt.Errorf("must be an RFC3339 datetime")
+	default:
+		return time.Time{}, fmt.Errorf("must be an RFC3339 datetime")
+	}
+}
+
+func asDate(raw any) (time.Time, error) {
+	switch v := raw.(type) {
+	case time.Time:
+		return time.Date(v.Year(), v.Month(), v.Day(), 0, 0, 0, 0, time.UTC), nil
+	case string:
+		s := strings.TrimSpace(v)
+		if t, err := time.Parse("2006-01-02", s); err == nil {
+			return t, nil
+		}
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC), nil
+		}
+		return time.Time{}, fmt.Errorf("must be a date (YYYY-MM-DD)")
+	default:
+		return time.Time{}, fmt.Errorf("must be a date (YYYY-MM-DD)")
+	}
+}
+
+func validUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i := 0; i < 36; i++ {
+		c := s[i]
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return false
+			}
+		default:
+			if !isHex(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isHex(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}

--- a/admin/doc.go
+++ b/admin/doc.go
@@ -1,0 +1,16 @@
+// Package admin is Gombit's runtime generic admin (ADMIN-1 / ADR-013).
+//
+// Feature packages register models explicitly:
+//
+//	admin.Register(app, Product{}, admin.Options{Slug: "products", ...})
+//
+// framework.New mounts the Huma introspection and data-plane routes only when
+// cookie session auth is on (cfg.Auth.Mode == cookie). JWT-only apps do not
+// get admin routes. Until ADMIN-3, every admin request also requires
+// auth.User.IsSuperuser.
+//
+// Options is the source of truth. After Register returns, handlers read
+// stored values and GORM constructors — they do not reflect over arbitrary
+// Go types. FieldsFrom and the empty-Fields default may use reflect only
+// inside Register; both are registration-time conveniences.
+package admin

--- a/admin/errors.go
+++ b/admin/errors.go
@@ -1,0 +1,30 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/danielgtaylor/huma/v2"
+)
+
+func errMissingSlug() error {
+	return fmt.Errorf("admin: missing slug")
+}
+
+func errDuplicateSlug(slug string) error {
+	return fmt.Errorf("admin: duplicate slug %q", slug)
+}
+
+func errInvalidSlug(slug string) error {
+	return fmt.Errorf("admin: invalid slug %q", slug)
+}
+
+func writeEnvelope(ctx huma.Context, env *contract.ErrorEnvelope) {
+	if env == nil {
+		return
+	}
+	ctx.SetHeader("Content-Type", "application/json")
+	ctx.SetStatus(env.GetStatus())
+	_ = json.NewEncoder(ctx.BodyWriter()).Encode(env)
+}

--- a/admin/fields.go
+++ b/admin/fields.go
@@ -1,0 +1,359 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+// FieldsFrom derives a default []Field from model at registration time.
+// It may use reflect on this one type. Do not call it from request handlers.
+//
+// Name comes from the json tag when present, otherwise the GORM column /
+// snake_case of the exported field name. Type is inferred from the Go type.
+// Primary keys are readonly. GORM created_at / updated_at are included when
+// present on the struct.
+func FieldsFrom(model any) ([]Field, error) {
+	sch, err := parseSchema(model)
+	if err != nil {
+		return nil, err
+	}
+	fields := make([]Field, 0, len(sch.Fields))
+	for _, sf := range sch.Fields {
+		if sf == nil || !sf.StructField.IsExported() {
+			continue
+		}
+		if sf.DBName == "" {
+			continue
+		}
+		if sf.StructField.Type == reflect.TypeOf(gorm.DeletedAt{}) {
+			continue
+		}
+		name := jsonFieldName(sf)
+		if name == "" || name == "-" {
+			continue
+		}
+		ft := inferFieldType(sf)
+		readOnly := sf.PrimaryKey || sf.AutoIncrement || sf.AutoCreateTime > 0 || sf.AutoUpdateTime > 0
+		required := sf.NotNull && !readOnly && !sf.HasDefaultValue && sf.FieldType.Kind() != reflect.Pointer
+		fields = append(fields, Field{
+			Name:     name,
+			Type:     ft,
+			Required: required,
+			ReadOnly: readOnly,
+			Column:   sf.DBName,
+		})
+	}
+	return fields, nil
+}
+
+func parseSchema(model any) (*schema.Schema, error) {
+	if model == nil {
+		return nil, fmt.Errorf("admin: nil model")
+	}
+	rv := reflect.ValueOf(model)
+	if rv.Kind() != reflect.Pointer {
+		ptr := reflect.New(rv.Type())
+		ptr.Elem().Set(rv)
+		model = ptr.Interface()
+	} else if rv.IsNil() {
+		model = reflect.New(rv.Type().Elem()).Interface()
+	}
+	sch, err := schema.Parse(model, &sync.Map{}, schema.NamingStrategy{})
+	if err != nil {
+		return nil, fmt.Errorf("admin: parse schema: %w", err)
+	}
+	return sch, nil
+}
+
+func jsonFieldName(sf *schema.Field) string {
+	tag := sf.StructField.Tag.Get("json")
+	if tag != "" {
+		name, _, _ := strings.Cut(tag, ",")
+		name = strings.TrimSpace(name)
+		if name != "" {
+			return name
+		}
+	}
+	if sf.DBName != "" {
+		return sf.DBName
+	}
+	return toSnake(sf.Name)
+}
+
+func inferFieldType(sf *schema.Field) FieldType {
+	t := sf.FieldType
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	switch t {
+	case reflect.TypeOf(time.Time{}):
+		return TypeDateTime
+	case reflect.TypeOf(json.RawMessage{}):
+		return TypeJSON
+	}
+	switch t.Kind() {
+	case reflect.String:
+		if strings.Contains(strings.ToLower(string(sf.DataType)), "text") {
+			return TypeText
+		}
+		return TypeString
+	case reflect.Bool:
+		return TypeBoolean
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return TypeInteger
+	case reflect.Float32, reflect.Float64:
+		return TypeFloat
+	case reflect.Struct, reflect.Map, reflect.Slice, reflect.Array:
+		return TypeJSON
+	default:
+		return TypeString
+	}
+}
+
+func derivePK(sch *schema.Schema) (name, column string, ft FieldType, err error) {
+	for _, sf := range sch.PrimaryFields {
+		if sf == nil {
+			continue
+		}
+		return jsonFieldName(sf), sf.DBName, inferFieldType(sf), nil
+	}
+	for _, sf := range sch.Fields {
+		if sf != nil && sf.PrimaryKey {
+			return jsonFieldName(sf), sf.DBName, inferFieldType(sf), nil
+		}
+	}
+	return "", "", "", fmt.Errorf("admin: model has no primary key")
+}
+
+func matchSchemaField(sch *schema.Schema, f Field) *schema.Field {
+	for _, sf := range sch.Fields {
+		if sf == nil {
+			continue
+		}
+		if f.Column != "" && sf.DBName == f.Column {
+			return sf
+		}
+		if jsonFieldName(sf) == f.Name || sf.DBName == f.Name || sf.Name == f.Name {
+			return sf
+		}
+	}
+	return nil
+}
+
+func implicitTimestampColumns(sch *schema.Schema) map[string]string {
+	out := map[string]string{}
+	for _, sf := range sch.Fields {
+		if sf == nil {
+			continue
+		}
+		switch {
+		case sf.AutoCreateTime > 0 || sf.DBName == ImplicitCreatedAt:
+			out[ImplicitCreatedAt] = sf.DBName
+		case sf.AutoUpdateTime > 0 || sf.DBName == ImplicitUpdatedAt:
+			out[ImplicitUpdatedAt] = sf.DBName
+		}
+	}
+	return out
+}
+
+func makeGetter(index []int, ft FieldType) func(any) any {
+	return func(inst any) any {
+		rv := reflect.ValueOf(inst)
+		if rv.Kind() == reflect.Pointer {
+			if rv.IsNil() {
+				return nil
+			}
+			rv = rv.Elem()
+		}
+		field := rv.FieldByIndex(index)
+		if !field.IsValid() {
+			return nil
+		}
+		if field.Kind() == reflect.Pointer {
+			if field.IsNil() {
+				return nil
+			}
+			field = field.Elem()
+		}
+		val := field.Interface()
+		if ft == TypeDate {
+			if t, ok := val.(time.Time); ok {
+				return t.Format("2006-01-02")
+			}
+		}
+		return val
+	}
+}
+
+func makeSetter(index []int, ft FieldType, destType reflect.Type) func(any, any) error {
+	return func(inst any, raw any) error {
+		coerced, err := coerceValue(raw, ft)
+		if err != nil {
+			return err
+		}
+		if coerced == nil {
+			return nil
+		}
+		rv := reflect.ValueOf(inst)
+		if rv.Kind() == reflect.Pointer {
+			rv = rv.Elem()
+		}
+		field := rv.FieldByIndex(index)
+		if !field.CanSet() {
+			return fmt.Errorf("field is not settable")
+		}
+		assigned, err := convertTo(coerced, destType)
+		if err != nil {
+			return err
+		}
+		field.Set(assigned)
+		return nil
+	}
+}
+
+func convertTo(val any, dest reflect.Type) (reflect.Value, error) {
+	if dest.Kind() == reflect.Pointer {
+		inner, err := convertTo(val, dest.Elem())
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		ptr := reflect.New(dest.Elem())
+		ptr.Elem().Set(inner)
+		return ptr, nil
+	}
+	src := reflect.ValueOf(val)
+	if !src.IsValid() {
+		return reflect.Zero(dest), nil
+	}
+	if src.Type().AssignableTo(dest) {
+		return src, nil
+	}
+	if src.Type().ConvertibleTo(dest) {
+		return src.Convert(dest), nil
+	}
+	if dest.Kind() == reflect.String {
+		return reflect.ValueOf(fmt.Sprint(val)).Convert(dest), nil
+	}
+	return reflect.Value{}, fmt.Errorf("cannot assign %T to %s", val, dest)
+}
+
+func makeNewInstance(elem reflect.Type) func() any {
+	return func() any {
+		return reflect.New(elem).Interface()
+	}
+}
+
+func makeNewSlice(elem reflect.Type) func() any {
+	sliceType := reflect.SliceOf(elem)
+	return func() any {
+		return reflect.New(sliceType).Interface()
+	}
+}
+
+func makeForEach(elem reflect.Type) func(any, func(any)) {
+	return func(slicePtr any, fn func(any)) {
+		rv := reflect.ValueOf(slicePtr)
+		if rv.Kind() == reflect.Pointer {
+			rv = rv.Elem()
+		}
+		for i := 0; i < rv.Len(); i++ {
+			item := rv.Index(i)
+			if item.Kind() == reflect.Pointer {
+				fn(item.Interface())
+				continue
+			}
+			fn(item.Addr().Interface())
+		}
+	}
+}
+
+func elemTypeOf(model any) (reflect.Type, error) {
+	if model == nil {
+		return nil, fmt.Errorf("admin: nil model")
+	}
+	t := reflect.TypeOf(model)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("admin: model must be a struct")
+	}
+	return t, nil
+}
+
+func toSnake(name string) string {
+	if name == "" {
+		return ""
+	}
+	var b strings.Builder
+	runes := []rune(name)
+	for i, r := range runes {
+		if unicode.IsUpper(r) {
+			if i > 0 && (unicode.IsLower(runes[i-1]) || (i+1 < len(runes) && unicode.IsLower(runes[i+1]))) {
+				b.WriteByte('_')
+			}
+			b.WriteRune(unicode.ToLower(r))
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func titleFromSlug(slug string) string {
+	parts := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == '_'
+	})
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, "")
+}
+
+func validIdent(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if i == 0 {
+			if r != '_' && !unicode.IsLetter(r) {
+				return false
+			}
+			continue
+		}
+		if r != '_' && !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func validSlug(slug string) bool {
+	if slug == "" {
+		return false
+	}
+	for i, r := range slug {
+		if i == 0 {
+			if r < 'a' || r > 'z' {
+				return false
+			}
+			continue
+		}
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' && r != '-' {
+			return false
+		}
+	}
+	return true
+}

--- a/admin/fields.go
+++ b/admin/fields.go
@@ -149,17 +149,27 @@ func matchSchemaField(sch *schema.Schema, f Field) *schema.Field {
 	return nil
 }
 
-func implicitTimestampColumns(sch *schema.Schema) map[string]string {
-	out := map[string]string{}
+func implicitTimestampColumns(sch *schema.Schema) map[string]implicitColumn {
+	out := map[string]implicitColumn{}
 	for _, sf := range sch.Fields {
 		if sf == nil {
 			continue
 		}
+		var name string
 		switch {
 		case sf.AutoCreateTime > 0 || sf.DBName == ImplicitCreatedAt:
-			out[ImplicitCreatedAt] = sf.DBName
+			name = ImplicitCreatedAt
 		case sf.AutoUpdateTime > 0 || sf.DBName == ImplicitUpdatedAt:
-			out[ImplicitUpdatedAt] = sf.DBName
+			name = ImplicitUpdatedAt
+		default:
+			continue
+		}
+		if sf.DBName == "" {
+			continue
+		}
+		out[name] = implicitColumn{
+			column: sf.DBName,
+			get:    makeGetter(sf.StructField.Index, TypeDateTime),
 		}
 	}
 	return out

--- a/admin/helpers_test.go
+++ b/admin/helpers_test.go
@@ -1,0 +1,263 @@
+package admin_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/admin"
+	"github.com/LAA-Software-Engineering/gombit/auth"
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/LAA-Software-Engineering/gombit/database"
+	"github.com/LAA-Software-Engineering/gombit/framework"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	testJWTSecret = "admin-test-jwt-secret-32-bytes-ok"
+	testPassword  = "correct-horse"
+)
+
+type cookieJar struct {
+	cookies map[string]*http.Cookie
+}
+
+func newCookieJar() *cookieJar {
+	return &cookieJar{cookies: map[string]*http.Cookie{}}
+}
+
+func (j *cookieJar) update(rec *httptest.ResponseRecorder) {
+	for _, c := range rec.Result().Cookies() {
+		j.cookies[c.Name] = c
+	}
+}
+
+func (j *cookieJar) attach(req *http.Request) {
+	for _, c := range j.cookies {
+		req.AddCookie(&http.Cookie{Name: c.Name, Value: c.Value}) //nolint:gosec // G124: request Cookie header only carries name/value.
+	}
+}
+
+func (j *cookieJar) value(name string) string {
+	if c, ok := j.cookies[name]; ok {
+		return c.Value
+	}
+	return ""
+}
+
+type Widget struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	Name      string    `json:"name"`
+	SKU       string    `json:"sku"`
+	Price     int       `json:"price"`
+	Note      string    `json:"note"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func widgetOptions(overrides ...func(*admin.Options)) admin.Options {
+	opts := admin.Options{
+		Slug:     "widgets",
+		Singular: "Widget",
+		Plural:   "Widgets",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "name", Type: admin.TypeString, Required: true},
+			{Name: "sku", Type: admin.TypeString},
+			{Name: "price", Type: admin.TypeInteger},
+			{Name: "note", Type: admin.TypeText},
+		},
+		List:     []string{"name", "sku", "price"},
+		Search:   []string{"name", "sku"},
+		Filter:   []string{"sku"},
+		Ordering: []string{"name", "price", "created_at"},
+		Actions: admin.Actions{
+			List: true, Detail: true, Create: true, Update: true, Delete: true,
+		},
+	}
+	for _, fn := range overrides {
+		fn(&opts)
+	}
+	return opts
+}
+
+func openSQLite(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := database.Open(config.DatabaseConfig{
+		Driver: config.DatabaseDriverSQLite,
+		DSN:    "file:" + filepath.Join(t.TempDir(), "admin.db") + "?cache=shared&_fk=1",
+	})
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func newCookieApp(t *testing.T) *framework.App {
+	t.Helper()
+	return newCookieAppWithDB(t, openSQLite(t))
+}
+
+func newCookieAppWithDB(t *testing.T, db *database.DB) *framework.App {
+	t.Helper()
+	if err := auth.Migrate(db.DB); err != nil {
+		t.Fatalf("auth.Migrate() error = %v", err)
+	}
+	if err := db.AutoMigrate(&Widget{}); err != nil {
+		t.Fatalf("AutoMigrate(Widget) error = %v", err)
+	}
+	cfg := config.DefaultFor(config.EnvironmentTest)
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.Auth.JWTSecret = testJWTSecret
+	cfg.Auth.BcryptCost = bcrypt.MinCost
+	cfg.Auth.AccessTokenTTL = time.Minute
+	cfg.Auth.RefreshTokenTTL = time.Hour
+	cfg.Auth.Mode = config.AuthModeCookie
+	app, err := framework.New(
+		framework.WithConfig(cfg),
+		framework.WithDatabase(db),
+		framework.WithLogger(zap.NewNop()),
+	)
+	if err != nil {
+		t.Fatalf("framework.New() error = %v", err)
+	}
+	return app
+}
+
+func newJWTApp(t *testing.T) *framework.App {
+	t.Helper()
+	db := openSQLite(t)
+	if err := auth.Migrate(db.DB); err != nil {
+		t.Fatalf("auth.Migrate() error = %v", err)
+	}
+	cfg := config.DefaultFor(config.EnvironmentTest)
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.Auth.JWTSecret = testJWTSecret
+	cfg.Auth.BcryptCost = bcrypt.MinCost
+	cfg.Auth.AccessTokenTTL = time.Minute
+	cfg.Auth.RefreshTokenTTL = time.Hour
+	app, err := framework.New(
+		framework.WithConfig(cfg),
+		framework.WithDatabase(db),
+		framework.WithLogger(zap.NewNop()),
+	)
+	if err != nil {
+		t.Fatalf("framework.New() error = %v", err)
+	}
+	return app
+}
+
+func apiPrefix(app *framework.App) string {
+	prefix := strings.TrimSuffix(app.Config().API.Prefix, "/")
+	if prefix == "" {
+		return "/api/v1"
+	}
+	return prefix
+}
+
+func doRequest(app *framework.App, jar *cookieJar, method, path, body string) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	var req *http.Request
+	if body != "" {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	if jar != nil {
+		jar.attach(req)
+		if csrf := jar.value(auth.CSRFCookieName); csrf != "" {
+			req.Header.Set(auth.CSRFHeaderName, csrf)
+		}
+	}
+	app.Router().ServeHTTP(rec, req)
+	if jar != nil {
+		jar.update(rec)
+	}
+	return rec
+}
+
+func fetchCSRF(t *testing.T, app *framework.App) *cookieJar {
+	t.Helper()
+	jar := newCookieJar()
+	rec := doRequest(app, jar, http.MethodGet, apiPrefix(app)+"/auth/csrf", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /auth/csrf status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	return jar
+}
+
+func loginSuperuser(t *testing.T, app *framework.App) *cookieJar {
+	t.Helper()
+	svc, err := auth.NewService(app.DB(), app.Config())
+	if err != nil {
+		t.Fatalf("auth.NewService: %v", err)
+	}
+	email := "admin-" + strings.ReplaceAll(t.Name(), "/", "-") + "@example.com"
+	if _, err := svc.CreateSuperuser(context.Background(), email, testPassword); err != nil {
+		t.Fatalf("CreateSuperuser: %v", err)
+	}
+	jar := fetchCSRF(t, app)
+	body, err := json.Marshal(map[string]string{"email": email, "password": testPassword})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rec := doRequest(app, jar, http.MethodPost, apiPrefix(app)+"/auth/login", string(body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("login status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	return jar
+}
+
+func loginUser(t *testing.T, app *framework.App, email, password string) *cookieJar {
+	t.Helper()
+	jar := fetchCSRF(t, app)
+	body, err := json.Marshal(map[string]string{"email": email, "password": password})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rec := doRequest(app, jar, http.MethodPost, apiPrefix(app)+"/auth/register", string(body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("register status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	rec = doRequest(app, jar, http.MethodPost, apiPrefix(app)+"/auth/login", string(body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("login status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	return jar
+}
+
+func decodeError(t *testing.T, rec *httptest.ResponseRecorder) contract.ErrorBody {
+	t.Helper()
+	var env contract.ErrorEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v; body: %s", err, rec.Body.String())
+	}
+	return env.Body
+}
+
+func assertError(t *testing.T, rec *httptest.ResponseRecorder, status int, code string) {
+	t.Helper()
+	if rec.Code != status {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, status, rec.Body.String())
+	}
+	got := decodeError(t, rec)
+	if got.Code != code {
+		t.Fatalf("error.code = %q, want %q; body: %s", got.Code, code, rec.Body.String())
+	}
+}
+
+func registerWidgets(t *testing.T, app *framework.App, overrides ...func(*admin.Options)) {
+	t.Helper()
+	if err := admin.Register(app, Widget{}, widgetOptions(overrides...)); err != nil {
+		t.Fatalf("admin.Register: %v", err)
+	}
+}

--- a/admin/helpers_test.go
+++ b/admin/helpers_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	testJWTSecret = "admin-test-jwt-secret-32-bytes-ok"
+	testJWTSecret = "admin-test-jwt-secret-32-bytes-ok" // #nosec G101 -- fake test secret.
 	testPassword  = "correct-horse"
 )
 

--- a/admin/integration_test.go
+++ b/admin/integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package admin_test
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/auth"
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	postgresDSN = flag.String("admin.postgres-dsn", "", "PostgreSQL DSN for admin integration tests")
+	mysqlDSN    = flag.String("admin.mysql-dsn", "", "MySQL DSN for admin integration tests")
+)
+
+func TestResourcePostgres(t *testing.T) {
+	if *postgresDSN == "" {
+		t.Skip("set -admin.postgres-dsn to run Postgres admin integration tests")
+	}
+	runResourceDriver(t, config.DatabaseDriverPostgres, *postgresDSN)
+}
+
+func TestResourceMySQL(t *testing.T) {
+	if *mysqlDSN == "" {
+		t.Skip("set -admin.mysql-dsn to run MySQL admin integration tests")
+	}
+	runResourceDriver(t, config.DatabaseDriverMySQL, *mysqlDSN)
+}
+
+func runResourceDriver(t *testing.T, driver config.DatabaseDriver, dsn string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db := openAdminDriver(t, driver, dsn)
+	app := newCookieAppWithDB(t, db)
+	registerWidgets(t, app)
+	jar := loginSuperuser(t, app)
+
+	create := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/widgets", `{"name":"Bolt","sku":"b-1","price":5}`)
+	if create.Code != http.StatusOK {
+		t.Fatalf("create status = %d; body: %s", create.Code, create.Body.String())
+	}
+	var created rowEnvelope
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	id := fmt.Sprint(asInt(created.Data["id"]))
+
+	list := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets?search=Bolt&ordering=name", "")
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status = %d; body: %s", list.Code, list.Body.String())
+	}
+	del := doRequest(app, jar, http.MethodDelete, "/api/v1/admin/resources/widgets/"+id, "")
+	if del.Code != http.StatusOK {
+		t.Fatalf("delete status = %d; body: %s", del.Code, del.Body.String())
+	}
+}
+
+func openAdminDriver(t *testing.T, driver config.DatabaseDriver, dsn string) *database.DB {
+	t.Helper()
+	db, err := database.Open(config.DatabaseConfig{Driver: driver, DSN: dsn})
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Migrator().DropTable(&Widget{})
+		_ = db.Migrator().DropTable(auth.Models()...)
+		_ = db.Close()
+	})
+	return db
+}

--- a/admin/meta.go
+++ b/admin/meta.go
@@ -1,0 +1,121 @@
+package admin
+
+import (
+	"context"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+)
+
+// Catalog is the GET /admin/meta success data object.
+type Catalog struct {
+	Models []ModelMeta `json:"models"`
+}
+
+// CatalogAux is optional envelope meta on the catalog.
+type CatalogAux struct {
+	Auth *AuthMeta `json:"auth,omitempty"`
+}
+
+// AuthMeta tells the SPA which bootstrap rule is in force until ADMIN-3.
+type AuthMeta struct {
+	Mode      string `json:"mode"`
+	Bootstrap string `json:"bootstrap"`
+}
+
+// ModelMeta is one registered model in the introspection API.
+type ModelMeta struct {
+	Slug        string      `json:"slug"`
+	Singular    string      `json:"singular"`
+	Plural      string      `json:"plural"`
+	PK          string      `json:"pk"`
+	Fields      []FieldMeta `json:"fields"`
+	List        []string    `json:"list"`
+	Search      []string    `json:"search"`
+	Filter      []string    `json:"filter"`
+	Ordering    []string    `json:"ordering"`
+	Actions     Actions     `json:"actions"`
+	Permissions Permissions `json:"permissions"`
+}
+
+// FieldMeta is the introspection shape of a field (no Column).
+type FieldMeta struct {
+	Name     string    `json:"name"`
+	Type     FieldType `json:"type"`
+	Required bool      `json:"required"`
+	ReadOnly bool      `json:"readonly"`
+	Related  *Relation `json:"related,omitempty"`
+}
+
+type catalogOutput struct {
+	Body contract.DataMeta[Catalog, CatalogAux]
+}
+
+type modelOutput struct {
+	Body contract.Data[ModelMeta]
+}
+
+type slugInput struct {
+	Slug string `path:"slug" doc:"Registered model slug"`
+}
+
+func modelMetaFrom(opts Options, pk string) ModelMeta {
+	fields := make([]FieldMeta, 0, len(opts.Fields))
+	for _, f := range opts.Fields {
+		var rel *Relation
+		if f.Related != nil {
+			copyRel := *f.Related
+			rel = &copyRel
+		}
+		fields = append(fields, FieldMeta{
+			Name:     f.Name,
+			Type:     f.Type,
+			Required: f.Required,
+			ReadOnly: f.ReadOnly || (f.Type == TypeRelation && f.Related != nil && f.Related.Kind == RelHasMany),
+			Related:  rel,
+		})
+	}
+	return ModelMeta{
+		Slug:        opts.Slug,
+		Singular:    opts.Singular,
+		Plural:      opts.Plural,
+		PK:          pk,
+		Fields:      fields,
+		List:        cloneStrings(opts.List),
+		Search:      cloneStrings(opts.Search),
+		Filter:      cloneStrings(opts.Filter),
+		Ordering:    cloneStrings(opts.Ordering),
+		Actions:     opts.Actions,
+		Permissions: opts.Permissions,
+	}
+}
+
+func cloneStrings(in []string) []string {
+	if in == nil {
+		return []string{}
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+func (h *handlers) listMeta(ctx context.Context, _ *struct{}) (*catalogOutput, error) {
+	models := h.reg.all()
+	catalog := Catalog{Models: make([]ModelMeta, 0, len(models))}
+	for _, m := range models {
+		catalog.Models = append(catalog.Models, m.meta)
+	}
+	return &catalogOutput{
+		Body: contract.DataMeta[Catalog, CatalogAux]{
+			Data: catalog,
+			Meta: &CatalogAux{Auth: &AuthMeta{Mode: "cookie", Bootstrap: "is_superuser"}},
+		},
+	}, nil
+}
+
+func (h *handlers) getMeta(ctx context.Context, input *slugInput) (*modelOutput, error) {
+	m, ok := h.reg.get(input.Slug)
+	if !ok {
+		return nil, contract.WithContext(ctx, contract.NotFound("unknown model"))
+	}
+	return &modelOutput{Body: contract.Data[ModelMeta]{Data: m.meta}}, nil
+}

--- a/admin/meta_test.go
+++ b/admin/meta_test.go
@@ -1,0 +1,232 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"time"
+
+	"github.com/LAA-Software-Engineering/gombit/admin"
+	"github.com/LAA-Software-Engineering/gombit/auth"
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/framework"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type catalogEnvelope struct {
+	Data struct {
+		Models []admin.ModelMeta `json:"models"`
+	} `json:"data"`
+	Meta *admin.CatalogAux `json:"meta"`
+}
+
+type modelEnvelope struct {
+	Data admin.ModelMeta `json:"data"`
+}
+
+func TestMetaEmptyCatalog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	jar := loginSuperuser(t, app)
+
+	rec := doRequest(app, jar, http.MethodGet, "/api/v1/admin/meta", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var env catalogEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v; body: %s", err, rec.Body.String())
+	}
+	if env.Data.Models == nil {
+		t.Fatal("data.models is nil, want empty array")
+	}
+	if len(env.Data.Models) != 0 {
+		t.Fatalf("data.models len = %d, want 0", len(env.Data.Models))
+	}
+	if env.Meta == nil || env.Meta.Auth == nil {
+		t.Fatal("meta.auth is nil")
+	}
+	if env.Meta.Auth.Mode != "cookie" || env.Meta.Auth.Bootstrap != "is_superuser" {
+		t.Fatalf("meta.auth = %+v", env.Meta.Auth)
+	}
+}
+
+func TestMetaListsRegisteredModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	jar := loginSuperuser(t, app)
+
+	rec := doRequest(app, jar, http.MethodGet, "/api/v1/admin/meta", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var env catalogEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v; body: %s", err, rec.Body.String())
+	}
+	if len(env.Data.Models) != 1 {
+		t.Fatalf("data.models len = %d, want 1; body: %s", len(env.Data.Models), rec.Body.String())
+	}
+	got := env.Data.Models[0]
+	if got.Slug != "widgets" || got.PK != "id" {
+		t.Fatalf("model = %+v, want slug=widgets pk=id", got)
+	}
+	if len(got.Fields) == 0 {
+		t.Fatal("fields is empty")
+	}
+	if got.Permissions.View != "admin.widgets.view" {
+		t.Fatalf("permissions.view = %q", got.Permissions.View)
+	}
+	if !got.Actions.List || !got.Actions.Create {
+		t.Fatalf("actions = %+v", got.Actions)
+	}
+
+	one := doRequest(app, jar, http.MethodGet, "/api/v1/admin/meta/widgets", "")
+	if one.Code != http.StatusOK {
+		t.Fatalf("GET meta/widgets status = %d; body: %s", one.Code, one.Body.String())
+	}
+	var single modelEnvelope
+	if err := json.Unmarshal(one.Body.Bytes(), &single); err != nil {
+		t.Fatalf("decode one: %v", err)
+	}
+	if single.Data.Slug != "widgets" {
+		t.Fatalf("slug = %q", single.Data.Slug)
+	}
+}
+
+func TestMetaRelationHasManyIsReadOnly(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Category struct {
+		ID   uint   `gorm:"primaryKey" json:"id"`
+		Name string `json:"name"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&Category{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	if err := admin.Register(app, Category{}, admin.Options{
+		Slug: "categories",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "name", Type: admin.TypeString, Required: true},
+			{
+				Name: "widgets",
+				Type: admin.TypeRelation,
+				Related: &admin.Relation{
+					Slug:       "widgets",
+					Kind:       admin.RelHasMany,
+					LabelField: "name",
+				},
+			},
+		},
+		List: []string{"name"},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	jar := loginSuperuser(t, app)
+	rec := doRequest(app, jar, http.MethodGet, "/api/v1/admin/meta/categories", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var env modelEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var rel *admin.FieldMeta
+	for i := range env.Data.Fields {
+		if env.Data.Fields[i].Name == "widgets" {
+			rel = &env.Data.Fields[i]
+			break
+		}
+	}
+	if rel == nil || rel.Related == nil || rel.Related.Kind != admin.RelHasMany {
+		t.Fatalf("widgets relation = %+v", rel)
+	}
+	if !rel.ReadOnly {
+		t.Fatal("has_many field should be readonly in meta")
+	}
+}
+
+func TestMetaUnknownSlugNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	jar := loginSuperuser(t, app)
+	rec := doRequest(app, jar, http.MethodGet, "/api/v1/admin/meta/missing", "")
+	assertError(t, rec, http.StatusNotFound, "not_found")
+}
+
+func TestMetaAnonymousUnauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	rec := doRequest(app, nil, http.MethodGet, "/api/v1/admin/meta", "")
+	assertError(t, rec, http.StatusUnauthorized, "authentication")
+}
+
+func TestMetaNonSuperuserForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	jar := loginUser(t, app, "user@example.com", testPassword)
+	rec := doRequest(app, jar, http.MethodGet, "/api/v1/admin/meta", "")
+	assertError(t, rec, http.StatusForbidden, "authorization")
+}
+
+func TestMetaHonorsAPIPrefix(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := openSQLite(t)
+	if err := auth.Migrate(db.DB); err != nil {
+		t.Fatalf("auth.Migrate: %v", err)
+	}
+	if err := db.AutoMigrate(&Widget{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	cfg := config.DefaultFor(config.EnvironmentTest)
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.Auth.JWTSecret = testJWTSecret
+	cfg.Auth.BcryptCost = bcrypt.MinCost
+	cfg.Auth.AccessTokenTTL = time.Minute
+	cfg.Auth.RefreshTokenTTL = time.Hour
+	cfg.Auth.Mode = config.AuthModeCookie
+	cfg.API.Prefix = "/svc/v2"
+	app, err := framework.New(
+		framework.WithConfig(cfg),
+		framework.WithDatabase(db),
+		framework.WithLogger(zap.NewNop()),
+	)
+	if err != nil {
+		t.Fatalf("framework.New: %v", err)
+	}
+	registerWidgets(t, app)
+	jar := loginSuperuser(t, app)
+	rec := doRequest(app, jar, http.MethodGet, "/svc/v2/admin/meta", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdminRoutesAppearInOpenAPI(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	rec := doRequest(app, nil, http.MethodGet, "/openapi.json", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("openapi status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, path := range []string{
+		"/api/v1/admin/meta",
+		"/api/v1/admin/meta/{slug}",
+		"/api/v1/admin/resources/{slug}",
+		"/api/v1/admin/resources/{slug}/{id}",
+	} {
+		if !strings.Contains(body, path) {
+			t.Fatalf("openapi.json missing %s", path)
+		}
+	}
+}

--- a/admin/mount.go
+++ b/admin/mount.go
@@ -17,7 +17,7 @@ const cookieSecurityName = "cookieAuth"
 type queryValuesKey struct{}
 
 type handlers struct {
-	reg  *Registry
+	reg  *registry
 	host Host
 }
 
@@ -50,7 +50,7 @@ func Mount(host Host) error {
 	return nil
 }
 
-func mountRoutes(host Host, reg *Registry, svc *auth.Service) {
+func mountRoutes(host Host, reg *registry, svc *auth.Service) {
 	prefix := strings.TrimSuffix(host.Config().API.Prefix, "/")
 	if prefix == "" {
 		prefix = "/api/v1"

--- a/admin/mount.go
+++ b/admin/mount.go
@@ -1,0 +1,155 @@
+package admin
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/LAA-Software-Engineering/gombit/auth"
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/danielgtaylor/huma/v2"
+)
+
+const cookieSecurityName = "cookieAuth"
+
+type queryValuesKey struct{}
+
+type handlers struct {
+	reg  *Registry
+	host Host
+}
+
+// Mount registers the admin Huma routes on host.API() when cookie auth is on.
+// The catalog is empty until Register is called. framework.New calls Mount
+// automatically in cookie mode; JWT-only apps must not call it.
+func Mount(host Host) error {
+	if host == nil {
+		return errors.New("admin: nil host")
+	}
+	if host.API() == nil {
+		return errors.New("admin: nil API")
+	}
+	cfg := host.Config()
+	if !cfg.Auth.Enabled() || cfg.Auth.EffectiveMode() != config.AuthModeCookie {
+		return nil
+	}
+	if host.DB() == nil {
+		return errors.New("admin: nil database")
+	}
+	svc, err := auth.NewService(host.DB(), cfg)
+	if err != nil {
+		return err
+	}
+	reg := newRegistry()
+	if !storeRegistry(host.API(), reg) {
+		return errors.New("admin: already mounted")
+	}
+	mountRoutes(host, reg, svc)
+	return nil
+}
+
+func mountRoutes(host Host, reg *Registry, svc *auth.Service) {
+	prefix := strings.TrimSuffix(host.Config().API.Prefix, "/")
+	if prefix == "" {
+		prefix = "/api/v1"
+	}
+	h := &handlers{reg: reg, host: host}
+	gates := huma.Middlewares{svc.RequireCookieSession(), requireSuperuser, attachQuery}
+	security := []map[string][]string{{cookieSecurityName: {}}}
+	tags := []string{"Admin"}
+
+	huma.Register(host.API(), huma.Operation{
+		OperationID: "admin-meta-list",
+		Method:      http.MethodGet,
+		Path:        prefix + "/admin/meta",
+		Summary:     "List registered admin models",
+		Tags:        tags,
+		Security:    security,
+		Middlewares: gates,
+	}, h.listMeta)
+
+	huma.Register(host.API(), huma.Operation{
+		OperationID: "admin-meta-get",
+		Method:      http.MethodGet,
+		Path:        prefix + "/admin/meta/{slug}",
+		Summary:     "Get one registered admin model",
+		Tags:        tags,
+		Security:    security,
+		Middlewares: gates,
+	}, h.getMeta)
+
+	huma.Register(host.API(), huma.Operation{
+		OperationID: "admin-resource-list",
+		Method:      http.MethodGet,
+		Path:        prefix + "/admin/resources/{slug}",
+		Summary:     "List admin resources",
+		Tags:        tags,
+		Security:    security,
+		Middlewares: gates,
+	}, h.listResources)
+
+	huma.Register(host.API(), huma.Operation{
+		OperationID: "admin-resource-create",
+		Method:      http.MethodPost,
+		Path:        prefix + "/admin/resources/{slug}",
+		Summary:     "Create an admin resource",
+		Tags:        tags,
+		Security:    security,
+		Middlewares: gates,
+	}, h.createResource)
+
+	huma.Register(host.API(), huma.Operation{
+		OperationID: "admin-resource-get",
+		Method:      http.MethodGet,
+		Path:        prefix + "/admin/resources/{slug}/{id}",
+		Summary:     "Get an admin resource",
+		Tags:        tags,
+		Security:    security,
+		Middlewares: gates,
+	}, h.getResource)
+
+	huma.Register(host.API(), huma.Operation{
+		OperationID: "admin-resource-update",
+		Method:      http.MethodPatch,
+		Path:        prefix + "/admin/resources/{slug}/{id}",
+		Summary:     "Update an admin resource",
+		Tags:        tags,
+		Security:    security,
+		Middlewares: gates,
+	}, h.updateResource)
+
+	huma.Register(host.API(), huma.Operation{
+		OperationID: "admin-resource-delete",
+		Method:      http.MethodDelete,
+		Path:        prefix + "/admin/resources/{slug}/{id}",
+		Summary:     "Delete an admin resource",
+		Tags:        tags,
+		Security:    security,
+		Middlewares: gates,
+	}, h.deleteResource)
+}
+
+func requireSuperuser(ctx huma.Context, next func(huma.Context)) {
+	user, ok := auth.UserFromContext(ctx.Context())
+	if !ok {
+		writeEnvelope(ctx, contract.WithContext(ctx.Context(), contract.Authentication("missing session cookie")))
+		return
+	}
+	if !user.IsSuperuser {
+		writeEnvelope(ctx, contract.WithContext(ctx.Context(), contract.Authorization("admin requires a superuser")))
+		return
+	}
+	next(ctx)
+}
+
+func attachQuery(ctx huma.Context, next func(huma.Context)) {
+	u := ctx.URL()
+	next(huma.WithValue(ctx, queryValuesKey{}, u.Query()))
+}
+
+func queryValues(ctx interface{ Value(any) any }) url.Values {
+	v, _ := ctx.Value(queryValuesKey{}).(url.Values)
+	return v
+}

--- a/admin/options.go
+++ b/admin/options.go
@@ -1,0 +1,128 @@
+package admin
+
+// Closed field-type set for v1 (ADR-013). ADMIN-1 may add members with a
+// docs bump; do not invent a parallel type system.
+const (
+	TypeString   FieldType = "string"
+	TypeText     FieldType = "text"
+	TypeInteger  FieldType = "integer"
+	TypeFloat    FieldType = "float"
+	TypeDecimal  FieldType = "decimal"
+	TypeBoolean  FieldType = "boolean"
+	TypeDateTime FieldType = "datetime"
+	TypeDate     FieldType = "date"
+	TypeUUID     FieldType = "uuid"
+	TypeJSON     FieldType = "json"
+	TypeRelation FieldType = "relation"
+)
+
+// Relation kinds for v1. Many-to-many is deferred.
+const (
+	RelBelongsTo = "belongs_to"
+	RelHasMany   = "has_many"
+)
+
+// Implicit timestamp names allowed in List and Ordering even when omitted
+// from Fields. They are GORM's default created_at / updated_at columns.
+const (
+	ImplicitCreatedAt = "created_at"
+	ImplicitUpdatedAt = "updated_at"
+)
+
+// FieldType is a closed admin field type string.
+type FieldType string
+
+// Options is the source of truth for one registered admin model.
+type Options struct {
+	// Slug is the URL key (products). Required, lowercase, unique per app.
+	Slug string
+	// Singular and Plural are UI labels. Empty values are derived at Register
+	// from the Go type name and slug.
+	Singular string
+	Plural   string
+	// PK is the JSON/field name of the primary key. Empty means derive the
+	// GORM primary key at Register and store it.
+	PK string
+	// Fields is the concrete field list handlers read. Empty means derive a
+	// default from the struct once, inside Register (see FieldsFrom).
+	Fields []Field
+	// List is the list-view column order.
+	List []string
+	// Search is the list of field names the search query param applies to.
+	Search []string
+	// Filter is the list of field names that may appear as list query keys.
+	Filter []string
+	// Ordering is the list of field names the ordering query param may use.
+	// created_at and updated_at may appear here even if omitted from Fields.
+	Ordering []string
+	// Actions enables list / detail / create / update / delete. The zero
+	// value (all false) defaults to all enabled.
+	Actions Actions
+	// Permissions are string keys echoed in meta for ADMIN-3. ADMIN-1 does
+	// not enforce them. Empty values default to admin.{slug}.{action}.
+	Permissions Permissions
+}
+
+// Field describes one registered admin field.
+//
+// Name is the JSON object key used in meta and in data-plane row payloads.
+// For v1, Name is also the GORM/SQL column unless Column is set (when the
+// Go exported name or GORM column differs from the JSON key).
+type Field struct {
+	Name     string    `json:"name"`
+	Type     FieldType `json:"type"`
+	Required bool      `json:"required"`
+	ReadOnly bool      `json:"readonly"`
+	Related  *Relation `json:"related,omitempty"`
+	// Column is the GORM/SQL column name. Empty means Name == JSON key ==
+	// column (the v1 default). Not emitted in meta.
+	Column string `json:"-"`
+}
+
+// Relation describes a belongs_to or has_many field. belongs_to is stored as
+// the foreign key on create/update. has_many is meta-only in ADMIN-1: the
+// data plane does not nest related collections.
+type Relation struct {
+	Slug       string `json:"slug"`
+	Kind       string `json:"kind"`
+	LabelField string `json:"label_field"`
+}
+
+// Actions names which data-plane operations are enabled for a model.
+type Actions struct {
+	List   bool `json:"list"`
+	Detail bool `json:"detail"`
+	Create bool `json:"create"`
+	Update bool `json:"update"`
+	Delete bool `json:"delete"`
+}
+
+// Permissions holds ADMIN-3 permission keys. ADMIN-1 stores and echoes them.
+type Permissions struct {
+	View   string `json:"view"`
+	Create string `json:"create"`
+	Update string `json:"update"`
+	Delete string `json:"delete"`
+}
+
+func (a Actions) zero() bool {
+	return !a.List && !a.Detail && !a.Create && !a.Update && !a.Delete
+}
+
+func defaultActions() Actions {
+	return Actions{List: true, Detail: true, Create: true, Update: true, Delete: true}
+}
+
+func validFieldType(t FieldType) bool {
+	switch t {
+	case TypeString, TypeText, TypeInteger, TypeFloat, TypeDecimal,
+		TypeBoolean, TypeDateTime, TypeDate, TypeUUID, TypeJSON, TypeRelation:
+		return true
+	default:
+		return false
+	}
+}
+
+func implicitTimestamp(name string) bool {
+	return name == ImplicitCreatedAt || name == ImplicitUpdatedAt
+}

--- a/admin/register.go
+++ b/admin/register.go
@@ -102,6 +102,9 @@ func registerModel(host Host, model any, opts Options) error {
 	if err != nil {
 		return err
 	}
+	if err := validateQueryableColumns(opts, resolved); err != nil {
+		return err
+	}
 
 	m := &registered{
 		meta:        modelMetaFrom(opts, pkName),
@@ -152,7 +155,7 @@ func fieldByName(fields []Field, name string) *Field {
 	return nil
 }
 
-func validateFieldRefs(opts Options, implicit map[string]string) error {
+func validateFieldRefs(opts Options, implicit map[string]implicitColumn) error {
 	known := map[string]bool{}
 	for _, f := range opts.Fields {
 		if f.Name == "" || !validIdent(f.Name) {
@@ -202,6 +205,39 @@ func validateFieldRefs(opts Options, implicit map[string]string) error {
 		return err
 	}
 	if err := check("ordering", opts.Ordering, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateQueryableColumns(opts Options, resolved []resolvedField) error {
+	byName := make(map[string]*resolvedField, len(resolved))
+	for i := range resolved {
+		byName[resolved[i].Name] = &resolved[i]
+	}
+	check := func(kind string, names []string) error {
+		for _, name := range names {
+			f, ok := byName[name]
+			if !ok {
+				continue
+			}
+			if f.column != "" {
+				continue
+			}
+			if f.Type == TypeRelation && f.Related != nil && f.Related.Kind == RelHasMany {
+				return fmt.Errorf("admin: %s %q is has_many and has no SQL column", kind, name)
+			}
+			return fmt.Errorf("admin: %s %q has no SQL column", kind, name)
+		}
+		return nil
+	}
+	if err := check("search", opts.Search); err != nil {
+		return err
+	}
+	if err := check("filter", opts.Filter); err != nil {
+		return err
+	}
+	if err := check("ordering", opts.Ordering); err != nil {
 		return err
 	}
 	return nil

--- a/admin/register.go
+++ b/admin/register.go
@@ -1,0 +1,251 @@
+package admin
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"gorm.io/gorm/schema"
+)
+
+// Register adds model T to the host's admin registry.
+//
+// host is typically *framework.App. Missing or duplicate Slug is an error.
+// Cookie auth must already be on (framework.New mounts the empty admin
+// routes in that mode). After Register returns, the registry holds concrete
+// Options values plus constructors for T; request handlers do not walk
+// arbitrary Go types.
+func Register[T any](host Host, model T, opts Options) error {
+	return registerModel(host, model, opts)
+}
+
+func registerModel(host Host, model any, opts Options) error {
+	if host == nil {
+		return fmt.Errorf("admin: nil host")
+	}
+	cfg := host.Config()
+	if !cfg.Auth.Enabled() || cfg.Auth.EffectiveMode() != config.AuthModeCookie {
+		return fmt.Errorf("admin: Register requires cookie auth (Auth.Mode=%s)", config.AuthModeCookie)
+	}
+	reg, ok := registryFor(host.API())
+	if !ok {
+		return fmt.Errorf("admin: routes are not mounted; Register requires cookie auth")
+	}
+
+	opts.Slug = strings.TrimSpace(opts.Slug)
+	if opts.Slug == "" {
+		return errMissingSlug()
+	}
+	if !validSlug(opts.Slug) {
+		return errInvalidSlug(opts.Slug)
+	}
+
+	elem, err := elemTypeOf(model)
+	if err != nil {
+		return err
+	}
+	sch, err := parseSchema(model)
+	if err != nil {
+		return err
+	}
+
+	if len(opts.Fields) == 0 {
+		derived, err := FieldsFrom(model)
+		if err != nil {
+			return err
+		}
+		opts.Fields = derived
+	}
+
+	if opts.Actions.zero() {
+		opts.Actions = defaultActions()
+	}
+	if opts.Singular == "" {
+		if name := elem.Name(); name != "" {
+			opts.Singular = name
+		} else {
+			opts.Singular = titleFromSlug(strings.TrimSuffix(opts.Slug, "s"))
+		}
+	}
+	if opts.Plural == "" {
+		if titled := titleFromSlug(opts.Slug); titled != "" {
+			opts.Plural = titled
+		} else {
+			opts.Plural = opts.Singular + "s"
+		}
+	}
+	opts.Permissions = defaultPermissions(opts.Slug, opts.Permissions)
+
+	pkName, pkColumn, pkType, err := derivePK(sch)
+	if err != nil {
+		return err
+	}
+	if opts.PK != "" {
+		pkName = opts.PK
+		if f := fieldByName(opts.Fields, opts.PK); f != nil && f.Column != "" {
+			pkColumn = f.Column
+		} else if sf := matchSchemaField(sch, Field{Name: opts.PK}); sf != nil {
+			pkColumn = sf.DBName
+			pkType = inferFieldType(sf)
+		}
+	}
+	if fieldByName(opts.Fields, pkName) == nil {
+		return fmt.Errorf("admin: pk %q is not in Fields", pkName)
+	}
+
+	implicit := implicitTimestampColumns(sch)
+	if err := validateFieldRefs(opts, implicit); err != nil {
+		return err
+	}
+
+	resolved, err := resolveFields(opts.Fields, sch)
+	if err != nil {
+		return err
+	}
+
+	m := &registered{
+		meta:        modelMetaFrom(opts, pkName),
+		actions:     opts.Actions,
+		pkColumn:    pkColumn,
+		pkType:      pkType,
+		newInstance: makeNewInstance(elem),
+		newSlice:    makeNewSlice(elem),
+		forEach:     makeForEach(elem),
+		fields:      resolved,
+		fieldByName: map[string]*resolvedField{},
+		implicit:    implicit,
+	}
+	for i := range m.fields {
+		m.fieldByName[m.fields[i].Name] = &m.fields[i]
+	}
+	if pk, ok := m.fieldByName[pkName]; ok && pk.Type != "" {
+		m.pkType = pk.Type
+		if pk.column != "" {
+			m.pkColumn = pk.column
+		}
+	}
+	return reg.add(m)
+}
+
+func defaultPermissions(slug string, p Permissions) Permissions {
+	if p.View == "" {
+		p.View = "admin." + slug + ".view"
+	}
+	if p.Create == "" {
+		p.Create = "admin." + slug + ".create"
+	}
+	if p.Update == "" {
+		p.Update = "admin." + slug + ".update"
+	}
+	if p.Delete == "" {
+		p.Delete = "admin." + slug + ".delete"
+	}
+	return p
+}
+
+func fieldByName(fields []Field, name string) *Field {
+	for i := range fields {
+		if fields[i].Name == name {
+			return &fields[i]
+		}
+	}
+	return nil
+}
+
+func validateFieldRefs(opts Options, implicit map[string]string) error {
+	known := map[string]bool{}
+	for _, f := range opts.Fields {
+		if f.Name == "" || !validIdent(f.Name) {
+			return fmt.Errorf("admin: invalid field name %q", f.Name)
+		}
+		if f.Column != "" && !validIdent(f.Column) {
+			return fmt.Errorf("admin: invalid column %q on field %q", f.Column, f.Name)
+		}
+		if !validFieldType(f.Type) {
+			return fmt.Errorf("admin: field %q has unknown type %q", f.Name, f.Type)
+		}
+		if f.Type == TypeRelation {
+			if f.Related == nil {
+				return fmt.Errorf("admin: field %q is a relation without related", f.Name)
+			}
+			if f.Related.Kind != RelBelongsTo && f.Related.Kind != RelHasMany {
+				return fmt.Errorf("admin: field %q has unknown relation kind %q", f.Name, f.Related.Kind)
+			}
+			if strings.TrimSpace(f.Related.Slug) == "" {
+				return fmt.Errorf("admin: field %q relation is missing slug", f.Name)
+			}
+		}
+		known[f.Name] = true
+	}
+	check := func(kind string, names []string, allowImplicit bool) error {
+		for _, name := range names {
+			if known[name] {
+				continue
+			}
+			if allowImplicit && implicitTimestamp(name) {
+				if _, ok := implicit[name]; !ok {
+					return fmt.Errorf("admin: %s %q is not a GORM timestamp on this model", kind, name)
+				}
+				continue
+			}
+			return fmt.Errorf("admin: %s %q is not a registered field", kind, name)
+		}
+		return nil
+	}
+	if err := check("list", opts.List, true); err != nil {
+		return err
+	}
+	if err := check("search", opts.Search, false); err != nil {
+		return err
+	}
+	if err := check("filter", opts.Filter, false); err != nil {
+		return err
+	}
+	if err := check("ordering", opts.Ordering, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resolveFields(fields []Field, sch *schema.Schema) ([]resolvedField, error) {
+	out := make([]resolvedField, 0, len(fields))
+	seen := map[string]struct{}{}
+	for _, f := range fields {
+		if _, ok := seen[f.Name]; ok {
+			return nil, fmt.Errorf("admin: duplicate field %q", f.Name)
+		}
+		seen[f.Name] = struct{}{}
+		if f.Type == TypeRelation && f.Related != nil && f.Related.Kind == RelHasMany {
+			f.ReadOnly = true
+		}
+		copyRel := f
+		if f.Related != nil {
+			rel := *f.Related
+			copyRel.Related = &rel
+		}
+		sf := matchSchemaField(sch, f)
+		if sf == nil {
+			if f.Type == TypeRelation && f.Related != nil && f.Related.Kind == RelHasMany {
+				out = append(out, resolvedField{
+					Field:  copyRel,
+					column: "",
+					get:    func(any) any { return nil },
+					set:    func(any, any) error { return fmt.Errorf("has_many is not writable") },
+				})
+				continue
+			}
+			return nil, fmt.Errorf("admin: field %q does not exist on the model", f.Name)
+		}
+		column := f.Column
+		if column == "" {
+			column = sf.DBName
+		}
+		out = append(out, resolvedField{
+			Field:  copyRel,
+			column: column,
+			get:    makeGetter(sf.StructField.Index, f.Type),
+			set:    makeSetter(sf.StructField.Index, f.Type, sf.FieldType),
+		})
+	}
+	return out, nil
+}

--- a/admin/register_test.go
+++ b/admin/register_test.go
@@ -106,10 +106,63 @@ func TestRegisterRejectsUnknownFieldType(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	app := newCookieApp(t)
 	err := admin.Register(app, Widget{}, widgetOptions(func(o *admin.Options) {
-		o.Fields = append(o.Fields, admin.Field{Name: "name", Type: "nope"})
+		o.Fields = append(o.Fields, admin.Field{Name: "mystery", Type: "nope"})
 	}))
-	if err == nil {
-		t.Fatal("Register() error = nil, want unknown type or duplicate")
+	if err == nil || !strings.Contains(err.Error(), "unknown type") {
+		t.Fatalf("Register() error = %v, want unknown type", err)
+	}
+}
+
+func TestRegisterRejectsDuplicateFieldName(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	err := admin.Register(app, Widget{}, widgetOptions(func(o *admin.Options) {
+		o.Fields = append(o.Fields, admin.Field{Name: "name", Type: admin.TypeString})
+	}))
+	if err == nil || !strings.Contains(err.Error(), "duplicate field") {
+		t.Fatalf("Register() error = %v, want duplicate field", err)
+	}
+}
+
+func TestRegisterRejectsHasManyInQueryOptions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Category struct {
+		ID   uint   `gorm:"primaryKey" json:"id"`
+		Name string `json:"name"`
+	}
+	hasMany := admin.Field{
+		Name: "widgets",
+		Type: admin.TypeRelation,
+		Related: &admin.Relation{
+			Slug:       "widgets",
+			Kind:       admin.RelHasMany,
+			LabelField: "name",
+		},
+	}
+	fields := []admin.Field{
+		{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+		{Name: "name", Type: admin.TypeString, Required: true},
+		hasMany,
+	}
+	cases := []struct {
+		kind string
+		opts admin.Options
+	}{
+		{"search", admin.Options{Slug: "categories", Fields: fields, Search: []string{"widgets"}}},
+		{"filter", admin.Options{Slug: "cat-filter", Fields: fields, Filter: []string{"widgets"}}},
+		{"ordering", admin.Options{Slug: "cat-order", Fields: fields, Ordering: []string{"widgets"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			app := newCookieApp(t)
+			if err := app.DB().AutoMigrate(&Category{}); err != nil {
+				t.Fatalf("AutoMigrate: %v", err)
+			}
+			err := admin.Register(app, Category{}, tc.opts)
+			if err == nil || !strings.Contains(err.Error(), tc.kind) || !strings.Contains(err.Error(), "has_many") {
+				t.Fatalf("Register() error = %v, want %s has_many", err, tc.kind)
+			}
+		})
 	}
 }
 

--- a/admin/register_test.go
+++ b/admin/register_test.go
@@ -1,0 +1,186 @@
+package admin_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/admin"
+	"github.com/gin-gonic/gin"
+)
+
+func TestRegisterMissingSlug(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	err := admin.Register(app, Widget{}, admin.Options{})
+	if err == nil || !strings.Contains(err.Error(), "missing slug") {
+		t.Fatalf("Register() error = %v, want missing slug", err)
+	}
+}
+
+func TestRegisterInvalidSlug(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	err := admin.Register(app, Widget{}, admin.Options{Slug: "Widgets"})
+	if err == nil || !strings.Contains(err.Error(), "invalid slug") {
+		t.Fatalf("Register() error = %v, want invalid slug", err)
+	}
+}
+
+func TestRegisterDuplicateSlug(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	if err := admin.Register(app, Widget{}, widgetOptions()); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	err := admin.Register(app, Widget{}, widgetOptions())
+	if err == nil || !strings.Contains(err.Error(), "duplicate slug") {
+		t.Fatalf("second Register() error = %v, want duplicate slug", err)
+	}
+}
+
+func TestRegisterRejectsJWTMode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newJWTApp(t)
+	err := admin.Register(app, Widget{}, widgetOptions())
+	if err == nil || !strings.Contains(err.Error(), "cookie") {
+		t.Fatalf("Register() on JWT app error = %v, want cookie-auth error", err)
+	}
+}
+
+func TestRegisterDerivesPKAndEmptyFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	if err := admin.Register(app, Widget{}, admin.Options{
+		Slug:     "widgets",
+		List:     []string{"name", "created_at"},
+		Ordering: []string{"created_at"},
+	}); err != nil {
+		t.Fatalf("Register empty Fields: %v", err)
+	}
+}
+
+func TestRegisterUnknownListField(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	err := admin.Register(app, Widget{}, widgetOptions(func(o *admin.Options) {
+		o.List = []string{"missing"}
+	}))
+	if err == nil || !strings.Contains(err.Error(), "list") {
+		t.Fatalf("Register() error = %v, want unknown list field", err)
+	}
+}
+
+func TestRegisterImplicitTimestampMissingOnModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Bare struct {
+		ID   uint   `gorm:"primaryKey" json:"id"`
+		Name string `json:"name"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&Bare{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	err := admin.Register(app, Bare{}, admin.Options{
+		Slug:     "bares",
+		Fields:   []admin.Field{{Name: "id", Type: admin.TypeInteger, ReadOnly: true}, {Name: "name", Type: admin.TypeString}},
+		Ordering: []string{"created_at"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "created_at") {
+		t.Fatalf("Register() error = %v, want missing timestamp", err)
+	}
+}
+
+func TestRegisterPKOverrideMustBeInFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	err := admin.Register(app, Widget{}, widgetOptions(func(o *admin.Options) {
+		o.PK = "missing"
+	}))
+	if err == nil || !strings.Contains(err.Error(), "pk") {
+		t.Fatalf("Register() error = %v, want pk not in Fields", err)
+	}
+}
+
+func TestRegisterRejectsUnknownFieldType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	err := admin.Register(app, Widget{}, widgetOptions(func(o *admin.Options) {
+		o.Fields = append(o.Fields, admin.Field{Name: "name", Type: "nope"})
+	}))
+	if err == nil {
+		t.Fatal("Register() error = nil, want unknown type or duplicate")
+	}
+}
+
+func TestFieldsFromUsesJSONNames(t *testing.T) {
+	fields, err := admin.FieldsFrom(Widget{})
+	if err != nil {
+		t.Fatalf("FieldsFrom: %v", err)
+	}
+	if len(fields) == 0 {
+		t.Fatal("FieldsFrom returned no fields")
+	}
+	byName := map[string]admin.Field{}
+	for _, f := range fields {
+		byName[f.Name] = f
+	}
+	id, ok := byName["id"]
+	if !ok {
+		t.Fatalf("FieldsFrom missing id; fields=%v", fields)
+	}
+	if !id.ReadOnly {
+		t.Fatal("id should be readonly")
+	}
+	if _, ok := byName["name"]; !ok {
+		t.Fatalf("FieldsFrom missing name; fields=%v", fields)
+	}
+	if _, ok := byName["created_at"]; !ok {
+		t.Fatalf("FieldsFrom missing created_at; fields=%v", fields)
+	}
+}
+
+func TestFieldsFromIsRegistrationTimeOnly(t *testing.T) {
+	// Compile-time documentation: FieldsFrom is exported for Register
+	// callers, not handlers. The handler-import test locks the other half.
+	_, err := admin.FieldsFrom(Widget{})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRegisterColumnMapping(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Mapped struct {
+		ID    uint   `gorm:"primaryKey" json:"id"`
+		Title string `gorm:"column:title_text" json:"title"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&Mapped{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	err := admin.Register(app, Mapped{}, admin.Options{
+		Slug: "mapped",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "title", Type: admin.TypeString, Column: "title_text", Required: true},
+		},
+		List: []string{"title"},
+	})
+	if err != nil {
+		t.Fatalf("Register column mapping: %v", err)
+	}
+}
+
+func TestRegisterErrorIsNotWrappedAsHTTP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	err := admin.Register(app, Widget{}, admin.Options{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var env interface{ GetStatus() int }
+	if errors.As(err, &env) {
+		t.Fatalf("Register should not return an HTTP error, got %#v", err)
+	}
+}

--- a/admin/registry.go
+++ b/admin/registry.go
@@ -16,17 +16,17 @@ type Host interface {
 	Config() config.Config
 }
 
-type Registry struct {
+type registry struct {
 	mu     sync.RWMutex
 	models []*registered
 	bySlug map[string]*registered
 }
 
-func newRegistry() *Registry {
-	return &Registry{bySlug: map[string]*registered{}}
+func newRegistry() *registry {
+	return &registry{bySlug: map[string]*registered{}}
 }
 
-func (r *Registry) add(m *registered) error {
+func (r *registry) add(m *registered) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, ok := r.bySlug[m.meta.Slug]; ok {
@@ -37,14 +37,14 @@ func (r *Registry) add(m *registered) error {
 	return nil
 }
 
-func (r *Registry) get(slug string) (*registered, bool) {
+func (r *registry) get(slug string) (*registered, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	m, ok := r.bySlug[slug]
 	return m, ok
 }
 
-func (r *Registry) all() []*registered {
+func (r *registry) all() []*registered {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	out := make([]*registered, len(r.models))
@@ -96,9 +96,9 @@ func (m *registered) toRow(inst any) map[string]any {
 	return out
 }
 
-var registries sync.Map // huma.API -> *Registry
+var registries sync.Map // huma.API -> *registry
 
-func registryFor(api huma.API) (*Registry, bool) {
+func registryFor(api huma.API) (*registry, bool) {
 	if api == nil {
 		return nil, false
 	}
@@ -106,11 +106,11 @@ func registryFor(api huma.API) (*Registry, bool) {
 	if !ok {
 		return nil, false
 	}
-	reg, ok := v.(*Registry)
+	reg, ok := v.(*registry)
 	return reg, ok
 }
 
-func storeRegistry(api huma.API, reg *Registry) bool {
+func storeRegistry(api huma.API, reg *registry) bool {
 	_, loaded := registries.LoadOrStore(api, reg)
 	return !loaded
 }

--- a/admin/registry.go
+++ b/admin/registry.go
@@ -62,7 +62,7 @@ type registered struct {
 	forEach     func(slicePtr any, fn func(any))
 	fields      []resolvedField
 	fieldByName map[string]*resolvedField
-	implicit    map[string]string // name -> column (created_at / updated_at)
+	implicit    map[string]implicitColumn // created_at / updated_at when omitted from Fields
 }
 
 type resolvedField struct {
@@ -72,6 +72,12 @@ type resolvedField struct {
 	set    func(inst any, raw any) error
 }
 
+// implicitColumn is a GORM timestamp allowed in List/Ordering without a Field.
+type implicitColumn struct {
+	column string
+	get    func(inst any) any
+}
+
 func (m *registered) field(name string) (*resolvedField, bool) {
 	f, ok := m.fieldByName[name]
 	return f, ok
@@ -79,19 +85,31 @@ func (m *registered) field(name string) (*resolvedField, bool) {
 
 func (m *registered) columnFor(name string) (string, bool) {
 	if f, ok := m.fieldByName[name]; ok {
+		if f.column == "" {
+			return "", false
+		}
 		return f.column, true
 	}
-	if col, ok := m.implicit[name]; ok {
-		return col, true
+	if col, ok := m.implicit[name]; ok && col.column != "" {
+		return col.column, true
 	}
 	return "", false
 }
 
 func (m *registered) toRow(inst any) map[string]any {
-	out := make(map[string]any, len(m.fields))
+	out := make(map[string]any, len(m.fields)+len(m.implicit))
 	for i := range m.fields {
 		f := &m.fields[i]
 		out[f.Name] = f.get(inst)
+	}
+	for name, col := range m.implicit {
+		if _, exists := out[name]; exists {
+			continue
+		}
+		if col.get == nil {
+			continue
+		}
+		out[name] = col.get(inst)
 	}
 	return out
 }

--- a/admin/registry.go
+++ b/admin/registry.go
@@ -1,0 +1,116 @@
+package admin
+
+import (
+	"sync"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/danielgtaylor/huma/v2"
+	"gorm.io/gorm"
+)
+
+// Host is satisfied by *framework.App. It is defined here so this package
+// does not import framework (framework.New calls Mount).
+type Host interface {
+	API() huma.API
+	DB() *gorm.DB
+	Config() config.Config
+}
+
+type Registry struct {
+	mu     sync.RWMutex
+	models []*registered
+	bySlug map[string]*registered
+}
+
+func newRegistry() *Registry {
+	return &Registry{bySlug: map[string]*registered{}}
+}
+
+func (r *Registry) add(m *registered) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.bySlug[m.meta.Slug]; ok {
+		return errDuplicateSlug(m.meta.Slug)
+	}
+	r.models = append(r.models, m)
+	r.bySlug[m.meta.Slug] = m
+	return nil
+}
+
+func (r *Registry) get(slug string) (*registered, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	m, ok := r.bySlug[slug]
+	return m, ok
+}
+
+func (r *Registry) all() []*registered {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*registered, len(r.models))
+	copy(out, r.models)
+	return out
+}
+
+type registered struct {
+	meta        ModelMeta
+	actions     Actions
+	pkColumn    string
+	pkType      FieldType
+	newInstance func() any
+	newSlice    func() any
+	forEach     func(slicePtr any, fn func(any))
+	fields      []resolvedField
+	fieldByName map[string]*resolvedField
+	implicit    map[string]string // name -> column (created_at / updated_at)
+}
+
+type resolvedField struct {
+	Field
+	column string
+	get    func(inst any) any
+	set    func(inst any, raw any) error
+}
+
+func (m *registered) field(name string) (*resolvedField, bool) {
+	f, ok := m.fieldByName[name]
+	return f, ok
+}
+
+func (m *registered) columnFor(name string) (string, bool) {
+	if f, ok := m.fieldByName[name]; ok {
+		return f.column, true
+	}
+	if col, ok := m.implicit[name]; ok {
+		return col, true
+	}
+	return "", false
+}
+
+func (m *registered) toRow(inst any) map[string]any {
+	out := make(map[string]any, len(m.fields))
+	for i := range m.fields {
+		f := &m.fields[i]
+		out[f.Name] = f.get(inst)
+	}
+	return out
+}
+
+var registries sync.Map // huma.API -> *Registry
+
+func registryFor(api huma.API) (*Registry, bool) {
+	if api == nil {
+		return nil, false
+	}
+	v, ok := registries.Load(api)
+	if !ok {
+		return nil, false
+	}
+	reg, ok := v.(*Registry)
+	return reg, ok
+}
+
+func storeRegistry(api huma.API, reg *Registry) bool {
+	_, loaded := registries.LoadOrStore(api, reg)
+	return !loaded
+}

--- a/admin/resources.go
+++ b/admin/resources.go
@@ -308,7 +308,7 @@ func applyFilters(ctx context.Context, q *gorm.DB, m *registered, values interfa
 			continue
 		}
 		f, ok := m.field(name)
-		if !ok {
+		if !ok || f.column == "" {
 			continue
 		}
 		val, err := coerceFilter(raw, f.Type)

--- a/admin/resources.go
+++ b/admin/resources.go
@@ -1,0 +1,364 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	defaultPage    = 1
+	defaultPerPage = 20
+	maxPerPage     = 100
+)
+
+type listInput struct {
+	Slug     string `path:"slug" doc:"Registered model slug"`
+	Page     int    `query:"page" doc:"1-based page"`
+	PerPage  int    `query:"per_page" doc:"Page size"`
+	Search   string `query:"search" doc:"Search term applied to Options.Search"`
+	Ordering string `query:"ordering" doc:"Field from Options.Ordering; prefix with - for DESC"`
+}
+
+type writeInput struct {
+	Slug string         `path:"slug" doc:"Registered model slug"`
+	Body map[string]any `doc:"Writable field values keyed by registered field names"`
+}
+
+type itemInput struct {
+	Slug string `path:"slug" doc:"Registered model slug"`
+	ID   string `path:"id" doc:"Primary key value"`
+}
+
+type patchInput struct {
+	Slug string         `path:"slug" doc:"Registered model slug"`
+	ID   string         `path:"id" doc:"Primary key value"`
+	Body map[string]any `doc:"Writable field values keyed by registered field names"`
+}
+
+type rowOutput struct {
+	Body contract.Data[map[string]any]
+}
+
+type listOutput struct {
+	Body contract.DataMeta[[]map[string]any, contract.PageMeta]
+}
+
+type deleteResult struct {
+	OK bool `json:"ok" example:"true"`
+}
+
+type deleteOutput struct {
+	Body contract.Data[deleteResult]
+}
+
+func (h *handlers) listResources(ctx context.Context, input *listInput) (*listOutput, error) {
+	m, err := h.modelForAction(ctx, input.Slug, func(a Actions) bool { return a.List })
+	if err != nil {
+		return nil, err
+	}
+	db, err := h.db()
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("admin database is not attached"))
+	}
+
+	page := input.Page
+	if page < 1 {
+		page = defaultPage
+	}
+	perPage := input.PerPage
+	if perPage < 1 {
+		perPage = defaultPerPage
+	}
+	if perPage > maxPerPage {
+		perPage = maxPerPage
+	}
+
+	q := db.WithContext(ctx).Model(m.newInstance())
+	q, err = applySearch(q, m, input.Search)
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.Validation("The request contains invalid fields.", map[string][]string{
+			"search": {err.Error()},
+		}))
+	}
+	q, err = applyFilters(ctx, q, m, queryValues(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	var total int64
+	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("count resources"))
+	}
+
+	q, err = applyOrdering(q, m, input.Ordering)
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.Validation("The request contains invalid fields.", map[string][]string{
+			"ordering": {err.Error()},
+		}))
+	}
+
+	slice := m.newSlice()
+	if err := q.Offset((page - 1) * perPage).Limit(perPage).Find(slice).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("list resources"))
+	}
+
+	rows := make([]map[string]any, 0)
+	m.forEach(slice, func(item any) {
+		rows = append(rows, m.toRow(item))
+	})
+	return &listOutput{
+		Body: contract.DataMeta[[]map[string]any, contract.PageMeta]{
+			Data: rows,
+			Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
+		},
+	}, nil
+}
+
+func (h *handlers) createResource(ctx context.Context, input *writeInput) (*rowOutput, error) {
+	m, err := h.modelForAction(ctx, input.Slug, func(a Actions) bool { return a.Create })
+	if err != nil {
+		return nil, err
+	}
+	db, err := h.db()
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("admin database is not attached"))
+	}
+	inst := m.newInstance()
+	if err := applyWrite(ctx, m, inst, input.Body, true); err != nil {
+		return nil, err
+	}
+	if err := db.WithContext(ctx).Create(inst).Error; err != nil {
+		return nil, mapDBError(ctx, err)
+	}
+	return &rowOutput{Body: contract.Data[map[string]any]{Data: m.toRow(inst)}}, nil
+}
+
+func (h *handlers) getResource(ctx context.Context, input *itemInput) (*rowOutput, error) {
+	m, err := h.modelForAction(ctx, input.Slug, func(a Actions) bool { return a.Detail })
+	if err != nil {
+		return nil, err
+	}
+	inst, err := h.loadByID(ctx, m, input.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &rowOutput{Body: contract.Data[map[string]any]{Data: m.toRow(inst)}}, nil
+}
+
+func (h *handlers) updateResource(ctx context.Context, input *patchInput) (*rowOutput, error) {
+	m, err := h.modelForAction(ctx, input.Slug, func(a Actions) bool { return a.Update })
+	if err != nil {
+		return nil, err
+	}
+	inst, err := h.loadByID(ctx, m, input.ID)
+	if err != nil {
+		return nil, err
+	}
+	if err := applyWrite(ctx, m, inst, input.Body, false); err != nil {
+		return nil, err
+	}
+	db, err := h.db()
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("admin database is not attached"))
+	}
+	if err := db.WithContext(ctx).Save(inst).Error; err != nil {
+		return nil, mapDBError(ctx, err)
+	}
+	return &rowOutput{Body: contract.Data[map[string]any]{Data: m.toRow(inst)}}, nil
+}
+
+func (h *handlers) deleteResource(ctx context.Context, input *itemInput) (*deleteOutput, error) {
+	m, err := h.modelForAction(ctx, input.Slug, func(a Actions) bool { return a.Delete })
+	if err != nil {
+		return nil, err
+	}
+	inst, err := h.loadByID(ctx, m, input.ID)
+	if err != nil {
+		return nil, err
+	}
+	db, err := h.db()
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("admin database is not attached"))
+	}
+	if err := db.WithContext(ctx).Delete(inst).Error; err != nil {
+		return nil, mapDBError(ctx, err)
+	}
+	return &deleteOutput{Body: contract.Data[deleteResult]{Data: deleteResult{OK: true}}}, nil
+}
+
+func (h *handlers) modelForAction(ctx context.Context, slug string, enabled func(Actions) bool) (*registered, error) {
+	m, ok := h.reg.get(slug)
+	if !ok {
+		return nil, contract.WithContext(ctx, contract.NotFound("unknown model"))
+	}
+	if !enabled(m.actions) {
+		return nil, contract.WithContext(ctx, contract.Authorization("action disabled"))
+	}
+	return m, nil
+}
+
+func (h *handlers) loadByID(ctx context.Context, m *registered, id string) (any, error) {
+	db, err := h.db()
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("admin database is not attached"))
+	}
+	pk, err := coercePathID(id, m.pkType)
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.NotFound("unknown resource"))
+	}
+	inst := m.newInstance()
+	err = db.WithContext(ctx).Where(clause.Eq{Column: clause.Column{Name: m.pkColumn}, Value: pk}).First(inst).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, contract.WithContext(ctx, contract.NotFound("unknown resource"))
+	}
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("load resource"))
+	}
+	return inst, nil
+}
+
+func (h *handlers) db() (*gorm.DB, error) {
+	if h.host == nil || h.host.DB() == nil {
+		return nil, errors.New("admin: nil database")
+	}
+	return h.host.DB(), nil
+}
+
+func applyWrite(ctx context.Context, m *registered, inst any, body map[string]any, creating bool) error {
+	if body == nil {
+		body = map[string]any{}
+	}
+	fields := map[string][]string{}
+	seen := map[string]struct{}{}
+	for name, raw := range body {
+		f, ok := m.field(name)
+		if !ok {
+			fields[name] = []string{"unknown field"}
+			continue
+		}
+		if f.ReadOnly || (f.Type == TypeRelation && f.Related != nil && f.Related.Kind == RelHasMany) {
+			fields[name] = []string{"field is read-only"}
+			continue
+		}
+		if err := f.set(inst, raw); err != nil {
+			fields[name] = []string{err.Error()}
+			continue
+		}
+		seen[name] = struct{}{}
+	}
+	if creating {
+		for i := range m.fields {
+			f := &m.fields[i]
+			if !f.Required || f.ReadOnly {
+				continue
+			}
+			if _, ok := seen[f.Name]; !ok {
+				fields[f.Name] = []string{"is required"}
+			}
+		}
+	}
+	if len(fields) > 0 {
+		return contract.WithContext(ctx, contract.Validation("The request contains invalid fields.", fields))
+	}
+	return nil
+}
+
+func applySearch(q *gorm.DB, m *registered, term string) (*gorm.DB, error) {
+	term = strings.TrimSpace(term)
+	if term == "" {
+		return q, nil
+	}
+	if len(m.meta.Search) == 0 {
+		return q, nil
+	}
+	pattern := "%" + escapeLike(term) + "%"
+	ors := make([]clause.Expression, 0, len(m.meta.Search))
+	for _, name := range m.meta.Search {
+		col, ok := m.columnFor(name)
+		if !ok {
+			continue
+		}
+		ors = append(ors, clause.Expr{
+			SQL:  quoteIdent(q, col) + " LIKE ? ESCAPE ?",
+			Vars: []any{pattern, `\`},
+		})
+	}
+	if len(ors) == 0 {
+		return q, nil
+	}
+	return q.Where(clause.Or(ors...)), nil
+}
+
+func applyFilters(ctx context.Context, q *gorm.DB, m *registered, values interface{ Get(string) string }) (*gorm.DB, error) {
+	if values == nil {
+		return q, nil
+	}
+	for _, name := range m.meta.Filter {
+		raw := strings.TrimSpace(values.Get(name))
+		if raw == "" {
+			continue
+		}
+		f, ok := m.field(name)
+		if !ok {
+			continue
+		}
+		val, err := coerceFilter(raw, f.Type)
+		if err != nil {
+			return nil, contract.WithContext(ctx, contract.Validation("The request contains invalid fields.", map[string][]string{
+				name: {err.Error()},
+			}))
+		}
+		q = q.Where(clause.Eq{Column: clause.Column{Name: f.column}, Value: val})
+	}
+	return q, nil
+}
+
+func applyOrdering(q *gorm.DB, m *registered, ordering string) (*gorm.DB, error) {
+	ordering = strings.TrimSpace(ordering)
+	if ordering == "" {
+		return q, nil
+	}
+	desc := false
+	name := ordering
+	if strings.HasPrefix(name, "-") {
+		desc = true
+		name = strings.TrimPrefix(name, "-")
+	}
+	allowed := false
+	for _, n := range m.meta.Ordering {
+		if n == name {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return nil, errors.New("ordering is not allowed for this field")
+	}
+	col, ok := m.columnFor(name)
+	if !ok {
+		return nil, errors.New("ordering is not allowed for this field")
+	}
+	return q.Order(clause.OrderByColumn{Column: clause.Column{Name: col}, Desc: desc}), nil
+}
+
+func quoteIdent(db *gorm.DB, name string) string {
+	var b strings.Builder
+	db.Dialector.QuoteTo(&b, name)
+	return b.String()
+}
+
+func mapDBError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "unique") || strings.Contains(msg, "duplicate") {
+		return contract.WithContext(ctx, contract.Conflict("resource already exists"))
+	}
+	return contract.WithContext(ctx, contract.Internal("persist resource"))
+}

--- a/admin/resources.go
+++ b/admin/resources.go
@@ -245,6 +245,10 @@ func applyWrite(ctx context.Context, m *registered, inst any, body map[string]an
 			fields[name] = []string{"field is read-only"}
 			continue
 		}
+		if raw == nil && f.Required {
+			fields[name] = []string{"is required"}
+			continue
+		}
 		if err := f.set(inst, raw); err != nil {
 			fields[name] = []string{err.Error()}
 			continue
@@ -348,7 +352,7 @@ func applyOrdering(q *gorm.DB, m *registered, ordering string) (*gorm.DB, error)
 
 func quoteIdent(db *gorm.DB, name string) string {
 	var b strings.Builder
-	db.Dialector.QuoteTo(&b, name)
+	db.QuoteTo(&b, name)
 	return b.String()
 }
 

--- a/admin/resources_test.go
+++ b/admin/resources_test.go
@@ -6,6 +6,7 @@ import (
 	"go/parser"
 	"go/token"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -228,6 +229,63 @@ func TestResourceListPaginationSearchOrderFilter(t *testing.T) {
 	assertError(t, badOrder, http.StatusUnprocessableEntity, contract.CodeValidationError)
 }
 
+func TestResourceListIncludesImplicitCreatedAt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app, func(o *admin.Options) {
+		o.List = []string{"name", "created_at"}
+	})
+	jar := loginSuperuser(t, app)
+
+	create := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/widgets", `{"name":"Dated"}`)
+	if create.Code != http.StatusOK {
+		t.Fatalf("create status = %d; body: %s", create.Code, create.Body.String())
+	}
+	var created rowEnvelope
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	assertCreatedAtPresent(t, created.Data)
+
+	list := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets", "")
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status = %d; body: %s", list.Code, list.Body.String())
+	}
+	var listed listEnvelope
+	if err := json.Unmarshal(list.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listed.Data) != 1 {
+		t.Fatalf("list len = %d, want 1; body: %s", len(listed.Data), list.Body.String())
+	}
+	assertCreatedAtPresent(t, listed.Data[0])
+
+	id := fmt.Sprint(asInt(created.Data["id"]))
+	detail := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets/"+id, "")
+	if detail.Code != http.StatusOK {
+		t.Fatalf("detail status = %d; body: %s", detail.Code, detail.Body.String())
+	}
+	var got rowEnvelope
+	if err := json.Unmarshal(detail.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	assertCreatedAtPresent(t, got.Data)
+}
+
+func TestResourceCreateWithoutCSRFForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	jar := loginSuperuser(t, app)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/resources/widgets", strings.NewReader(`{"name":"X"}`))
+	req.Header.Set("Content-Type", "application/json")
+	jar.attach(req)
+	app.Router().ServeHTTP(rec, req)
+	assertError(t, rec, http.StatusForbidden, "authorization")
+}
+
 func TestResourceBelongsToStoresFK(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	type Category struct {
@@ -335,5 +393,17 @@ func asInt(v any) int64 {
 		return n
 	default:
 		return 0
+	}
+}
+
+func assertCreatedAtPresent(t *testing.T, row map[string]any) {
+	t.Helper()
+	v, ok := row["created_at"]
+	if !ok || v == nil {
+		t.Fatalf("row missing created_at: %#v", row)
+	}
+	s := fmt.Sprint(v)
+	if s == "" || strings.HasPrefix(s, "0001-01-01") {
+		t.Fatalf("created_at is empty/zero: %#v", v)
 	}
 }

--- a/admin/resources_test.go
+++ b/admin/resources_test.go
@@ -228,6 +228,51 @@ func TestResourceListPaginationSearchOrderFilter(t *testing.T) {
 	assertError(t, badOrder, http.StatusUnprocessableEntity, contract.CodeValidationError)
 }
 
+func TestResourceBelongsToStoresFK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Category struct {
+		ID   uint   `gorm:"primaryKey" json:"id"`
+		Name string `json:"name"`
+	}
+	type Item struct {
+		ID         uint   `gorm:"primaryKey" json:"id"`
+		Name       string `json:"name"`
+		CategoryID uint   `json:"category_id"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&Category{}, &Item{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	if err := admin.Register(app, Item{}, admin.Options{
+		Slug: "items",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "name", Type: admin.TypeString, Required: true},
+			{
+				Name:    "category_id",
+				Type:    admin.TypeRelation,
+				Related: &admin.Relation{Slug: "categories", Kind: admin.RelBelongsTo, LabelField: "name"},
+			},
+		},
+		List:   []string{"name", "category_id"},
+		Filter: []string{"category_id"},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	jar := loginSuperuser(t, app)
+	rec := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/items", `{"name":"Nail","category_id":7}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var created rowEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if asInt(created.Data["category_id"]) != 7 {
+		t.Fatalf("category_id = %#v, want 7", created.Data["category_id"])
+	}
+}
+
 func TestJWTModeDoesNotMountAdmin(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	app := newJWTApp(t)

--- a/admin/resources_test.go
+++ b/admin/resources_test.go
@@ -1,0 +1,294 @@
+package admin_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/LAA-Software-Engineering/gombit/admin"
+	"github.com/LAA-Software-Engineering/gombit/contract"
+	"github.com/gin-gonic/gin"
+)
+
+type rowEnvelope struct {
+	Data map[string]any `json:"data"`
+}
+
+type listEnvelope struct {
+	Data []map[string]any   `json:"data"`
+	Meta *contract.PageMeta `json:"meta"`
+}
+
+func TestResourceCRUDAndAuthz(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	jar := loginSuperuser(t, app)
+
+	create := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/widgets", `{"name":"Alpha","sku":"a-1","price":10}`)
+	if create.Code != http.StatusOK {
+		t.Fatalf("create status = %d; body: %s", create.Code, create.Body.String())
+	}
+	var created rowEnvelope
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created.Data["name"] != "Alpha" {
+		t.Fatalf("created name = %#v", created.Data["name"])
+	}
+	id := fmt.Sprint(asInt(created.Data["id"]))
+
+	got := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets/"+id, "")
+	if got.Code != http.StatusOK {
+		t.Fatalf("detail status = %d; body: %s", got.Code, got.Body.String())
+	}
+
+	patch := doRequest(app, jar, http.MethodPatch, "/api/v1/admin/resources/widgets/"+id, `{"note":"updated"}`)
+	if patch.Code != http.StatusOK {
+		t.Fatalf("patch status = %d; body: %s", patch.Code, patch.Body.String())
+	}
+	var updated rowEnvelope
+	if err := json.Unmarshal(patch.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("decode patch: %v", err)
+	}
+	if updated.Data["note"] != "updated" {
+		t.Fatalf("note = %#v", updated.Data["note"])
+	}
+
+	list := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets", "")
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status = %d; body: %s", list.Code, list.Body.String())
+	}
+	var listed listEnvelope
+	if err := json.Unmarshal(list.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if listed.Meta == nil || listed.Meta.Total != 1 {
+		t.Fatalf("list meta = %+v", listed.Meta)
+	}
+
+	del := doRequest(app, jar, http.MethodDelete, "/api/v1/admin/resources/widgets/"+id, "")
+	if del.Code != http.StatusOK {
+		t.Fatalf("delete status = %d; body: %s", del.Code, del.Body.String())
+	}
+	missing := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets/"+id, "")
+	assertError(t, missing, http.StatusNotFound, "not_found")
+}
+
+func TestResourceAnonymousUnauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	rec := doRequest(app, nil, http.MethodGet, "/api/v1/admin/resources/widgets", "")
+	assertError(t, rec, http.StatusUnauthorized, "authentication")
+}
+
+func TestResourceNonSuperuserForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	jar := loginUser(t, app, "staff@example.com", testPassword)
+	rec := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets", "")
+	assertError(t, rec, http.StatusForbidden, "authorization")
+}
+
+func TestResourceUnknownSlugNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	jar := loginSuperuser(t, app)
+	rec := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/missing", "")
+	assertError(t, rec, http.StatusNotFound, "not_found")
+}
+
+func TestResourceUnknownIDNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	jar := loginSuperuser(t, app)
+	rec := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets/9999", "")
+	assertError(t, rec, http.StatusNotFound, "not_found")
+}
+
+func TestResourceDisabledActionForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app, func(o *admin.Options) {
+		o.Actions.Delete = false
+	})
+	jar := loginSuperuser(t, app)
+	create := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/widgets", `{"name":"Keep"}`)
+	if create.Code != http.StatusOK {
+		t.Fatalf("create status = %d; body: %s", create.Code, create.Body.String())
+	}
+	var created rowEnvelope
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	id := fmt.Sprint(asInt(created.Data["id"]))
+	rec := doRequest(app, jar, http.MethodDelete, "/api/v1/admin/resources/widgets/"+id, "")
+	assertError(t, rec, http.StatusForbidden, "authorization")
+}
+
+func TestResourceValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	jar := loginSuperuser(t, app)
+
+	missing := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/widgets", `{}`)
+	assertError(t, missing, http.StatusUnprocessableEntity, contract.CodeValidationError)
+	env := decodeError(t, missing)
+	if len(env.Fields["name"]) == 0 {
+		t.Fatalf("fields.name missing; %#v", env.Fields)
+	}
+
+	readonly := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/widgets", `{"id":9,"name":"X"}`)
+	assertError(t, readonly, http.StatusUnprocessableEntity, contract.CodeValidationError)
+
+	unknown := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/widgets", `{"name":"X","nope":1}`)
+	assertError(t, unknown, http.StatusUnprocessableEntity, contract.CodeValidationError)
+}
+
+func TestResourceListPaginationSearchOrderFilter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app)
+	jar := loginSuperuser(t, app)
+
+	fixtures := []string{
+		`{"name":"Alpha","sku":"s-a","price":30}`,
+		`{"name":"Beta","sku":"s-b","price":10}`,
+		`{"name":"Gamma","sku":"s-a","price":20}`,
+	}
+	for _, body := range fixtures {
+		rec := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/widgets", body)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("create %s status = %d; body: %s", body, rec.Code, rec.Body.String())
+		}
+	}
+
+	page := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets?page=1&per_page=2", "")
+	if page.Code != http.StatusOK {
+		t.Fatalf("page status = %d; body: %s", page.Code, page.Body.String())
+	}
+	var paged listEnvelope
+	if err := json.Unmarshal(page.Body.Bytes(), &paged); err != nil {
+		t.Fatalf("decode page: %v", err)
+	}
+	if paged.Meta == nil || paged.Meta.Page != 1 || paged.Meta.PerPage != 2 || paged.Meta.Total != 3 {
+		t.Fatalf("page meta = %+v", paged.Meta)
+	}
+	if len(paged.Data) != 2 {
+		t.Fatalf("page data len = %d, want 2", len(paged.Data))
+	}
+
+	search := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets?search=Beta", "")
+	var found listEnvelope
+	if err := json.Unmarshal(search.Body.Bytes(), &found); err != nil {
+		t.Fatalf("decode search: %v", err)
+	}
+	if found.Meta == nil || found.Meta.Total != 1 || len(found.Data) != 1 || found.Data[0]["name"] != "Beta" {
+		t.Fatalf("search = %+v", found)
+	}
+
+	ordered := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets?ordering=-price", "")
+	var ranked listEnvelope
+	if err := json.Unmarshal(ordered.Body.Bytes(), &ranked); err != nil {
+		t.Fatalf("decode order: %v", err)
+	}
+	if len(ranked.Data) != 3 {
+		t.Fatalf("order len = %d", len(ranked.Data))
+	}
+	if ranked.Data[0]["name"] != "Alpha" {
+		t.Fatalf("first ordered = %#v, want Alpha", ranked.Data[0]["name"])
+	}
+
+	createdOrder := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets?ordering=-created_at", "")
+	if createdOrder.Code != http.StatusOK {
+		t.Fatalf("ordering created_at status = %d; body: %s", createdOrder.Code, createdOrder.Body.String())
+	}
+
+	filtered := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets?sku=s-a", "")
+	var matches listEnvelope
+	if err := json.Unmarshal(filtered.Body.Bytes(), &matches); err != nil {
+		t.Fatalf("decode filter: %v", err)
+	}
+	if matches.Meta == nil || matches.Meta.Total != 2 {
+		t.Fatalf("filter meta = %+v data=%+v", matches.Meta, matches.Data)
+	}
+
+	badOrder := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets?ordering=note", "")
+	assertError(t, badOrder, http.StatusUnprocessableEntity, contract.CodeValidationError)
+}
+
+func TestJWTModeDoesNotMountAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newJWTApp(t)
+	rec := doRequest(app, nil, http.MethodGet, "/api/v1/admin/meta", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("JWT admin meta status = %d, want 404; body: %s", rec.Code, rec.Body.String())
+	}
+	spec := doRequest(app, nil, http.MethodGet, "/openapi.json", "")
+	if spec.Code != http.StatusOK {
+		t.Fatalf("openapi status = %d", spec.Code)
+	}
+	if strings.Contains(spec.Body.String(), "/api/v1/admin/meta") {
+		t.Fatal("JWT OpenAPI includes admin routes")
+	}
+}
+
+func TestHandlersDoNotImportReflect(t *testing.T) {
+	t.Parallel()
+	// Request handlers must not walk arbitrary Go types. Registration-time
+	// reflect lives in fields.go (and register.go constructors).
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(thisFile)
+	forbidden := []string{
+		"mount.go",
+		"meta.go",
+		"resources.go",
+		"convert.go",
+		"options.go",
+		"errors.go",
+		"registry.go",
+	}
+	fset := token.NewFileSet()
+	for _, name := range forbidden {
+		path := filepath.Join(dir, name)
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, spec := range file.Imports {
+			if spec.Path != nil && spec.Path.Value == `"reflect"` {
+				t.Errorf("%s imports reflect; request-time / handler files must not", name)
+			}
+		}
+	}
+}
+
+func asInt(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return i
+	case int:
+		return int64(n)
+	case int64:
+		return n
+	default:
+		return 0
+	}
+}

--- a/auth/cookie_handlers.go
+++ b/auth/cookie_handlers.go
@@ -95,10 +95,18 @@ func (s *Service) expiredSessionCookies() []http.Cookie {
 	}
 }
 
+// RequireCookieSession is the exported cookie-session gate used by runtime
+// packages such as admin. It authenticates the gombit_access cookie and
+// stores the User on the request context for UserFromContext. It does not
+// itself enforce CSRF; CSRFMiddleware (csrf.go) is wired as global Gin
+// middleware ahead of it for state-changing requests.
+func (s *Service) RequireCookieSession() func(ctx huma.Context, next func(huma.Context)) {
+	return s.requireCookieSession()
+}
+
 // requireCookieSession is the cookie-mode analogue of requireBearer: it reads
 // the access token from the gombit_access cookie instead of the Authorization
-// header. It does not itself enforce CSRF; CSRFMiddleware (csrf.go) is wired
-// as global Gin middleware ahead of it for state-changing requests.
+// header.
 func (s *Service) requireCookieSession() func(ctx huma.Context, next func(huma.Context)) {
 	return func(ctx huma.Context, next func(huma.Context)) {
 		cookie, err := huma.ReadCookie(ctx, AccessCookieName)

--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -165,7 +165,8 @@ func mapServiceError(ctx context.Context, err error) error {
 
 type userContextKey struct{}
 
-// UserFromContext returns the authenticated user stored by requireBearer.
+// UserFromContext returns the authenticated user stored by requireBearer or
+// RequireCookieSession.
 func UserFromContext(ctx context.Context) (User, bool) {
 	if ctx == nil {
 		return User{}, false

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -1,19 +1,163 @@
-# Admin (post-v0.1)
+# Admin (ADMIN-1)
 
-Gombit's Django-style admin is the prioritized post-v0.1 flagship (build plan
-M6-Admin). Implementation has not started.
-
-The accepted architecture is **[ADR-013](adr/013-runtime-generic-admin.md)**:
-a framework-owned React app over an explicit model registry and a Huma
-introspection API. Not `--admin` scaffolded pages.
+Gombit's Django-style admin is a **runtime generic admin** over an explicit
+model registry and a Huma introspection + data-plane API
+([ADR-013](adr/013-runtime-generic-admin.md)). This issue ships the registry
+and HTTP contract. The framework-owned React SPA under `/admin/` is ADMIN-2
+and is **not** in this tree yet.
 
 | Issue | What it ships |
 | --- | --- |
-| ADMIN-0 (#33) | This decision (ADR-013). Done when the ADR is merged. |
-| ADMIN-1 | `admin.Register` + `GET /api/v1/admin/meta` + generic `/api/v1/admin/resources/{slug}` |
-| ADMIN-2 | Framework-owned SPA under `/admin/` |
-| ADMIN-3 | Groups/permissions on top of `IsSuperuser` |
+| ADMIN-0 (#33) | ADR-013. Done. |
+| ADMIN-1 (#34) | `admin.Register` + `GET /api/v1/admin/meta` + generic `/api/v1/admin/resources/{slug}` |
+| ADMIN-2 | Framework-owned SPA under `/admin/` — not here |
+| ADMIN-3 | Groups/permissions on top of `IsSuperuser` — not here |
 
-Do not add a runtime `admin` package, admin HTTP routes, or an admin React
-app until ADMIN-1. Session/cookie auth (`--auth cookie`) is a hard
-prerequisite; see [auth-cookie.md](auth-cookie.md).
+## When routes mount
+
+`framework.New` mounts empty admin Huma routes **only** when cookie session
+auth is on (`cfg.Auth.Mode == cookie` / `AuthModeCookie`) and a database is
+attached. JWT-only apps do not get `/api/v1/admin/…` (they 404; the paths
+are absent from OpenAPI). Dual Bearer-API + cookie-admin in one process is
+not introduced here.
+
+Session is required. Until ADMIN-3, `auth.User.IsSuperuser` is the only
+admin principal (`gombit createsuperuser`). `/auth/register` never sets
+that flag.
+
+| Caller | Result |
+| --- | --- |
+| Anonymous | D10 `authentication` (401) |
+| Authenticated non-superuser | D10 `authorization` (403) |
+| Superuser, disabled action | D10 `authorization` (403) |
+| Superuser, unknown slug or id | D10 `not_found` (404) |
+
+CSRF on POST/PATCH/DELETE is the existing M5-3 global middleware
+(`X-CSRF-Token`). See [auth-cookie.md](auth-cookie.md).
+
+## Registration
+
+Feature packages register models explicitly — typically from
+`internal/<feature>/admin.go` or `routes.go`. The framework never walks
+GORM models, AutoMigrate lists, or packages.
+
+```go
+func RegisterAdmin(app *framework.App) error {
+    return admin.Register(app, Product{}, admin.Options{
+        Slug:     "products",
+        Singular: "Product",
+        Plural:   "Products",
+        Fields: []admin.Field{
+            {Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+            {Name: "name", Type: admin.TypeString, Required: true},
+            {
+                Name: "category_id",
+                Type: admin.TypeRelation,
+                Related: &admin.Relation{
+                    Slug:       "categories",
+                    Kind:       admin.RelBelongsTo,
+                    LabelField: "name",
+                },
+            },
+        },
+        List:     []string{"name", "category_id"},
+        Search:   []string{"name"},
+        Filter:   []string{"category_id"},
+        Ordering: []string{"name", "created_at"},
+        Actions: admin.Actions{
+            List: true, Detail: true, Create: true, Update: true, Delete: true,
+        },
+        Permissions: admin.Permissions{
+            View:   "admin.products.view",
+            Create: "admin.products.create",
+            Update: "admin.products.update",
+            Delete: "admin.products.delete",
+        },
+    })
+}
+```
+
+`Options` is the source of truth. Missing or duplicate `Slug` is an error at
+`Register`. After `Register` returns, handlers read stored values plus a
+constructor for `T` (`Register[T any]`). They do **not** reflect over
+arbitrary Go types.
+
+### Fields, PK, and names
+
+- **`Field.Name`** is the JSON object key in meta and in data-plane rows.
+  For v1, `Name` is also the GORM/SQL column unless `Field.Column` is set
+  (use that when the Go exported name or GORM column differs).
+- **`Options.PK`** is the JSON/field name of the primary key. Empty means
+  derive the GORM primary key **at Register** and store it. The PK field
+  must appear in `Fields`.
+- **Empty `Fields`** derives a default from the struct once, inside
+  `Register`, via `admin.FieldsFrom(T)`. That helper may use `reflect`
+  **only at registration time**. Do not call it from request handlers.
+- **`created_at` / `updated_at`** are implicit GORM timestamp columns.
+  They may appear in `List` and `Ordering` even when omitted from
+  `Fields`. Search and filter still require an explicit field. If the
+  model has no such GORM column, `Register` errors.
+- Zero `Actions` defaults to all enabled. Empty `Permissions` default to
+  `admin.{slug}.{view,create,update,delete}` and are echoed in meta only
+  (ADMIN-3 enforces them).
+
+Closed field types: `string`, `text`, `integer`, `float`, `decimal`,
+`boolean`, `datetime`, `date`, `uuid`, `json`, `relation`.
+
+Relation `kind` is `belongs_to` or `has_many`. **`belongs_to`** is stored as
+the foreign key on create/update. **`has_many` is meta-only** in ADMIN-1:
+the data plane does not nest related collections and treats the field as
+read-only.
+
+`Register` does not AutoMigrate. The application still owns schema
+(Atlas / `AutoMigrate` in examples).
+
+Generated apps are **not** auto-registered. Prefer an explicit
+`product.RegisterAdmin` in the app; this repo does not scaffold that call
+so JWT goldens stay still.
+
+## HTTP (Huma on `app.API()`, D10)
+
+Paths honor `config.API.Prefix` (default `/api/v1`) and appear in OpenAPI.
+
+| Method | Path | Body |
+| --- | --- | --- |
+| `GET` | `/api/v1/admin/meta` | `{ "data": { "models": [ ... ] }, "meta"?: { "auth": { "mode": "cookie", "bootstrap": "is_superuser" } } }` |
+| `GET` | `/api/v1/admin/meta/{slug}` | `{ "data": { /* one model */ } }` — 404 `not_found` if unknown |
+| `GET` | `/api/v1/admin/resources/{slug}` | list; `meta` is `contract.PageMeta` (`page`, `per_page`, `total`) |
+| `POST` | `/api/v1/admin/resources/{slug}` | create writable fields |
+| `GET` | `/api/v1/admin/resources/{slug}/{id}` | detail |
+| `PATCH` | `/api/v1/admin/resources/{slug}/{id}` | update writable fields |
+| `DELETE` | `/api/v1/admin/resources/{slug}/{id}` | `{ "data": { "ok": true } }` |
+
+`data.models` is required on the catalog (empty array when nothing is
+registered). Raw `*gin.Engine` is **not** used for these endpoints.
+
+List query parameters:
+
+- `page`, `per_page` (default page 1, per_page 20, max 100)
+- `search` (OR `LIKE` across `Options.Search`)
+- `ordering` (a field from `Options.Ordering`; prefix `-` for DESC)
+- one query key per `Options.Filter` field
+
+Row JSON is keyed by registered field names. Create/update accept only
+writable (non-readonly) fields. Unknown keys, readonly keys, and type
+failures render D10 `validation_error` with `fields`.
+
+The application's public CRUD API stays the feature's own typed Huma
+routes. Admin does not replace them.
+
+## Example
+
+[`examples/admin`](../examples/admin) — cookie mode + SQLite +
+`admin.Register` of `widget.Widget`, plus curl for meta and one CRUD
+cycle. Superuser is seeded with `auth.Service.CreateSuperuser` (same path
+as `gombit createsuperuser`).
+
+## Out of scope
+
+- ADMIN-2 React SPA / `/admin/` embed
+- Groups/permissions tables (ADMIN-3); permission **keys** only
+- `--admin` generator / golden template changes
+- M6 batteries (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
+- `localStorage` tokens

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -95,8 +95,9 @@ arbitrary Go types.
   **only at registration time**. Do not call it from request handlers.
 - **`created_at` / `updated_at`** are implicit GORM timestamp columns.
   They may appear in `List` and `Ordering` even when omitted from
-  `Fields`. Search and filter still require an explicit field. If the
-  model has no such GORM column, `Register` errors.
+  `Fields`. When the model has those columns, list and detail row JSON
+  include the values. Search and filter still require an explicit field.
+  If the model has no such GORM column, `Register` errors.
 - Zero `Actions` defaults to all enabled. Empty `Permissions` default to
   `admin.{slug}.{view,create,update,delete}` and are echoed in meta only
   (ADMIN-3 enforces them).
@@ -107,7 +108,8 @@ Closed field types: `string`, `text`, `integer`, `float`, `decimal`,
 Relation `kind` is `belongs_to` or `has_many`. **`belongs_to`** is stored as
 the foreign key on create/update. **`has_many` is meta-only** in ADMIN-1:
 the data plane does not nest related collections and treats the field as
-read-only.
+read-only. `Register` rejects `has_many` (and any field with no SQL column)
+in Search, Filter, or Ordering.
 
 `Register` does not AutoMigrate. The application still owns schema
 (Atlas / `AutoMigrate` in examples).
@@ -140,9 +142,11 @@ List query parameters:
 - `ordering` (a field from `Options.Ordering`; prefix `-` for DESC)
 - one query key per `Options.Filter` field
 
-Row JSON is keyed by registered field names. Create/update accept only
-writable (non-readonly) fields. Unknown keys, readonly keys, and type
-failures render D10 `validation_error` with `fields`.
+Row JSON is keyed by registered field names, plus implicit `created_at` /
+`updated_at` when the GORM model has them and they were omitted from
+`Fields`. Create/update accept only writable (non-readonly) fields.
+Unknown keys, readonly keys, and type failures render D10
+`validation_error` with `fields`.
 
 The application's public CRUD API stays the feature's own typed Huma
 routes. Admin does not replace them.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -482,8 +482,8 @@ tests, pipes), the missing flags are a hard error instead of a hang.
 `--no-input` skips TTY detection entirely.
 
 `IsSuperuser` is the only identity flag `auth.User` gains for this issue.
-Groups/permissions are a product surface for the post-v0.1 admin milestone
-(ADMIN-3), not part of M4-6.
+ADMIN-1 gates the admin introspection and data plane on that flag until
+ADMIN-3 adds groups/permissions. See [admin.md](admin.md).
 
 ## `gombit openapi` and `gombit client`
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -52,7 +52,7 @@ steps that need their own runtime surfaces.
 | 3. database connection | Owned in M1-4 through `database.Open`; applications open/close the handle and attach it with `framework.WithDatabase`. |
 | 4. migration state checks | Deferred to M2. |
 | 5. optional Redis/cache connection | Owned in M1-5 through `cache.Open`, the default memory cache, and `app.Redis()` for the Redis escape hatch. |
-| 6. auth infrastructure | Owned in M5-2 (Bearer) and M5-3 (cookie/session + CSRF) through `auth` + `framework.New` when `GOMBIT_JWT_SECRET` is set. |
+| 6. auth infrastructure | Owned in M5-2 (Bearer) and M5-3 (cookie/session + CSRF) through `auth` + `framework.New` when `GOMBIT_JWT_SECRET` is set. Cookie-mode `New` also mounts empty admin Huma routes (ADMIN-1); models are added with `admin.Register`. JWT-only apps do not get admin routes. |
 | 7. tracing and metrics | Basic trace-ID propagation and HTTP request metrics are owned in M1-7; full OpenTelemetry exporter wiring is future runtime work. |
 | 8. HTTP server construction | Owned in M1-2 through `framework.Run` and `RunContext`. |
 | 9. middleware installation | Recovery is owned in M1-2. Route-registration composition (independently-registered route groups, each with optional group-scoped middleware) is owned in M1-3 — see [`docs/router.md`](router.md). Request ID, trace context, metrics, security headers, request timeout, and trusted-proxy configuration are owned in M1-7. XSS HTML-tag sanitization of request input is owned in M1-8 (fundamental first-party default on the runtime stack; not covered by security headers alone). CORS, rate limiting, and auth remain separate issues. |

--- a/examples/admin/README.md
+++ b/examples/admin/README.md
@@ -1,0 +1,76 @@
+# Admin registry + introspection example (ADMIN-1)
+
+Minimal `framework.App` with `Config.Auth.Mode = config.AuthModeCookie`,
+SQLite, and an explicit `admin.Register` of a small `widget.Widget` model.
+`framework.New` mounts empty admin routes in cookie mode; this example
+registers one model from the feature package. JWT-only apps do not get
+these routes.
+
+See [`docs/admin.md`](../../docs/admin.md) and
+[ADR-013](../../docs/adr/013-runtime-generic-admin.md).
+
+## Run
+
+```sh
+go run ./examples/admin
+```
+
+Interactive docs: [http://127.0.0.1:8082/docs](http://127.0.0.1:8082/docs).
+
+The example seeds `admin@example.com` / `correct-horse-battery-staple` as a
+superuser on start (same `auth.Service.CreateSuperuser` path as
+`gombit createsuperuser`). `/auth/register` never sets `IsSuperuser`.
+
+## E2E (meta + one CRUD cycle)
+
+A cookie jar is required. CSRF must be double-submitted on POST/PATCH/DELETE.
+
+```sh
+JAR=$(mktemp)
+
+CSRF_BODY=$(curl -sS -c "$JAR" -b "$JAR" http://127.0.0.1:8082/api/v1/auth/csrf)
+CSRF=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["csrf_token"])' <<<"$CSRF_BODY")
+
+curl -sS -c "$JAR" -b "$JAR" -X POST http://127.0.0.1:8082/api/v1/auth/login \
+  -H 'Content-Type: application/json' -H "X-CSRF-Token: $CSRF" \
+  -d '{"email":"admin@example.com","password":"correct-horse-battery-staple"}'
+
+# catalog (data.models is required; empty array when nothing is registered)
+curl -sS -c "$JAR" -b "$JAR" http://127.0.0.1:8082/api/v1/admin/meta
+curl -sS -c "$JAR" -b "$JAR" http://127.0.0.1:8082/api/v1/admin/meta/widgets
+
+# create / list / detail / update / delete
+CREATED=$(curl -sS -c "$JAR" -b "$JAR" -X POST http://127.0.0.1:8082/api/v1/admin/resources/widgets \
+  -H 'Content-Type: application/json' -H "X-CSRF-Token: $CSRF" \
+  -d '{"name":"Wrench","sku":"w-1"}')
+ID=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["id"])' <<<"$CREATED")
+
+curl -sS -c "$JAR" -b "$JAR" "http://127.0.0.1:8082/api/v1/admin/resources/widgets?search=Wrench&ordering=name"
+curl -sS -c "$JAR" -b "$JAR" "http://127.0.0.1:8082/api/v1/admin/resources/widgets/$ID"
+curl -sS -c "$JAR" -b "$JAR" -X PATCH "http://127.0.0.1:8082/api/v1/admin/resources/widgets/$ID" \
+  -H 'Content-Type: application/json' -H "X-CSRF-Token: $CSRF" \
+  -d '{"sku":"w-1a"}'
+curl -sS -c "$JAR" -b "$JAR" -X DELETE "http://127.0.0.1:8082/api/v1/admin/resources/widgets/$ID" \
+  -H "X-CSRF-Token: $CSRF"
+
+rm -f "$JAR"
+```
+
+Anonymous calls return D10 `authentication` (401). A normal registered user
+(not a superuser) gets D10 `authorization` (403). Unknown slugs/ids are
+`not_found`. A disabled action is `authorization` for an authenticated
+superuser.
+
+## Create a superuser against a file DSN
+
+When the example is pointed at a file-backed SQLite DSN instead of the
+in-memory default, use `gombit createsuperuser`:
+
+```sh
+GOMBIT_DATABASE_DRIVER=sqlite \
+GOMBIT_DATABASE_DSN='file:admin-example.db?cache=shared&_fk=1' \
+GOMBIT_JWT_SECRET='dev-only-example-jwt-secret-not-for-prod' \
+GOMBIT_AUTH_MODE=cookie \
+go run ./cmd/gombit createsuperuser --no-input \
+  --email admin@example.com --password correct-horse-battery-staple
+```

--- a/examples/admin/internal/widget/admin.go
+++ b/examples/admin/internal/widget/admin.go
@@ -1,0 +1,27 @@
+package widget
+
+import (
+	"github.com/LAA-Software-Engineering/gombit/admin"
+	"github.com/LAA-Software-Engineering/gombit/framework"
+)
+
+// RegisterAdmin registers Widget on the runtime admin. Feature packages own
+// this call — the framework never discovers GORM models by itself (ADR-013).
+func RegisterAdmin(app *framework.App) error {
+	return admin.Register(app, Widget{}, admin.Options{
+		Slug:     "widgets",
+		Singular: "Widget",
+		Plural:   "Widgets",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "name", Type: admin.TypeString, Required: true},
+			{Name: "sku", Type: admin.TypeString},
+		},
+		List:     []string{"name", "sku"},
+		Search:   []string{"name", "sku"},
+		Ordering: []string{"name", "created_at"},
+		Actions: admin.Actions{
+			List: true, Detail: true, Create: true, Update: true, Delete: true,
+		},
+	})
+}

--- a/examples/admin/internal/widget/widget.go
+++ b/examples/admin/internal/widget/widget.go
@@ -1,0 +1,12 @@
+package widget
+
+import "time"
+
+// Widget is the small model registered with the admin in this example.
+type Widget struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	Name      string    `json:"name"`
+	SKU       string    `json:"sku"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/examples/admin/main.go
+++ b/examples/admin/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/LAA-Software-Engineering/gombit/auth"
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/database"
+	"github.com/LAA-Software-Engineering/gombit/examples/admin/internal/widget"
+	"github.com/LAA-Software-Engineering/gombit/framework"
+)
+
+func main() {
+	cfg := config.Default()
+	cfg.HTTP.Addr = "127.0.0.1:8082"
+	cfg.Auth.JWTSecret = "dev-only-example-jwt-secret-not-for-prod"
+	cfg.Auth.Mode = config.AuthModeCookie
+	// Secure=false only because this example serves plain HTTP on
+	// 127.0.0.1. config.Validate requires CookieSecure=true in production.
+	cfg.Auth.CookieSecure = false
+
+	db, err := database.Open(config.DatabaseConfig{
+		Driver: config.DatabaseDriverSQLite,
+		DSN:    "file:admin-example?mode=memory&cache=shared&_fk=1",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	app, err := framework.New(framework.WithConfig(cfg), framework.WithDatabase(db))
+	if err != nil {
+		_ = db.Close()
+		log.Fatal(err)
+	}
+	if err := widget.RegisterAdmin(app); err != nil {
+		_ = db.Close()
+		log.Fatal(err)
+	}
+
+	app.OnStart(func(ctx context.Context) error {
+		if err := auth.Migrate(db.DB); err != nil {
+			return err
+		}
+		if err := db.AutoMigrate(&widget.Widget{}); err != nil {
+			return err
+		}
+		svc, err := auth.NewService(db.DB, cfg)
+		if err != nil {
+			return err
+		}
+		_, err = svc.CreateSuperuser(ctx, "admin@example.com", "correct-horse-battery-staple")
+		if err != nil && !errors.Is(err, auth.ErrEmailTaken) {
+			return err
+		}
+		return nil
+	})
+	app.OnStop(func(context.Context) error {
+		return db.Close()
+	})
+
+	log.Printf("admin example listening on http://%s (docs http://127.0.0.1:8082/docs)", cfg.HTTP.Addr)
+	log.Printf("seeded superuser admin@example.com / correct-horse-battery-staple")
+	if err := framework.Run(app); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/framework/app.go
+++ b/framework/app.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/LAA-Software-Engineering/gombit/admin"
 	"github.com/LAA-Software-Engineering/gombit/auth"
 	"github.com/LAA-Software-Engineering/gombit/cache"
 	"github.com/LAA-Software-Engineering/gombit/config"
@@ -135,6 +136,13 @@ func New(options ...Option) (*App, error) {
 		}
 		if err := auth.Mount(app.api, app.db.DB, app.cfg); err != nil {
 			return nil, err
+		}
+		// Admin introspection + data plane mount only in cookie mode
+		// (ADR-013). JWT-only apps do not grow admin routes.
+		if app.cfg.Auth.EffectiveMode() == config.AuthModeCookie {
+			if err := admin.Mount(app); err != nil {
+				return nil, err
+			}
 		}
 	}
 	mountEmbeddedFrontend(app.router, app.embeddedFrontend, app.cfg.API.Prefix)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the ADMIN-1 runtime admin: explicit `admin.Register`, Huma `GET /api/v1/admin/meta` (+ `/{slug}`), and the generic `/api/v1/admin/resources/{slug}` CRUD data plane. Cookie-mode apps mount empty admin routes from `framework.New`; JWT-only apps do not. Superuser cookie session is required until ADMIN-3.

Closes #34

## Acceptance criteria

- [x] Registered models expose fields/permissions over the endpoint (`GET /api/v1/admin/meta` and `GET /api/v1/admin/meta/{slug}`)
- [x] ADR-013 generic data plane (`/api/v1/admin/resources/{slug}` list/create/detail/update/delete) so ADMIN-2 is not blocked
- [x] Missing/duplicate slug fails at `Register`; no request-time reflection
- [x] Cookie-only mount; session + `IsSuperuser`; 401/403/404 codes as specified
- [x] CSRF on POST/PATCH/DELETE via existing M5-3 middleware
- [x] Example + docs; no ADMIN-2 SPA; no groups table; no `--admin` generator

## Scope notes

- **ADMIN-2** (framework-owned React SPA / `/admin/` embed) is not in this PR.
- **ADMIN-3** groups/permissions tables are not here; permission **keys** are stored and echoed only.
- No `gombit new --auth cookie` scaffold change, so goldens stay still. Apps that want a model in admin call `admin.Register` themselves (see `examples/admin/internal/widget`).
- `has_many` is meta-only; the data plane does not nest collections. `belongs_to` stores the FK.
- `created_at` / `updated_at` may appear in `List` and `Ordering` even when omitted from `Fields` (GORM timestamp columns). Search/filter still require an explicit field.
- `Field.Name` is the JSON key. For v1, `Name == json == column` unless `Field.Column` is set.
- `examples/client` OpenAPI + TS client were **not** regenerated: that checked-in spec is JWT and does not grow admin routes. Cookie-mode apps emit admin paths in live `/openapi.json`.

## Validation

- [x] `go test ./admin`
- [x] `go test ./framework`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [x] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB-touching default suite is SQLite. Postgres/MySQL use the same opt-in `//go:build integration` + DSN flags pattern as `auth` (portable GORM, no driver-specific SQL in `go test ./admin`)
- [x] Stable features ship docs (`docs/admin.md`) and appear in an example app (`examples/admin`)
- [ ] Extraction preserves contracts — N/A (new runtime package, not an extraction)
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — N/A (no generator/scaffold edits)
- [x] API changes regenerate the OpenAPI doc + TS client in this PR — N/A for checked-in `examples/client` (JWT, unchanged). Admin routes appear in live OpenAPI on cookie-mode apps
- [x] No secrets in generated frontend source; `VITE_*` is treated as public — N/A (no frontend in this PR); access tokens stay in HttpOnly cookies
- [x] Scope stays inside this issue's milestone — no M6 batteries; no ADMIN-2 SPA
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7cead8d-780d-4ee8-ae63-2a4e49ca67e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7cead8d-780d-4ee8-ae63-2a4e49ca67e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

