### PR TITLE
fix: configure git identity before annotated tag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,10 @@ jobs:
             echo "Tag push: $next"
           else
             BUMP="${INPUT_BUMP:-patch}"
+            # actions/checkout does not configure a git identity, and an
+            # annotated tag (git tag -a below) requires one to exist.
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
             git fetch --tags --force
 
             latest=""


### PR DESCRIPTION
## Summary

The manually-triggered release run failed: version resolution correctly computed `v0.1.0` from an empty tag history, but `git tag -a "$next" -m "$next"` then failed with `empty ident name ... fatal: Committer identity unknown`. `actions/checkout` does not configure a git identity, and creating an *annotated* tag requires a tagger name/email.

Fix: `git config user.name`/`user.email` before the tag step, using the standard `github-actions[bot]` identity.

Failed run: https://github.com/LAA-Software-Engineering/gombit/actions/runs/32187066935/job/95873044738

Workflow-only change; no application code touched.

## Validation

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Full release run — can only be verified by re-running the workflow after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)