### PR TITLE
chore: add weekly Dependabot checks for Go modules and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` with weekly update checks for:
- `gomod` (root `go.mod`)
- `github-actions` (workflow action versions in `.github/workflows/`)

No linked issue — this is repo hygiene/tooling, not a build-plan §4 backlog entry.

## Acceptance criteria

N/A — not tied to a backlog issue. Self-imposed criteria:
- [x] Dependabot config validates against schema and targets the correct ecosystems/directories
- [x] Interval is weekly for both ecosystems, as requested

## Scope notes

- Only the root `go.mod` is configured. `goldentest/testdata/golden/**/go.mod` files are golden-test fixtures (generated app output), not real dependency roots, so they're intentionally excluded.

## Validation

- [x] Reviewed `.github/dependabot.yml` for correct YAML/schema shape
- [ ] `go test ./...` — N/A, no Go code changed
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — N/A, no Go code changed
- [ ] Project `code-review` skill run against this diff — N/A, config-only change outside the skill's Go/React scope

## Working agreement checklist

- [ ] New behavior has tests — N/A, config file, not application behavior
- [ ] Stable features ship docs and appear in an example app — N/A
- [ ] Extraction preserves contracts — N/A, no code extraction
- [ ] Generators are idempotent/additive... — N/A, no generator touched
- [ ] API changes regenerate the OpenAPI doc + TS client — N/A, no API change
- [ ] No secrets in generated frontend source — N/A, no frontend change
- [x] Scope stays inside milestone bounds — pure CI/tooling config, no feature scope
- [ ] This PR links its issue — N/A, no backlog issue exists for this chore

🤖 Generated with [Claude Code](https://claude.com/claude-code)