### PR TITLE
fix: tutorial bugs found running docs/tutorial.md end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           node-version: "22"
 
       - name: Regenerate sample spec and client
-        run: go run ./cmd/gombit client check --write
+        run: go run ./cmd/gombit client check --write --spec examples/client/openapi.json --out examples/client/frontend/src/api/generated
 
       - name: Fail on contract drift
         run: git diff --exit-code -- examples/client/openapi.json examples/client/frontend/src/api/generated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ CLI smoke checks:
 ```bash
 go run ./cmd/gombit --help
 go run ./cmd/gombit make --help
-go run ./cmd/gombit client check
+go run ./cmd/gombit client check --spec examples/client/openapi.json --out examples/client/frontend/src/api/generated
 go run ./cmd/gombit doctor
 go run ./cmd/gombit config show
 go run ./cmd/gombit routes
@@ -150,11 +150,17 @@ Any API change must regenerate the OpenAPI document and the TypeScript client
 **in the same PR**:
 
 ```bash
-go run ./cmd/gombit client check --write
+go run ./cmd/gombit client check --write --spec examples/client/openapi.json --out examples/client/frontend/src/api/generated
 ```
 
 CI fails if `examples/client/openapi.json` or
 `examples/client/frontend/src/api/generated` would change.
+
+`gombit client check`'s bare defaults (`openapi.json` /
+`frontend/src/api/generated`) target a generated app, not this repository —
+outside this repository it also needs `--url` to fetch a live spec, since a
+separately compiled `gombit` binary has no Go-level `huma.API` to compare
+against. See [`docs/client.md`](docs/client.md).
 
 ### Admin UI
 

--- a/cli/client.go
+++ b/cli/client.go
@@ -79,8 +79,18 @@ func newClientGenerateCommand(stdout io.Writer, stderr io.Writer) *cobra.Command
 func newClientCheckCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
 	cmd := silence(&cobra.Command{
 		Use:   "check",
-		Short: "Fail when the committed TypeScript client drifts from the live contract",
-		Args:  cobra.ArbitraryArgs,
+		Short: "Fail when the committed TypeScript client drifts from the contract",
+		Long: `Fail when the committed TypeScript client drifts from the contract.
+
+Without --url, the comparison source is an in-process huma.API (the
+framework's own SampleApp by default), which only exists inside this
+repository — that mode backs the framework's own CI check against
+examples/client/. Generated apps have no Go-level access to their API from
+a separately compiled gombit binary, so pass --url to fetch the live
+/openapi.json from a running app instead:
+
+  gombit client check --url http://127.0.0.1:8080/openapi.json`,
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				return fmt.Errorf("gombit client check: unexpected argument %q", args[0])
@@ -101,7 +111,11 @@ func newClientCheckCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return client.CheckDrift(cmd.Context(), client.DriftOptions{
+			rawURL, err := cmd.Flags().GetString("url")
+			if err != nil {
+				return err
+			}
+			opts := client.DriftOptions{
 				WorkDir:   ".",
 				SpecPath:  spec,
 				OutDir:    out,
@@ -109,12 +123,21 @@ func newClientCheckCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
 				NPXBinary: npx,
 				Stdout:    stdout,
 				Stderr:    stderr,
-			})
+			}
+			if rawURL != "" {
+				specBytes, err := fetchOpenAPI(cmd.Context(), rawURL)
+				if err != nil {
+					return err
+				}
+				opts.SpecBytes = specBytes
+			}
+			return client.CheckDrift(cmd.Context(), opts)
 		},
 	})
-	cmd.Flags().String("spec", client.SampleSpecPath, "committed OpenAPI 3.1 document path")
-	cmd.Flags().String("out", client.SampleOutDir, "committed generated TypeScript directory")
+	cmd.Flags().String("spec", client.DefaultSpecPath, "committed OpenAPI 3.1 document path")
+	cmd.Flags().String("out", client.DefaultOutDir, "committed generated TypeScript directory")
 	cmd.Flags().Bool("write", false, "rewrite committed fixtures instead of reporting drift")
 	cmd.Flags().String("npx", "npx", "npx binary used to run openapi-typescript")
+	cmd.Flags().String("url", "", "URL of a live /openapi.json to compare against instead of an in-process API (required outside this repository)")
 	return cmd
 }

--- a/cli/client_test.go
+++ b/cli/client_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestClientCheckURLFetchesLiveSpecInsteadOfSampleApp exercises the path a
+// generated app uses: gombit is a separately compiled binary with no
+// Go-level access to the app's huma.API, so `client check --url` must fetch
+// the live /openapi.json and compare/write against that, never against the
+// framework's own SampleApp.
+func TestClientCheckURLFetchesLiveSpecInsteadOfSampleApp(t *testing.T) {
+	const liveSpec = `{"openapi":"3.1.0","info":{"title":"generated-app-from-url-test","version":"0.0.0"},"paths":{}}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(liveSpec))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err := ExecuteRoot(context.Background(), NewRoot(stdout, stderr), []string{
+		"client", "check", "--write", "--url", srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("gombit client check --write --url: %v\nstderr: %s", err, stderr.String())
+	}
+
+	// #nosec G304 -- test-controlled path under t.TempDir()
+	written, err := os.ReadFile(filepath.Join(dir, "openapi.json"))
+	if err != nil {
+		t.Fatalf("read written spec: %v", err)
+	}
+	if !strings.Contains(string(written), "generated-app-from-url-test") {
+		t.Fatalf("written spec = %s, want content fetched from --url", written)
+	}
+}
+
+func TestClientCheckDefaultsMatchGenerateNotExamplesClient(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err := ExecuteRoot(context.Background(), NewRoot(stdout, stderr), []string{"client", "check", "--help"})
+	if err != nil {
+		t.Fatalf("gombit client check --help: %v", err)
+	}
+	out := stdout.String() + stderr.String()
+	if strings.Contains(out, `default "examples/client`) {
+		t.Fatalf("client check --help still defaults to framework-repo-only examples/client paths:\n%s", out)
+	}
+	if !strings.Contains(out, `default "openapi.json"`) {
+		t.Fatalf("client check --help missing openapi.json default:\n%s", out)
+	}
+	if !strings.Contains(out, `default "frontend/src/api/generated"`) {
+		t.Fatalf("client check --help missing frontend/src/api/generated default:\n%s", out)
+	}
+	if !strings.Contains(out, "--url") {
+		t.Fatalf("client check --help missing --url flag:\n%s", out)
+	}
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -123,7 +123,7 @@ func usage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  db <subcommand>   see gombit db")
 	_, _ = fmt.Fprintln(w, "  openapi generate [--out openapi.json] [--url http://127.0.0.1:8080/openapi.json]")
 	_, _ = fmt.Fprintln(w, "  client generate [--spec openapi.json] [--out frontend/src/api/generated] [--dry-run] [--force]")
-	_, _ = fmt.Fprintln(w, "  client check [--write] [--spec examples/client/openapi.json] [--out examples/client/frontend/src/api/generated]")
+	_, _ = fmt.Fprintln(w, "  client check [--write] [--spec openapi.json] [--out frontend/src/api/generated] [--url http://127.0.0.1:8080/openapi.json]")
 	_, _ = fmt.Fprintln(w, "  routes [--url http://127.0.0.1:8080]")
 	_, _ = fmt.Fprintln(w, "  doctor [--dir database/migrations]")
 	_, _ = fmt.Fprintln(w, "  config show")
@@ -149,7 +149,7 @@ func openapiUsage(w io.Writer) {
 func clientUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "available client subcommands:")
 	_, _ = fmt.Fprintln(w, "  generate [--spec openapi.json] [--out frontend/src/api/generated] [--dry-run] [--force] [--npx npx]")
-	_, _ = fmt.Fprintln(w, "  check [--write] [--spec examples/client/openapi.json] [--out examples/client/frontend/src/api/generated] [--npx npx]")
+	_, _ = fmt.Fprintln(w, "  check [--write] [--spec openapi.json] [--out frontend/src/api/generated] [--url http://127.0.0.1:8080/openapi.json] [--npx npx]")
 }
 
 func configUsage(w io.Writer) {

--- a/client/drift.go
+++ b/client/drift.go
@@ -36,8 +36,13 @@ type DriftOptions struct {
 	// OutDir is the committed generated-client directory, relative to WorkDir unless absolute.
 	// Default: SampleOutDir.
 	OutDir string
-	// API is the Huma API to emit. Nil means SampleApp().
+	// API is the Huma API to emit. Nil and SpecBytes nil means SampleApp().
 	API huma.API
+	// SpecBytes is a pre-fetched OpenAPI document (e.g. from a live /openapi.json
+	// URL) to treat as the current contract. Takes precedence over API. Callers
+	// outside this module — generated apps have no Go-level huma.API to pass —
+	// use this to check their own contract instead of the framework's SampleApp.
+	SpecBytes []byte
 	// Write regenerates committed fixtures instead of comparing them.
 	Write bool
 	// NPXBinary is the npx executable used by Generate. Default: npx.
@@ -46,35 +51,48 @@ type DriftOptions struct {
 	Stderr    io.Writer
 }
 
-// CheckDrift regenerates the sample OpenAPI document and TypeScript client and
+// CheckDrift regenerates the OpenAPI document and TypeScript client and
 // reports whether committed artifacts would change.
 //
 // The spec is compared semantically via encoding/json, so whitespace-only
 // differences are not drift. Generated TypeScript is compared byte-for-byte.
-// Generation is in-process from SampleApp (or opts.API) and does not fetch a
-// live /openapi.json URL.
 //
-// When Write is true, fixtures are rewritten in place with contract.WriteOpenAPI
-// and Generate.
+// The document used for comparison comes from, in order: opts.SpecBytes (a
+// pre-fetched live spec), opts.API (an in-process huma.API — this module's
+// own tests and go:generate directive use this to compare examples/client/
+// against SampleApp), or SampleApp() itself. Generated apps have neither a
+// Go-level huma.API nor a reason to compare against the framework's sample
+// widget API, so the CLI's `gombit client check --url` path fetches the
+// live spec over HTTP and passes it as SpecBytes.
+//
+// When Write is true, fixtures are rewritten in place.
 func CheckDrift(ctx context.Context, opts DriftOptions) error {
 	if ctx == nil {
 		return errors.New("client: nil context")
 	}
 	opts = normalizeDriftOptions(opts)
 
-	api := opts.API
-	if api == nil {
-		app, err := SampleApp()
-		if err != nil {
-			return fmt.Errorf("client: sample app: %w", err)
+	spec := opts.SpecBytes
+	if spec == nil {
+		api := opts.API
+		if api == nil {
+			app, err := SampleApp()
+			if err != nil {
+				return fmt.Errorf("client: sample app: %w", err)
+			}
+			api = app.API()
 		}
-		api = app.API()
+		var err error
+		spec, err = contract.OpenAPIJSON(api)
+		if err != nil {
+			return err
+		}
 	}
 
 	if opts.Write {
-		return writeSampleFixtures(ctx, opts, api)
+		return writeSampleFixtures(ctx, opts, spec)
 	}
-	return compareSampleFixtures(ctx, opts, api)
+	return compareSampleFixtures(ctx, opts, spec)
 }
 
 func normalizeDriftOptions(opts DriftOptions) DriftOptions {
@@ -106,9 +124,9 @@ func resolvePath(workDir, path string) string {
 	return filepath.Join(workDir, path)
 }
 
-func writeSampleFixtures(ctx context.Context, opts DriftOptions, api huma.API) error {
+func writeSampleFixtures(ctx context.Context, opts DriftOptions, spec []byte) error {
 	specPath := resolvePath(opts.WorkDir, opts.SpecPath)
-	if err := contract.WriteOpenAPI(specPath, api); err != nil {
+	if err := contract.WriteOpenAPIFile(specPath, spec); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintf(opts.Stdout, "wrote %s\n", displayPath(opts.WorkDir, specPath)); err != nil {
@@ -124,7 +142,7 @@ func writeSampleFixtures(ctx context.Context, opts DriftOptions, api huma.API) e
 	})
 }
 
-func compareSampleFixtures(ctx context.Context, opts DriftOptions, api huma.API) error {
+func compareSampleFixtures(ctx context.Context, opts DriftOptions, generatedSpec []byte) error {
 	tmpDir, err := os.MkdirTemp("", "gombit-drift-*")
 	if err != nil {
 		return fmt.Errorf("client: temp dir: %w", err)
@@ -132,13 +150,8 @@ func compareSampleFixtures(ctx context.Context, opts DriftOptions, api huma.API)
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	generatedSpecPath := filepath.Join(tmpDir, "openapi.json")
-	if err := contract.WriteOpenAPI(generatedSpecPath, api); err != nil {
+	if err := contract.WriteOpenAPIFile(generatedSpecPath, generatedSpec); err != nil {
 		return err
-	}
-	// #nosec G304 -- generatedSpecPath is created in this function
-	generatedSpec, err := os.ReadFile(generatedSpecPath)
-	if err != nil {
-		return fmt.Errorf("client: read generated spec: %w", err)
 	}
 
 	specPath := resolvePath(opts.WorkDir, opts.SpecPath)

--- a/client/drift_test.go
+++ b/client/drift_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/LAA-Software-Engineering/gombit/contract"
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humagin"
 	"github.com/gin-gonic/gin"
 )
 
@@ -167,6 +168,73 @@ func TestCheckDriftWriteRegeneratesFixtures(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CheckDrift() after write error = %v, want nil", err)
+	}
+}
+
+// TestCheckDriftUsesSpecBytesOverSampleApp models the `gombit client check
+// --url` path a generated app uses: it has no Go-level huma.API to pass, so
+// the CLI fetches a live spec over HTTP and hands it in as SpecBytes. That
+// must take precedence over the API/SampleApp fallback and never touch
+// SampleApp's own contract.
+func TestCheckDriftUsesSpecBytesOverSampleApp(t *testing.T) {
+	requireNode(t)
+
+	router := gin.New()
+	api := humagin.New(router, contract.HumaConfig("drift-spec-bytes-test", "0.0.0"))
+	huma.Register(api, huma.Operation{
+		OperationID: "list-widgets-from-url",
+		Method:      http.MethodGet,
+		Path:        "/api/v1/widgets",
+		Summary:     "List widgets",
+	}, func(ctx context.Context, input *struct{}) (*struct {
+		Body contract.Data[[]string]
+	}, error) {
+		return &struct {
+			Body contract.Data[[]string]
+		}{Body: contract.Data[[]string]{Data: []string{"widget-1"}}}, nil
+	})
+	specBytes, err := contract.OpenAPIJSON(api)
+	if err != nil {
+		t.Fatalf("contract.OpenAPIJSON() error = %v", err)
+	}
+
+	workDir := t.TempDir()
+	stdout := new(bytes.Buffer)
+	err = CheckDrift(context.Background(), DriftOptions{
+		WorkDir:   workDir,
+		SpecPath:  "openapi.json",
+		OutDir:    "frontend/src/api/generated",
+		SpecBytes: specBytes,
+		Write:     true,
+		Stdout:    stdout,
+		Stderr:    ioDiscard{},
+	})
+	if err != nil {
+		t.Fatalf("CheckDrift(SpecBytes, write) error = %v", err)
+	}
+
+	// #nosec G304 -- test-controlled path under t.TempDir()
+	written, err := os.ReadFile(filepath.Join(workDir, "openapi.json"))
+	if err != nil {
+		t.Fatalf("read written spec: %v", err)
+	}
+	if !strings.Contains(string(written), "list-widgets-from-url") {
+		t.Fatalf("written spec = %s, want it to come from SpecBytes, not SampleApp", written)
+	}
+	if strings.Contains(string(written), "SampleApp") {
+		t.Fatal("written spec unexpectedly contains SampleApp content")
+	}
+
+	// A subsequent check against the same SpecBytes must report no drift.
+	err = CheckDrift(context.Background(), DriftOptions{
+		WorkDir:   workDir,
+		SpecPath:  "openapi.json",
+		OutDir:    "frontend/src/api/generated",
+		SpecBytes: specBytes,
+		Stderr:    ioDiscard{},
+	})
+	if err != nil {
+		t.Fatalf("CheckDrift(SpecBytes) after write error = %v, want nil", err)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -354,7 +354,11 @@ func ApplyEnvironmentDefaults(cfg Config) Config {
 }
 
 // Load reads configuration from the process environment and validates it.
+// It first applies .env from the current working directory, if one exists,
+// without overwriting variables the process environment already sets — see
+// loadDotEnv.
 func Load() (Config, error) {
+	loadDotEnv()
 	return LoadFromEnv(os.LookupEnv)
 }
 

--- a/config/dotenv.go
+++ b/config/dotenv.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// dotEnvFile is the file Load looks for in the current working directory.
+// gombit new writes this with a per-project random GOMBIT_JWT_SECRET; it is
+// gitignored and never read by LoadFromEnv directly, only by Load.
+const dotEnvFile = ".env"
+
+// loadDotEnv reads KEY=VALUE pairs from .env in the current working
+// directory and applies them to the process environment, without
+// overwriting a variable that is already set. It is a silent no-op when the
+// file does not exist, so it is safe to call unconditionally: a real
+// deployment sets variables through its own environment and never ships a
+// .env file (it is gitignored by every gombit new scaffold).
+func loadDotEnv() {
+	f, err := os.Open(dotEnvFile)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		key, value, ok := parseDotEnvLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		if _, set := os.LookupEnv(key); set {
+			continue
+		}
+		_ = os.Setenv(key, value)
+	}
+}
+
+// parseDotEnvLine parses a single KEY=VALUE line, skipping blanks and `#`
+// comments. It strips one layer of matching single or double quotes from
+// the value, the same convention every gombit-generated .env file follows.
+func parseDotEnvLine(line string) (key, value string, ok bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", "", false
+	}
+	k, v, found := strings.Cut(line, "=")
+	if !found {
+		return "", "", false
+	}
+	k = strings.TrimSpace(k)
+	if k == "" {
+		return "", "", false
+	}
+	v = strings.TrimSpace(v)
+	if len(v) >= 2 {
+		if (v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'') {
+			v = v[1 : len(v)-1]
+		}
+	}
+	return k, v, true
+}

--- a/config/dotenv_test.go
+++ b/config/dotenv_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseDotEnvLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantKey   string
+		wantValue string
+		wantOK    bool
+	}{
+		{name: "simple", line: "GOMBIT_JWT_SECRET=abc123", wantKey: "GOMBIT_JWT_SECRET", wantValue: "abc123", wantOK: true},
+		{name: "blank", line: "", wantOK: false},
+		{name: "comment", line: "# a comment", wantOK: false},
+		{name: "indented comment", line: "  # indented", wantOK: false},
+		{name: "no equals", line: "not an assignment", wantOK: false},
+		{name: "empty value", line: "GOMBIT_DOCS_ENABLED=", wantKey: "GOMBIT_DOCS_ENABLED", wantValue: "", wantOK: true},
+		{name: "double quoted", line: `GOMBIT_APP_NAME="my app"`, wantKey: "GOMBIT_APP_NAME", wantValue: "my app", wantOK: true},
+		{name: "single quoted", line: `GOMBIT_APP_NAME='my app'`, wantKey: "GOMBIT_APP_NAME", wantValue: "my app", wantOK: true},
+		{name: "surrounding whitespace", line: "  GOMBIT_HTTP_ADDR = :8080  ", wantKey: "GOMBIT_HTTP_ADDR", wantValue: ":8080", wantOK: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key, value, ok := parseDotEnvLine(tc.line)
+			if ok != tc.wantOK {
+				t.Fatalf("parseDotEnvLine(%q) ok = %v, want %v", tc.line, ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if key != tc.wantKey || value != tc.wantValue {
+				t.Fatalf("parseDotEnvLine(%q) = (%q, %q), want (%q, %q)", tc.line, key, value, tc.wantKey, tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestLoadDotEnvAppliesUnsetVariables(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	content := "GOMBIT_APP_NAME=fromdotenv\n# comment\n\nGOMBIT_HTTP_ADDR=:9999\n"
+	if err := os.WriteFile(filepath.Join(dir, dotEnvFile), []byte(content), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	_ = os.Unsetenv(envAppName)
+	_ = os.Unsetenv(envHTTPAddr)
+	t.Cleanup(func() {
+		_ = os.Unsetenv(envAppName)
+		_ = os.Unsetenv(envHTTPAddr)
+	})
+
+	loadDotEnv()
+
+	if got := os.Getenv(envAppName); got != "fromdotenv" {
+		t.Fatalf("GOMBIT_APP_NAME = %q, want %q", got, "fromdotenv")
+	}
+	if got := os.Getenv(envHTTPAddr); got != ":9999" {
+		t.Fatalf("GOMBIT_HTTP_ADDR = %q, want %q", got, ":9999")
+	}
+}
+
+func TestLoadDotEnvDoesNotOverwriteProcessEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	content := "GOMBIT_APP_NAME=fromdotenv\n"
+	if err := os.WriteFile(filepath.Join(dir, dotEnvFile), []byte(content), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	t.Setenv(envAppName, "fromprocess")
+
+	loadDotEnv()
+
+	if got := os.Getenv(envAppName); got != "fromprocess" {
+		t.Fatalf("GOMBIT_APP_NAME = %q, want %q (process env must win)", got, "fromprocess")
+	}
+}
+
+func TestLoadDotEnvNoFileIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Should not panic or error when .env does not exist.
+	loadDotEnv()
+}
+
+func TestLoadAppliesDotEnvJWTSecret(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	content := "GOMBIT_JWT_SECRET=from-dotenv-secret-32-bytes-min!!\n"
+	if err := os.WriteFile(filepath.Join(dir, dotEnvFile), []byte(content), 0o600); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	_ = os.Unsetenv(envJWTSecret)
+	t.Cleanup(func() { _ = os.Unsetenv(envJWTSecret) })
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil", err)
+	}
+	if cfg.Auth.JWTSecret != "from-dotenv-secret-32-bytes-min!!" {
+		t.Fatalf("Auth.JWTSecret = %q, want value from .env", cfg.Auth.JWTSecret)
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -143,6 +143,7 @@ demo/
 ├── frontend/             # Vite + React skeleton (main.tsx, router, generated client)
 ├── gombit.yaml
 ├── .air.toml
+├── .env                  # gitignored; per-project random GOMBIT_JWT_SECRET, loaded automatically
 ├── .env.example
 ├── go.mod
 └── README.md

--- a/docs/client.md
+++ b/docs/client.md
@@ -75,25 +75,41 @@ generated client. See that README to typecheck it.
 
 ## Contract drift check
 
-`gombit client check` rebuilds the sample widget API with `client.SampleApp()`,
-writes the spec with `contract.WriteOpenAPI`, regenerates the TypeScript client
-with `client.Generate`, and fails if committed artifacts would change. It does
-not fetch a live `/openapi.json` URL.
+`gombit client check` regenerates the OpenAPI document and TypeScript client
+and fails if committed artifacts would change. The document it compares
+against comes from, in order: `--url` (fetched over HTTP), an in-process
+`huma.API` (only available to Go callers inside this repository, such as
+`client.SampleApp()`), or `client.SampleApp()` itself. `--spec` and `--out`
+default to `openapi.json` and `frontend/src/api/generated` — the same
+defaults as `client generate` — so a bare `gombit client check --url ...` is
+meant to run inside a **generated app**, not this repository.
 
-From the repository root:
+**In a generated app**, with the API running (`gombit dev` or a deployed
+instance):
 
 ```sh
-go run ./cmd/gombit client check
-go run ./cmd/gombit client check --write
+gombit client check --url http://127.0.0.1:8080/openapi.json
 ```
 
-`--write` rewrites `examples/client/openapi.json` and
-`examples/client/frontend/src/api/generated`. CI runs `--write` and then
-`git diff --exit-code` on those paths, so a Huma handler change that is not
-regenerated fails the job. Spec comparison in `CheckDrift` is semantic
+`gombit` is a separately compiled binary there, so it has no Go-level
+`huma.API` to compare against — `--url` is required.
+
+**In this repository**, the drift check instead guards
+`examples/client/openapi.json` and `examples/client/frontend/src/api/generated`
+against `client.SampleApp()`, so it needs explicit paths:
+
+```sh
+go run ./cmd/gombit client check --spec examples/client/openapi.json --out examples/client/frontend/src/api/generated
+go run ./cmd/gombit client check --write --spec examples/client/openapi.json --out examples/client/frontend/src/api/generated
+```
+
+`--write` rewrites those two paths. CI runs the `--write` form and then
+`git diff --exit-code` on them, so a Huma handler change to `SampleApp` that
+is not regenerated fails the job. Spec comparison in `CheckDrift` is semantic
 (`encoding/json`); whitespace-only JSON is not drift.
 
-`go generate ./client` runs the same rewrite as `--write`.
+`go generate ./client` runs the same rewrite as the explicit-path `--write`
+form above.
 
 ## React skeleton
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -28,7 +28,13 @@ shape with environment-derived `/docs` and cache namespace. Mutating
 ## Environment
 
 `config.Load()` reads the process environment and validates the resulting
-configuration. The M1-1 boundary recognizes:
+configuration. Before that, it applies a `.env` file from the current working
+directory if one exists — `gombit new` writes one with a per-project random
+`GOMBIT_JWT_SECRET`, and `.env` values never override a variable the process
+environment already sets. A real deployment sets configuration through its
+own environment and does not ship a `.env` file (it is gitignored by every
+`gombit new` scaffold), so this is a no-op in production. The M1-1 boundary
+recognizes:
 
 | Variable | Field | Default |
 | --- | --- | --- |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -134,6 +134,8 @@ Contributors run the CLI directly with `go run ./cmd/gombit …` — see
 gombit version
 ```
 
+A release archive (Option 2) is stamped with build metadata:
+
 ```text
 gombit:   v0.1.0
 commit:   9abb3c6ecc8c1bf93419aa43c4d4f1ae3de97a2b
@@ -141,6 +143,11 @@ built:    2026-08-18T19:33:15Z
 go:       go1.25.7
 platform: linux/amd64
 ```
+
+`go install` (Option 1) and a plain `go build` from source (Option 3) carry
+no ldflags, so `commit` and `built` read `unknown` instead — only `gombit`
+(the module version) and the `go`/`platform` fields are populated. That's
+expected, not a broken install.
 
 Then check the whole environment:
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -31,6 +31,16 @@ gombit db makemigrations create_accounts \
   --model github.com/acme/shop/internal/product.Product
 ```
 
+> **Known issue:** each invocation's `--model` list is the *entire* desired
+> schema, not an addition to previous migrations. If an earlier migration
+> covered `Account` and a later `makemigrations` call for a new feature only
+> lists `Product`, Atlas treats `Account`'s table as no longer wanted and
+> writes a migration that **drops it** — there is no persisted registry of
+> previously-migrated models yet. Always repeat every model that should still
+> exist, including ones from earlier migrations, in every
+> `gombit db makemigrations` call. Read the generated SQL before running
+> `gombit db migrate`; an unexpected `DROP TABLE` is the symptom.
+
 The command writes a temporary Atlas Program Mode loader under `.gombit`,
 passes all supplied model types to `gormschema.New(driver).Load(...)`, writes
 the generated SQL schema to a temporary `schema.sql`, and then runs:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -244,7 +244,10 @@ curl -s http://127.0.0.1:8080/api/v1/tasks
 {"data":[],"meta":{"page":1,"per_page":20,"total":0}}
 ```
 
-That shape is the D10 envelope: success is `{"data": ..., "meta"?: ...}`.
+That shape is the D10 envelope: success is `{"data": ..., "meta"?: ...}`. Your
+own response also carries a `$schema` field pointing at its JSON Schema
+(Huma's doing, on every response) — every JSON example in this tutorial
+omits it for brevity.
 
 ---
 
@@ -295,10 +298,12 @@ Errors are constructed with `contract` helpers rather than raw status codes:
 return nil, contract.WithContext(ctx, contract.NotFound("task not found"))
 ```
 
-Inspect what you've mounted:
+Inspect what you've mounted. Bare `gombit routes` only prints framework
+routes (`/livez`, `/docs`, and so on) — pass `--url` to see the feature
+routes `gombit dev` is actually serving:
 
 ```bash
-gombit routes
+gombit routes --url http://127.0.0.1:8080
 gombit openapi generate --out openapi.json
 ```
 
@@ -323,12 +328,16 @@ overwritten.
 The important command is the drift check:
 
 ```bash
-gombit client check
+gombit client check --url http://127.0.0.1:8080/openapi.json
 ```
 
-It fails if the committed client no longer matches the spec. Wire it into your
-own CI: it's what stops a backend change from silently breaking the frontend.
-`gombit dev` regenerates the client automatically while it's running.
+It fails if the committed client no longer matches the live contract. `gombit`
+is a separately compiled binary, so outside the framework's own repository it
+has no Go-level access to your API — `--url` fetches the live `/openapi.json`
+from a running app (`gombit dev` or your deployed API) instead. Wire it into
+your own CI against a running instance of your app: it's what stops a backend
+change from silently breaking the frontend. `gombit dev` regenerates the
+client automatically while it's running.
 
 **✅ Checkpoint** — `frontend/src/api/generated/schema.ts` contains a task
 type with `title` and `done`.
@@ -348,13 +357,21 @@ TypeScript error rather than a runtime surprise.
 
 **Server validation maps into the form.** The `fields` object from the D10
 error envelope is fed into React Hook Form, so field errors from Go render next
-to the right inputs — one validation source of truth, not two.
+to the right inputs — one validation source of truth, not two. Required
+fields also get a client-side rule with its own message (`"Title is
+required"`), so an empty submit shows text immediately, before round-tripping
+to the server at all.
 
 > **No secrets in frontend source.** Anything under `VITE_*` is compiled into
 > the bundle and is public. Treat it that way.
 
-**✅ Checkpoint** — the task list renders at <http://127.0.0.1:5173>, and
-submitting an empty title shows an inline error from the server.
+You scaffolded with `--auth cookie`, so `RequireAuth` guards every route
+except `/login` — visiting `/tasks` right now redirects there. The next
+chapter sets up a login; come back and finish this checkpoint after it.
+
+**✅ Checkpoint** — once you can log in (chapter 8), the task list renders at
+<http://127.0.0.1:5173>, and submitting an empty title shows a "Title is
+required" inline error next to the field.
 
 ---
 
@@ -364,16 +381,22 @@ You scaffolded with `--auth cookie`, so sessions are HttpOnly cookies plus CSRF
 double-submit. (The API default, `--auth jwt`, keeps the access token **in
 memory — never `localStorage`**.)
 
-Create an admin account:
+`gombit new` already wrote a random `GOMBIT_JWT_SECRET` into `.env` (cookie
+mode signs its CSRF token with the same secret), and every `gombit` command
+run from this directory — including the `gombit dev` you started in chapter
+2 — loads `.env` automatically. Create an admin account:
 
 ```bash
-export GOMBIT_JWT_SECRET="$(openssl rand -hex 32)"
 gombit createsuperuser --email admin@example.com
 ```
 
-The secret is required: without it Bearer auth is unmounted and nobody could
-log in. `createsuperuser` prompts for the password when you leave `--password`
-off — better than putting it in your shell history.
+The secret is required: without it Bearer auth stays unmounted and nobody
+could log in. `createsuperuser` prompts for the password when you leave
+`--password` off — better than putting it in your shell history.
+
+> `.env` is gitignored and never read outside this directory. A real
+> deployment has no `.env` file and sets `GOMBIT_JWT_SECRET` through its own
+> environment instead — see [Ship it](#11-ship-it).
 
 Under cookie auth, **every state-changing request needs a CSRF token**. The
 full flow:
@@ -525,20 +548,24 @@ Details: [admin.md](admin.md) and [ADR-013](adr/013-runtime-generic-admin.md).
 Django's `manage.py` equivalent:
 
 ```bash
-gombit make command backfill_done
+gombit make command backfill_done --package task
 ```
 
-This writes a Cobra command into your feature package and registers it on
-**your** CLI at `cmd/gombit`, again via `go/ast`. Run it:
+`--package task` writes into your existing feature package
+(`internal/task/`) instead of the default `internal/commands/`, and
+registers the command on **your** CLI at `cmd/gombit`, again via `go/ast`.
+The command name is normalized to kebab-case for the CLI regardless of how
+you typed it, so `backfill_done` becomes the runnable `backfill-done`. Run
+it:
 
 ```bash
-go run ./cmd/gombit backfill_done
+go run ./cmd/gombit backfill-done
 ```
 
 Your binary keeps the whole framework tree — `db`, `routes`, `doctor`,
 `createsuperuser` — plus your own commands.
 
-**✅ Checkpoint** — `go run ./cmd/gombit --help` lists `backfill_done`.
+**✅ Checkpoint** — `go run ./cmd/gombit --help` lists `backfill-done`.
 
 ---
 

--- a/goldentest/testdata/golden/make-command/frontend/src/pages/LoginPage.tsx
+++ b/goldentest/testdata/golden/make-command/frontend/src/pages/LoginPage.tsx
@@ -67,12 +67,12 @@ export function LoginPage() {
       >
         <label>
           Email
-          <input type="email" autoComplete="username" {...register("email", { required: true })} />
+          <input type="email" autoComplete="username" {...register("email", { required: "Email is required" })} />
         </label>
         {errors.email?.message ? <p>{errors.email.message}</p> : null}
         <label>
           Password
-          <input type="password" autoComplete="current-password" {...register("password", { required: true })} />
+          <input type="password" autoComplete="current-password" {...register("password", { required: "Password is required" })} />
         </label>
         {errors.password?.message ? <p>{errors.password.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>

--- a/goldentest/testdata/golden/make-command/frontend/src/pages/ProductFormPage.tsx
+++ b/goldentest/testdata/golden/make-command/frontend/src/pages/ProductFormPage.tsx
@@ -49,7 +49,7 @@ export function ProductFormPage() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <label>
           Name
-          <input type="text" {...register("name", { required: true })} />
+          <input type="text" {...register("name", { required: "Name is required" })} />
         </label>
         {errors.name?.message ? <p>{errors.name.message}</p> : null}
         <label>

--- a/goldentest/testdata/golden/make-resource/frontend/src/book/form.tsx
+++ b/goldentest/testdata/golden/make-resource/frontend/src/book/form.tsx
@@ -59,7 +59,7 @@ export function BookFormPage() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <label>
           Title
-          <input type="text" {...register("title", { required: true })} />
+          <input type="text" {...register("title", { required: "Title is required" })} />
         </label>
         {errors.title?.message ? <p>{errors.title.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>

--- a/goldentest/testdata/golden/make-resource/frontend/src/pages/LoginPage.tsx
+++ b/goldentest/testdata/golden/make-resource/frontend/src/pages/LoginPage.tsx
@@ -67,12 +67,12 @@ export function LoginPage() {
       >
         <label>
           Email
-          <input type="email" autoComplete="username" {...register("email", { required: true })} />
+          <input type="email" autoComplete="username" {...register("email", { required: "Email is required" })} />
         </label>
         {errors.email?.message ? <p>{errors.email.message}</p> : null}
         <label>
           Password
-          <input type="password" autoComplete="current-password" {...register("password", { required: true })} />
+          <input type="password" autoComplete="current-password" {...register("password", { required: "Password is required" })} />
         </label>
         {errors.password?.message ? <p>{errors.password.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>

--- a/goldentest/testdata/golden/make-resource/frontend/src/pages/ProductFormPage.tsx
+++ b/goldentest/testdata/golden/make-resource/frontend/src/pages/ProductFormPage.tsx
@@ -49,7 +49,7 @@ export function ProductFormPage() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <label>
           Name
-          <input type="text" {...register("name", { required: true })} />
+          <input type="text" {...register("name", { required: "Name is required" })} />
         </label>
         {errors.name?.message ? <p>{errors.name.message}</p> : null}
         <label>

--- a/goldentest/testdata/golden/new-cookie/frontend/src/pages/LoginPage.tsx
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/pages/LoginPage.tsx
@@ -73,12 +73,12 @@ export function LoginPage() {
       >
         <label>
           Email
-          <input type="email" autoComplete="username" {...register("email", { required: true })} />
+          <input type="email" autoComplete="username" {...register("email", { required: "Email is required" })} />
         </label>
         {errors.email?.message ? <p>{errors.email.message}</p> : null}
         <label>
           Password
-          <input type="password" autoComplete="current-password" {...register("password", { required: true })} />
+          <input type="password" autoComplete="current-password" {...register("password", { required: "Password is required" })} />
         </label>
         {errors.password?.message ? <p>{errors.password.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>

--- a/goldentest/testdata/golden/new-cookie/frontend/src/pages/ProductFormPage.tsx
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/pages/ProductFormPage.tsx
@@ -49,7 +49,7 @@ export function ProductFormPage() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <label>
           Name
-          <input type="text" {...register("name", { required: true })} />
+          <input type="text" {...register("name", { required: "Name is required" })} />
         </label>
         {errors.name?.message ? <p>{errors.name.message}</p> : null}
         <label>

--- a/goldentest/testdata/golden/new-mui/frontend/src/pages/LoginPage.tsx
+++ b/goldentest/testdata/golden/new-mui/frontend/src/pages/LoginPage.tsx
@@ -98,7 +98,7 @@ export function LoginPage() {
           <Controller
             name="email"
             control={control}
-            rules={{ required: true }}
+            rules={{ required: "Email is required" }}
             render={({ field, fieldState }) => (
               <TextField
                 {...field}
@@ -115,7 +115,7 @@ export function LoginPage() {
           <Controller
             name="password"
             control={control}
-            rules={{ required: true }}
+            rules={{ required: "Password is required" }}
             render={({ field, fieldState }) => (
               <TextField
                 {...field}

--- a/goldentest/testdata/golden/new-mui/frontend/src/pages/ProductFormPage.tsx
+++ b/goldentest/testdata/golden/new-mui/frontend/src/pages/ProductFormPage.tsx
@@ -55,7 +55,7 @@ export function ProductFormPage() {
           <Controller
             name="name"
             control={control}
-            rules={{ required: true }}
+            rules={{ required: "Name is required" }}
             render={({ field, fieldState }) => (
               <TextField
                 {...field}

--- a/goldentest/testdata/golden/new/frontend/src/pages/LoginPage.tsx
+++ b/goldentest/testdata/golden/new/frontend/src/pages/LoginPage.tsx
@@ -67,12 +67,12 @@ export function LoginPage() {
       >
         <label>
           Email
-          <input type="email" autoComplete="username" {...register("email", { required: true })} />
+          <input type="email" autoComplete="username" {...register("email", { required: "Email is required" })} />
         </label>
         {errors.email?.message ? <p>{errors.email.message}</p> : null}
         <label>
           Password
-          <input type="password" autoComplete="current-password" {...register("password", { required: true })} />
+          <input type="password" autoComplete="current-password" {...register("password", { required: "Password is required" })} />
         </label>
         {errors.password?.message ? <p>{errors.password.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>

--- a/goldentest/testdata/golden/new/frontend/src/pages/ProductFormPage.tsx
+++ b/goldentest/testdata/golden/new/frontend/src/pages/ProductFormPage.tsx
@@ -49,7 +49,7 @@ export function ProductFormPage() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <label>
           Name
-          <input type="text" {...register("name", { required: true })} />
+          <input type="text" {...register("name", { required: "Name is required" })} />
         </label>
         {errors.name?.message ? <p>{errors.name.message}</p> : null}
         <label>

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -513,7 +513,7 @@ func renderFormField(field Field) string {
 	case FieldText:
 		b.WriteString("          <textarea {...register(\"" + field.JSONName + "\"")
 		if field.Required {
-			b.WriteString(", { required: true }")
+			b.WriteString(", { required: \"" + field.GoName + " is required\" }")
 		}
 		b.WriteString(")} />\n")
 	case FieldBool:
@@ -523,7 +523,7 @@ func renderFormField(field Field) string {
 	default:
 		b.WriteString("          <input type=\"text\" {...register(\"" + field.JSONName + "\"")
 		if field.Required {
-			b.WriteString(", { required: true }")
+			b.WriteString(", { required: \"" + field.GoName + " is required\" }")
 		}
 		b.WriteString(")} />\n")
 	}
@@ -752,7 +752,7 @@ func renderMUIFormField(field Field) string {
 	var b strings.Builder
 	rules := ""
 	if field.Required && field.Type != FieldBool {
-		rules = " rules={{ required: true }}"
+		rules = " rules={{ required: \"" + field.GoName + " is required\" }}"
 	}
 	b.WriteString("          <Controller\n")
 	b.WriteString("            name=\"" + field.JSONName + "\"\n")

--- a/resourcegen/generate_test.go
+++ b/resourcegen/generate_test.go
@@ -110,6 +110,12 @@ func TestGenerateBookFeaturePackage(t *testing.T) {
 	if !strings.Contains(formTS, "applyContractErrors") || !strings.Contains(formTS, "setError") {
 		t.Fatal("form.tsx does not map D10 field errors through applyContractErrors")
 	}
+	if strings.Contains(formTS, "required: true") {
+		t.Fatal("form.tsx required rule has no message; submitting an empty field will show no error text")
+	}
+	if !strings.Contains(formTS, `required: "Title is required"`) {
+		t.Fatalf("form.tsx missing a required-field error message:\n%s", formTS)
+	}
 	resources := readFile(t, filepath.Join(appDir, "frontend", "src", "resources.tsx"))
 	if !strings.Contains(resources, "generatedResourceRoutes") || !strings.Contains(resources, "BookListPage") {
 		t.Fatal("resources.tsx missing React Router registry for Book")
@@ -393,6 +399,12 @@ func TestGenerateMUIResourcePages(t *testing.T) {
 		if !strings.Contains(formTS, want) {
 			t.Fatalf("MUI form.tsx missing %q", want)
 		}
+	}
+	if strings.Contains(formTS, "required: true") {
+		t.Fatal("MUI form.tsx required rule has no message; submitting an empty field will show no error text")
+	}
+	if !strings.Contains(formTS, `required: "Title is required"`) {
+		t.Fatalf("MUI form.tsx missing a required-field error message:\n%s", formTS)
 	}
 }
 

--- a/scaffold/generate.go
+++ b/scaffold/generate.go
@@ -290,6 +290,25 @@ func newJWTSecret() (string, error) {
 	return hex.EncodeToString(buf), nil
 }
 
+// envExampleJWTComment is the comment block .env.example carries above its
+// GOMBIT_JWT_SECRET line. It is accurate there: DevelopmentJWTPlaceholder
+// really is shorter than MinProductionJWTSecretLength. withGeneratedDotEnv
+// swaps it for dotEnvJWTComment in the generated .env, where the value is a
+// full-length random secret instead, so the same claim would be false.
+const envExampleJWTComment = "" +
+	"# HMAC secret shared by Bearer access JWTs and (in cookie mode) the CSRF\n" +
+	"# double-submit signature. This development placeholder is shorter than 32\n" +
+	"# characters and is rejected in production (Appendix C). `gombit new` also\n" +
+	"# writes a gitignored `.env` with a per-project random secret. Never put\n" +
+	"# this in VITE_*.\n"
+
+// dotEnvJWTComment replaces envExampleJWTComment in the generated .env.
+const dotEnvJWTComment = "" +
+	"# HMAC secret shared by Bearer access JWTs and (in cookie mode) the CSRF\n" +
+	"# double-submit signature. gombit new generated this as a random,\n" +
+	"# per-project secret — do not commit it or reuse it across environments.\n" +
+	"# Never put this in VITE_*.\n"
+
 func withGeneratedDotEnv(files []renderedFile, secret string) ([]renderedFile, error) {
 	var example []byte
 	for _, file := range files {
@@ -306,7 +325,11 @@ func withGeneratedDotEnv(files []renderedFile, secret string) ([]renderedFile, e
 	if bytes.Equal(replaced, example) {
 		return nil, errors.New("scaffold: JWT placeholder missing from .env.example")
 	}
-	files = append(files, renderedFile{relPath: ".env", content: replaced})
+	commentReplaced := bytes.Replace(replaced, []byte(envExampleJWTComment), []byte(dotEnvJWTComment), 1)
+	if bytes.Equal(commentReplaced, replaced) {
+		return nil, errors.New("scaffold: JWT comment block missing from .env.example")
+	}
+	files = append(files, renderedFile{relPath: ".env", content: commentReplaced})
 	sort.Slice(files, func(i, j int) bool {
 		return files[i].relPath < files[j].relPath
 	})

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -132,6 +132,12 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	if config.IsInsecureJWTSecret(secret) {
 		t.Fatal(".env JWT secret is a known insecure placeholder")
 	}
+	if strings.Contains(dotenv, "shorter than 32") {
+		t.Fatal(".env JWT comment must not claim the generated secret is shorter than 32 characters")
+	}
+	if !strings.Contains(dotenv, "gombit new generated this as a random") {
+		t.Fatalf(".env JWT comment was not swapped for the per-project-secret version:\n%s", dotenv)
+	}
 	if !strings.Contains(stdout.String(), "create demo/go.mod") {
 		t.Fatalf("stdout = %q, want created file list", stdout.String())
 	}
@@ -228,6 +234,19 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	}
 	if strings.Contains(strings.ToLower(loginPage), "localstorage") {
 		t.Fatal("LoginPage.tsx uses localStorage")
+	}
+	if strings.Contains(loginPage, "required: true") {
+		t.Fatal("LoginPage.tsx required rule has no message; submitting an empty field will show no error text")
+	}
+	if !strings.Contains(loginPage, `required: "Email is required"`) || !strings.Contains(loginPage, `required: "Password is required"`) {
+		t.Fatalf("LoginPage.tsx missing required-field error messages:\n%s", loginPage)
+	}
+	productFormPage := readFile(t, filepath.Join(dest, "frontend", "src", "pages", "ProductFormPage.tsx"))
+	if strings.Contains(productFormPage, "required: true") {
+		t.Fatal("ProductFormPage.tsx required rule has no message")
+	}
+	if !strings.Contains(productFormPage, `required: "Name is required"`) {
+		t.Fatalf("ProductFormPage.tsx missing required-field error message:\n%s", productFormPage)
 	}
 	appClient := readFile(t, filepath.Join(dest, "frontend", "src", "api", "client.ts"))
 	if !strings.Contains(appClient, "refreshInFlight") {
@@ -423,6 +442,19 @@ func TestGenerateRecordsAuthAndUIChoices(t *testing.T) {
 	}
 	if strings.Contains(strings.ToLower(login), "localstorage") {
 		t.Fatal("cookie + mui LoginPage.tsx uses localStorage")
+	}
+	if strings.Contains(login, "required: true") {
+		t.Fatal("cookie + mui LoginPage.tsx required rule has no message")
+	}
+	if !strings.Contains(login, `required: "Email is required"`) || !strings.Contains(login, `required: "Password is required"`) {
+		t.Fatalf("cookie + mui LoginPage.tsx missing required-field error messages:\n%s", login)
+	}
+	productForm := readFile(t, filepath.Join(workDir, "shop", "frontend", "src", "pages", "ProductFormPage.tsx"))
+	if strings.Contains(productForm, "required: true") {
+		t.Fatal("cookie + mui ProductFormPage.tsx required rule has no message")
+	}
+	if !strings.Contains(productForm, `required: "Name is required"`) {
+		t.Fatalf("cookie + mui ProductFormPage.tsx missing required-field error message:\n%s", productForm)
 	}
 	client := readFile(t, filepath.Join(workDir, "shop", "frontend", "src", "api", "client.ts"))
 	if !strings.Contains(client, "X-CSRF-Token") {

--- a/scaffold/templates/frontend/src/pages/LoginPage.tsx.tmpl
+++ b/scaffold/templates/frontend/src/pages/LoginPage.tsx.tmpl
@@ -115,7 +115,7 @@ export function LoginPage() {
           <Controller
             name="email"
             control={control}
-            rules={{"{{"}} required: true }}
+            rules={{"{{"}} required: "Email is required" }}
             render={({ field, fieldState }) => (
               <TextField
                 {...field}
@@ -132,7 +132,7 @@ export function LoginPage() {
           <Controller
             name="password"
             control={control}
-            rules={{"{{"}} required: true }}
+            rules={{"{{"}} required: "Password is required" }}
             render={({ field, fieldState }) => (
               <TextField
                 {...field}
@@ -170,12 +170,12 @@ export function LoginPage() {
       >
         <label>
           Email
-          <input type="email" autoComplete="username" {...register("email", { required: true })} />
+          <input type="email" autoComplete="username" {...register("email", { required: "Email is required" })} />
         </label>
         {errors.email?.message ? <p>{errors.email.message}</p> : null}
         <label>
           Password
-          <input type="password" autoComplete="current-password" {...register("password", { required: true })} />
+          <input type="password" autoComplete="current-password" {...register("password", { required: "Password is required" })} />
         </label>
         {errors.password?.message ? <p>{errors.password.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>

--- a/scaffold/templates/frontend/src/pages/ProductFormPage.tsx.tmpl
+++ b/scaffold/templates/frontend/src/pages/ProductFormPage.tsx.tmpl
@@ -56,7 +56,7 @@ export function ProductFormPage() {
           <Controller
             name="name"
             control={control}
-            rules={{"{{"}} required: true }}
+            rules={{"{{"}} required: "Name is required" }}
             render={({ field, fieldState }) => (
               <TextField
                 {...field}
@@ -108,7 +108,7 @@ export function ProductFormPage() {
       <form onSubmit={handleSubmit(onSubmit)}>
         <label>
           Name
-          <input type="text" {...register("name", { required: true })} />
+          <input type="text" {...register("name", { required: "Name is required" })} />
         </label>
         {errors.name?.message ? <p>{errors.name.message}</p> : null}
         <label>


### PR DESCRIPTION
## Summary

Ran `docs/tutorial.md` end to end in a sandbox (scaffold → migrate → resource → contract → client → frontend → auth → admin → management command → embed build), verifying each checkpoint against a real running app rather than just reading the docs. This fixes everything found that had a safe, scoped fix; two deeper problems are filed as follow-up issues instead of shipped half-working (see Scope notes).

- **`.env` is now actually loaded.** `gombit new` writes `.env` with a random `GOMBIT_JWT_SECRET`, but nothing read it — `config.Load()` only reads real process env vars. Following the tutorial as written (`gombit dev` in one terminal, `createsuperuser` in another) left Bearer/CSRF auth silently unmounted, so an unauthenticated `POST` with no CSRF header succeeded instead of being rejected. `config.Load()` now applies `.env` from the cwd first, without overriding anything already set.
- **`gombit client check` works outside this repository.** Its defaults pointed at `examples/client/...` (this repo's own fixtures), and even with correct flags it always compared against the framework's own `SampleApp()` — a compiled `gombit` binary has no Go-level access to a generated app's actual API. Defaults now match `client generate`, and `--url` fetches a live `/openapi.json` for generated apps to check against.
- **Generated forms show a real validation message.** Every required-field rule was `{ required: true }` with no message, so an empty submit showed a red-bordered input with no text — and since the client-side rule fires first, the server's D10 field-error mapping the form is wired for never even got exercised. Fixed in `gombit make resource` output and the base scaffold's Login/Product forms.
- **`.env`'s JWT secret comment matches its value.** Was copy-pasted from `.env.example`, where "shorter than 32 characters" is true; false for the real 64-char secret `.env` actually gets.
- **Docs corrections**: `gombit routes` needs `--url` to show feature routes (ch.5); `gombit make command backfill_done` registers as `backfill-done`, not the literal typed name (ch.10); ch.7's "task list renders" checkpoint isn't actually checkable until ch.8's login exists under `--auth cookie`; `installation.md`'s `gombit version` example is release-archive output, not what `go install` produces; every JSON example omits the `$schema` field Huma actually adds.

## Acceptance criteria

No linked backlog issue — see above.

## Scope notes

Two deeper, harder problems surfaced while fixing the above are **not** fixed here, and are filed for follow-up instead:

- **#96** — `gombit db migrate` fails with `table already exists` after `gombit make resource --force`, because `AutoMigrate` (which runs at every app startup) and Atlas's tracked migration history can silently diverge.
- **#97** — found while attempting to fix #96: `gombit db makemigrations <name> --model X` treats each invocation's model list as the *complete* desired schema. A later migration that doesn't repeat an earlier model's `--model` flag **drops that model's table**. This is a pre-existing hazard independent of #96, and a real fix for either needs to solve it first (e.g. a persisted model registry) — bigger than fits this PR. I attempted a scaffold-time mitigation, confirmed by testing that it doesn't work and actively triggers #97 earlier (at tutorial chapter 3), and reverted it rather than ship something that causes silent `DROP TABLE`s.

## Validation

- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — 0 issues
- [x] Project `code-review` skill run against this diff — approved
- [x] Manually re-ran the affected tutorial steps against a locally built binary (via `go mod edit -replace` per `installation.md`'s documented dev workflow): `.env`-driven `createsuperuser` with no manual export, `gombit dev` correctly rejecting an unauthenticated CSRF-less POST, `client check --url` reporting no drift against a live server, and the fixed form template producing a visible "Title is required" / "Email is required" message in the browser.
- [x] `go test ./goldentest -update`, diff reviewed — only the intended `required: true` → `required: "X is required"` changes

## Working agreement checklist

- [ ] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A, no DB-touching code in this PR (the migration work was reverted, see Scope notes)
- [x] Stable features ship docs and appear in an example app — docs updated alongside each code fix
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests — N/A, no extraction
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — template string changes only, no generator write/overwrite logic touched
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no API/contract changes
- [x] No secrets in generated frontend source; `VITE_*` is treated as public — unaffected
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep — confirmed; deferred the two harder problems rather than scope-creep into a migration-system redesign
- [x] This PR links its issue and states which acceptance criteria it satisfies — no backlog issue exists for this QA pass; explained above, and the two new issues it surfaced are filed and linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)