### PR TITLE
fix: persisted migration model registry (fixes #97)

### DIFF
--- a/cli/db.go
+++ b/cli/db.go
@@ -67,13 +67,17 @@ func newMakeMigrationsCommand(stdout io.Writer, stderr io.Writer) *cobra.Command
 			if err != nil {
 				return err
 			}
-			models := make([]migrations.Model, 0, len(modelValues))
-			for _, value := range modelValues {
-				model, err := migrations.ParseModel(value)
-				if err != nil {
-					return err
-				}
-				models = append(models, model)
+			models, err := parseModels(modelValues)
+			if err != nil {
+				return err
+			}
+			forgetValues, err := cmd.Flags().GetStringArray("forget-model")
+			if err != nil {
+				return err
+			}
+			forgetModels, err := parseModels(forgetValues)
+			if err != nil {
+				return err
 			}
 			return migrations.MakeMigrations(cmd.Context(), migrations.Options{
 				WorkDir:      ".",
@@ -82,6 +86,7 @@ func newMakeMigrationsCommand(stdout io.Writer, stderr io.Writer) *cobra.Command
 				MigrationDir: migrationDir,
 				AtlasBinary:  atlasBin,
 				Models:       models,
+				ForgetModels: forgetModels,
 				Stdout:       stdout,
 				Stderr:       stderr,
 			})
@@ -90,8 +95,21 @@ func newMakeMigrationsCommand(stdout io.Writer, stderr io.Writer) *cobra.Command
 	cmd.Flags().String("driver", "", "database driver: sqlite, postgres, or mysql")
 	cmd.Flags().String("dir", "database/migrations", "migration directory")
 	cmd.Flags().String("atlas-bin", "atlas", "Atlas CLI binary path")
-	cmd.Flags().StringArray("model", nil, "GORM model import path and type, e.g. github.com/acme/app/internal/product.Product; repeat for multiple models")
+	cmd.Flags().StringArray("model", nil, "GORM model import path and type, e.g. github.com/acme/app/internal/product.Product; repeat for multiple models. Merged with models already registered from earlier makemigrations runs — you don't need to repeat them.")
+	cmd.Flags().StringArray("forget-model", nil, "GORM model import path and type to stop tracking, proposing a DROP for its table; repeat for multiple models")
 	return cmd
+}
+
+func parseModels(values []string) ([]migrations.Model, error) {
+	models := make([]migrations.Model, 0, len(values))
+	for _, value := range values {
+		model, err := migrations.ParseModel(value)
+		if err != nil {
+			return nil, err
+		}
+		models = append(models, model)
+	}
+	return models, nil
 }
 
 func newMigrateCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {

--- a/cli/db_test.go
+++ b/cli/db_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestMakeMigrationsRejectsInvalidForgetModel(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err := ExecuteRoot(context.Background(), NewRoot(stdout, stderr), []string{
+		"db", "makemigrations", "create_products",
+		"--model", "github.com/example/app/internal/product.Product",
+		"--forget-model", "not-a-valid-spec",
+	})
+	if err == nil {
+		t.Fatal("gombit db makemigrations --forget-model not-a-valid-spec: error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "import/path.TypeName") {
+		t.Fatalf("error = %q, want it to explain the model spec format", err)
+	}
+}
+
+func TestMakeMigrationsHelpDescribesForgetModel(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	err := ExecuteRoot(context.Background(), NewRoot(stdout, stderr), []string{"db", "makemigrations", "--help"})
+	if err != nil {
+		t.Fatalf("gombit db makemigrations --help: %v", err)
+	}
+	out := stdout.String() + stderr.String()
+	if !strings.Contains(out, "--forget-model") {
+		t.Fatalf("help missing --forget-model:\n%s", out)
+	}
+	if !strings.Contains(out, "Merged with models already registered") {
+		t.Fatalf("help missing note about the persisted model registry:\n%s", out)
+	}
+}

--- a/cmd/gombit/main_test.go
+++ b/cmd/gombit/main_test.go
@@ -103,7 +103,19 @@ func TestRunMakeMigrationsUsesConfiguredDriver(t *testing.T) {
 func TestRunMakeMigrationsRequiresModel(t *testing.T) {
 	stubConfig(t, config.Default())
 
-	err := run(context.Background(), []string{
+	// db makemigrations always targets WorkDir "." — chdir into an isolated
+	// temp dir so this doesn't create database/migrations in the repo.
+	workDir := t.TempDir()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+
+	err = run(context.Background(), []string{
 		"db",
 		"makemigrations",
 		"create_products",
@@ -113,7 +125,7 @@ func TestRunMakeMigrationsRequiresModel(t *testing.T) {
 	if err == nil {
 		t.Fatal("run() error = nil, want missing model error")
 	}
-	if !strings.Contains(err.Error(), "at least one model") {
+	if !strings.Contains(err.Error(), "no models to migrate") {
 		t.Fatalf("run() error = %q, want missing model message", err)
 	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -328,9 +328,11 @@ that file are not preserved.
 Gombit does not invent a migration DSL. The generated GORM model is
 Atlas-loader ready. If the `atlas` binary is on `PATH`, `make resource`
 attempts `migrations.MakeMigrations` with every `&pkg.Type{}` already
-registered in `internal/platform` AutoMigrate plus the new model — Atlas
-migrate diff treats that slice as the entire desired schema, so omitting
-existing tables would emit DROP. If Atlas is missing from `PATH`, SQL is
+registered in `internal/platform` AutoMigrate plus the new model, merged with
+`database/migrations/models.json` (see
+[migrations.md](migrations.md#generate-a-migration)) — so a model that isn't
+in the `AutoMigrate` list for some reason but is still tracked in the
+registry isn't dropped either. If Atlas is missing from `PATH`, SQL is
 skipped and the command prints:
 
 ```sh

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -21,25 +21,38 @@ supplied with `--atlas-bin`:
 curl -sSf https://atlasgo.sh | sh -s -- --community
 ```
 
-Repeat `--model` for every GORM model that should be part of the desired
-schema:
+You only need to name what's new. `gombit db makemigrations` persists every
+model it's ever seen for a given `--dir` in `database/migrations/models.json`
+and merges new `--model` flags into that set — it is not the entire desired
+schema by itself, just what this invocation is adding. Adding a second
+feature later only needs its own model:
 
 ```sh
 gombit db makemigrations create_accounts \
   --driver postgres \
-  --model github.com/acme/shop/internal/account.Account \
-  --model github.com/acme/shop/internal/product.Product
+  --model github.com/acme/shop/internal/account.Account
 ```
 
-> **Known issue:** each invocation's `--model` list is the *entire* desired
-> schema, not an addition to previous migrations. If an earlier migration
-> covered `Account` and a later `makemigrations` call for a new feature only
-> lists `Product`, Atlas treats `Account`'s table as no longer wanted and
-> writes a migration that **drops it** — there is no persisted registry of
-> previously-migrated models yet. Always repeat every model that should still
-> exist, including ones from earlier migrations, in every
-> `gombit db makemigrations` call. Read the generated SQL before running
-> `gombit db migrate`; an unexpected `DROP TABLE` is the symptom.
+`product.Product` from the first migration is carried forward automatically;
+this does not generate a `DROP TABLE product`. Commit `models.json` alongside
+the SQL files it describes — like `atlas.sum`, it's part of the migration
+history, not build output. Atlas itself ignores it (only `*.sql` and
+`atlas.sum` are meaningful to `atlas migrate diff`/`apply`), and `gombit db
+status`/`migrate` skip it the same way they already skip `atlas.sum`.
+
+To retire a model — the table is genuinely going away — say so explicitly
+instead of just omitting it, so Atlas proposes the drop on purpose:
+
+```sh
+gombit db makemigrations drop_legacy_widget \
+  --driver postgres \
+  --forget-model github.com/acme/shop/internal/widget.Widget
+```
+
+`--forget-model` removes the entry from `models.json` and from this
+invocation's desired schema, so the generated migration is the intentional
+`DROP TABLE` — the only way to get one, now that the registry means a model
+is never dropped by accident just because a later call didn't repeat it.
 
 The command writes a temporary Atlas Program Mode loader under `.gombit`,
 passes all supplied model types to `gormschema.New(driver).Load(...)`, writes
@@ -232,9 +245,11 @@ same three drivers.
 
 ## Model Registration
 
-M2-1 keeps model enumeration explicit. Generated apps should pass feature
-package models from `internal/<feature>` using repeated `--model` flags until
-later generator work adds an application-owned registry.
+M2-1 keeps model enumeration explicit: pass feature package models from
+`internal/<feature>` with `--model` flags, one per `gombit db makemigrations`
+call for whatever's new. `database/migrations/models.json` is the persisted
+registry of every model named so far (see [Generate A
+Migration](#generate-a-migration)) — you don't repeat earlier ones.
 
 The model spec format is:
 

--- a/migrations/makemigrations.go
+++ b/migrations/makemigrations.go
@@ -25,8 +25,8 @@ var migrationNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]*$`)
 
 // Model identifies one GORM model type imported by the generated Atlas loader.
 type Model struct {
-	ImportPath string
-	TypeName   string
+	ImportPath string `json:"import_path"`
+	TypeName   string `json:"type_name"`
 }
 
 // Options configures MakeMigrations.
@@ -36,7 +36,16 @@ type Options struct {
 	Driver       config.DatabaseDriver
 	MigrationDir string
 	AtlasBinary  string
-	Models       []Model
+	// Models are the GORM models this invocation is declaring. They are
+	// merged with whatever is already in the persisted registry
+	// (RegistryPath) — not the entire desired schema by themselves — so a
+	// migration for one new model does not implicitly drop tables for
+	// models used in earlier migrations.
+	Models []Model
+	// ForgetModels removes models from the persisted registry (and this
+	// invocation's desired schema), the explicit way to let Atlas propose
+	// dropping a table that's genuinely going away.
+	ForgetModels []Model
 	Stdout       io.Writer
 	Stderr       io.Writer
 
@@ -94,6 +103,23 @@ func MakeMigrations(ctx context.Context, opts Options) error {
 	if !filepath.IsAbs(migrationDir) {
 		migrationDir = filepath.Join(absWorkDir, migrationDir)
 	}
+
+	// Loaded (and the "nothing to do" case rejected) before MkdirAll, so an
+	// invocation that ends up with nothing to migrate doesn't leave behind an
+	// empty migration directory as a side effect of failing.
+	registered, err := LoadRegistry(migrationDir)
+	if err != nil {
+		return err
+	}
+	// allModels, not opts.Models, is the desired schema: it also carries
+	// forward every model an earlier makemigrations call registered, so this
+	// invocation only needs to name what's new. Without this, Atlas would
+	// see anything not repeated here as schema drift and drop it (#97).
+	allModels := SubtractModels(MergeModels(registered, opts.Models), opts.ForgetModels)
+	if len(allModels) == 0 {
+		return errors.New("migrations: no models to migrate: nothing in the registry and no --model given")
+	}
+
 	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
 		return fmt.Errorf("migrations: create migration dir: %w", err)
 	}
@@ -122,7 +148,7 @@ func MakeMigrations(ctx context.Context, opts Options) error {
 	if err := os.MkdirAll(loaderDir, 0o750); err != nil {
 		return fmt.Errorf("migrations: create loader dir: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(loaderDir, "main.go"), []byte(loaderSource(opts.Driver, opts.Models)), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(loaderDir, "main.go"), []byte(loaderSource(opts.Driver, allModels)), 0o600); err != nil {
 		return fmt.Errorf("migrations: write loader: %w", err)
 	}
 
@@ -157,6 +183,9 @@ func MakeMigrations(ctx context.Context, opts Options) error {
 	}
 	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
 		return fmt.Errorf("migrations: atlas migrate diff: %w", err)
+	}
+	if err := SaveRegistry(migrationDir, allModels); err != nil {
+		return err
 	}
 	return nil
 }
@@ -195,13 +224,26 @@ func validateOptions(opts Options) error {
 	default:
 		return fmt.Errorf("migrations: unsupported driver %q", opts.Driver)
 	}
-	if len(opts.Models) == 0 {
-		return errors.New("migrations: at least one model is required")
-	}
+	// A migration can validly carry zero --model flags when the persisted
+	// registry already has entries (this run only picks up field changes on
+	// already-known models), so "no models at all" is checked later against
+	// the merged set, not here.
 	for _, model := range opts.Models {
-		if strings.TrimSpace(model.ImportPath) == "" || !goIdentifierPattern.MatchString(model.TypeName) {
-			return fmt.Errorf("migrations: invalid model %#v", model)
+		if err := validateModel(model); err != nil {
+			return err
 		}
+	}
+	for _, model := range opts.ForgetModels {
+		if err := validateModel(model); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateModel(model Model) error {
+	if strings.TrimSpace(model.ImportPath) == "" || !goIdentifierPattern.MatchString(model.TypeName) {
+		return fmt.Errorf("migrations: invalid model %#v", model)
 	}
 	return nil
 }

--- a/migrations/makemigrations_test.go
+++ b/migrations/makemigrations_test.go
@@ -242,6 +242,106 @@ func TestMakeMigrationsRunsAtlasCLISQLiteWhenAvailable(t *testing.T) {
 	}
 }
 
+// TestMakeMigrationsSecondModelDoesNotDropTheFirst is the regression test for
+// #97: a migration that names one new model must not propose dropping the
+// table an earlier migration created for a model this invocation doesn't
+// repeat.
+func TestMakeMigrationsSecondModelDoesNotDropTheFirst(t *testing.T) {
+	atlasBin := os.Getenv("ATLAS_BINARY")
+	if atlasBin == "" {
+		var err error
+		atlasBin, err = exec.LookPath("atlas")
+		if err != nil {
+			t.Skip("Atlas CLI not found; set ATLAS_BINARY to run the real SQLite makemigrations smoke test")
+		}
+	}
+
+	migrationDir := t.TempDir()
+	ctx := context.Background()
+	root := projectRoot(t)
+
+	// Migration 1 names only Product, exactly like a single-feature app.
+	err := MakeMigrations(ctx, Options{
+		WorkDir:      root,
+		Name:         "create_products",
+		Driver:       config.DatabaseDriverSQLite,
+		MigrationDir: migrationDir,
+		AtlasBinary:  atlasBin,
+		Models: []Model{
+			{ImportPath: "github.com/LAA-Software-Engineering/gombit/migrations/testmodels", TypeName: "Product"},
+		},
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("MakeMigrations() [1] error = %v, want nil", err)
+	}
+
+	registered, err := LoadRegistry(migrationDir)
+	if err != nil {
+		t.Fatalf("LoadRegistry() after migration 1: %v", err)
+	}
+	if len(registered) != 1 || registered[0].TypeName != "Product" {
+		t.Fatalf("registry after migration 1 = %#v, want just Product", registered)
+	}
+
+	// Migration 2 names only Account — a second feature added later, the way
+	// the tutorial's own chapter 3 teaches. It must NOT drop products.
+	err = MakeMigrations(ctx, Options{
+		WorkDir:      root,
+		Name:         "create_accounts",
+		Driver:       config.DatabaseDriverSQLite,
+		MigrationDir: migrationDir,
+		AtlasBinary:  atlasBin,
+		Models: []Model{
+			{ImportPath: "github.com/LAA-Software-Engineering/gombit/migrations/testmodels", TypeName: "Account"},
+		},
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("MakeMigrations() [2] error = %v, want nil", err)
+	}
+
+	files, err := filepath.Glob(filepath.Join(migrationDir, "*.sql"))
+	if err != nil {
+		t.Fatalf("glob migration files: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("migration files = %v, want two SQL migrations", files)
+	}
+
+	var secondMigration string
+	for _, f := range files {
+		if strings.Contains(f, "create_accounts") {
+			secondMigration = f
+		}
+	}
+	if secondMigration == "" {
+		t.Fatalf("migration files = %v, want one named create_accounts", files)
+	}
+	// #nosec G304 -- secondMigration comes from filepath.Glob over migrationDir
+	data, err := os.ReadFile(secondMigration)
+	if err != nil {
+		t.Fatalf("read migration file: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(strings.ToUpper(content), "DROP TABLE") {
+		t.Fatalf("migration 2 = %q, must not drop the products table from migration 1 (#97)", content)
+	}
+	if !strings.Contains(content, "accounts") {
+		t.Fatalf("migration 2 = %q, want it to create the accounts table", content)
+	}
+
+	registered, err = LoadRegistry(migrationDir)
+	if err != nil {
+		t.Fatalf("LoadRegistry() after migration 2: %v", err)
+	}
+	if len(registered) != 2 {
+		t.Fatalf("registry after migration 2 = %#v, want both Product and Account", registered)
+	}
+}
+
 func TestMakeMigrationsValidatesOptions(t *testing.T) {
 	tests := []struct {
 		name string
@@ -257,10 +357,36 @@ func TestMakeMigrationsValidatesOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := MakeMigrations(context.Background(), tt.opts); err == nil {
+			opts := tt.opts
+			// "missing models" is only rejected once the persisted registry
+			// is consulted and found empty too — give it a real, isolated
+			// WorkDir regardless, so no case can touch the package directory.
+			opts.WorkDir = t.TempDir()
+			if err := MakeMigrations(context.Background(), opts); err == nil {
 				t.Fatal("MakeMigrations() error = nil, want error")
 			}
 		})
+	}
+}
+
+// TestMakeMigrationsNoModelsDoesNotCreateMigrationDir guards against a
+// regression where rejecting "nothing to migrate" would still leave behind
+// an empty database/migrations/ as a side effect of checking.
+func TestMakeMigrationsNoModelsDoesNotCreateMigrationDir(t *testing.T) {
+	workDir := t.TempDir()
+	err := MakeMigrations(context.Background(), Options{
+		WorkDir: workDir,
+		Name:    "create_products",
+		Driver:  config.DatabaseDriverSQLite,
+	})
+	if err == nil {
+		t.Fatal("MakeMigrations() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "no models to migrate") {
+		t.Fatalf("error = %q, want it to explain there's nothing to migrate", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(workDir, "database", "migrations")); !os.IsNotExist(statErr) {
+		t.Fatalf("database/migrations was created despite MakeMigrations() failing: stat err = %v", statErr)
 	}
 }
 

--- a/migrations/registry.go
+++ b/migrations/registry.go
@@ -1,0 +1,123 @@
+package migrations
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// registryFileName is the model registry Gombit persists inside the
+// migration directory, alongside the versioned SQL files and atlas.sum. It
+// is not an Atlas file and Atlas ignores it; ListMigrationFiles skips it the
+// same way it skips atlas.sum.
+const registryFileName = "models.json"
+
+// modelRegistry is the on-disk JSON shape of the persisted model set.
+type modelRegistry struct {
+	Models []Model `json:"models"`
+}
+
+// RegistryPath returns the path to the persisted model registry inside
+// migrationDir.
+func RegistryPath(migrationDir string) string {
+	return filepath.Join(migrationDir, registryFileName)
+}
+
+// LoadRegistry reads the model set previously persisted in migrationDir. A
+// missing file is not an error — it means no migration has been generated
+// there yet — and returns a nil slice.
+func LoadRegistry(migrationDir string) ([]Model, error) {
+	path := RegistryPath(migrationDir)
+	// #nosec G304 -- path is derived from the configured migration directory.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("migrations: read model registry %s: %w", path, err)
+	}
+	var reg modelRegistry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return nil, fmt.Errorf("migrations: parse model registry %s: %w", path, err)
+	}
+	for _, model := range reg.Models {
+		if err := validateModel(model); err != nil {
+			return nil, fmt.Errorf("migrations: model registry %s: %w", path, err)
+		}
+	}
+	return reg.Models, nil
+}
+
+// SaveRegistry persists models to migrationDir, sorted for stable diffs
+// regardless of the order callers passed them in.
+func SaveRegistry(migrationDir string, models []Model) error {
+	data, err := json.MarshalIndent(modelRegistry{Models: sortModels(models)}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("migrations: marshal model registry: %w", err)
+	}
+	data = append(data, '\n')
+	path := RegistryPath(migrationDir)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("migrations: write model registry %s: %w", path, err)
+	}
+	return nil
+}
+
+// MergeModels unions existing (typically the persisted registry) with
+// additional (typically the --model flags for this invocation), removing
+// duplicates. additional's relative order is preserved first — it is what
+// the caller explicitly asked for this run — followed by any existing-only
+// models in sorted order.
+func MergeModels(existing, additional []Model) []Model {
+	seen := make(map[Model]bool, len(existing)+len(additional))
+	merged := make([]Model, 0, len(existing)+len(additional))
+	for _, model := range additional {
+		if seen[model] {
+			continue
+		}
+		seen[model] = true
+		merged = append(merged, model)
+	}
+	var rest []Model
+	for _, model := range existing {
+		if seen[model] {
+			continue
+		}
+		seen[model] = true
+		rest = append(rest, model)
+	}
+	return append(merged, sortModels(rest)...)
+}
+
+// SubtractModels returns models with every entry in remove removed.
+func SubtractModels(models, remove []Model) []Model {
+	if len(remove) == 0 {
+		return models
+	}
+	drop := make(map[Model]bool, len(remove))
+	for _, model := range remove {
+		drop[model] = true
+	}
+	out := make([]Model, 0, len(models))
+	for _, model := range models {
+		if drop[model] {
+			continue
+		}
+		out = append(out, model)
+	}
+	return out
+}
+
+func sortModels(models []Model) []Model {
+	out := append([]Model(nil), models...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ImportPath == out[j].ImportPath {
+			return out[i].TypeName < out[j].TypeName
+		}
+		return out[i].ImportPath < out[j].ImportPath
+	})
+	return out
+}

--- a/migrations/registry_test.go
+++ b/migrations/registry_test.go
@@ -1,0 +1,174 @@
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadRegistryMissingFileIsEmpty(t *testing.T) {
+	models, err := LoadRegistry(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadRegistry() error = %v, want nil", err)
+	}
+	if models != nil {
+		t.Fatalf("LoadRegistry() = %#v, want nil", models)
+	}
+}
+
+func TestSaveThenLoadRegistryRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	want := []Model{
+		{ImportPath: "github.com/example/app/internal/account", TypeName: "Account"},
+		{ImportPath: "github.com/example/app/internal/product", TypeName: "Product"},
+	}
+	if err := SaveRegistry(dir, want); err != nil {
+		t.Fatalf("SaveRegistry() error = %v", err)
+	}
+	got, err := LoadRegistry(dir)
+	if err != nil {
+		t.Fatalf("LoadRegistry() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("LoadRegistry() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSaveRegistrySortsRegardlessOfInputOrder(t *testing.T) {
+	dir := t.TempDir()
+	unsorted := []Model{
+		{ImportPath: "github.com/example/app/internal/task", TypeName: "Task"},
+		{ImportPath: "github.com/example/app/internal/account", TypeName: "Account"},
+	}
+	if err := SaveRegistry(dir, unsorted); err != nil {
+		t.Fatalf("SaveRegistry() error = %v", err)
+	}
+	got, err := LoadRegistry(dir)
+	if err != nil {
+		t.Fatalf("LoadRegistry() error = %v", err)
+	}
+	want := []Model{
+		{ImportPath: "github.com/example/app/internal/account", TypeName: "Account"},
+		{ImportPath: "github.com/example/app/internal/task", TypeName: "Task"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("LoadRegistry() = %#v, want sorted %#v", got, want)
+	}
+}
+
+func TestLoadRegistryRejectsInvalidEntries(t *testing.T) {
+	dir := t.TempDir()
+	// #nosec G306 -- test fixture
+	if err := os.WriteFile(RegistryPath(dir), []byte(`{"models":[{"import_path":"","type_name":"Product"}]}`), 0o600); err != nil {
+		t.Fatalf("write registry fixture: %v", err)
+	}
+	if _, err := LoadRegistry(dir); err == nil {
+		t.Fatal("LoadRegistry() error = nil, want error for invalid entry")
+	}
+}
+
+func TestLoadRegistryRejectsMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	// #nosec G306 -- test fixture
+	if err := os.WriteFile(RegistryPath(dir), []byte(`not json`), 0o600); err != nil {
+		t.Fatalf("write registry fixture: %v", err)
+	}
+	if _, err := LoadRegistry(dir); err == nil {
+		t.Fatal("LoadRegistry() error = nil, want error for malformed JSON")
+	}
+}
+
+func TestRegistryPathIsInsideMigrationDir(t *testing.T) {
+	got := RegistryPath("database/migrations")
+	want := filepath.Join("database/migrations", "models.json")
+	if got != want {
+		t.Fatalf("RegistryPath() = %q, want %q", got, want)
+	}
+}
+
+func TestMergeModels(t *testing.T) {
+	product := Model{ImportPath: "github.com/example/app/internal/product", TypeName: "Product"}
+	account := Model{ImportPath: "github.com/example/app/internal/account", TypeName: "Account"}
+	task := Model{ImportPath: "github.com/example/app/internal/task", TypeName: "Task"}
+
+	tests := []struct {
+		name       string
+		existing   []Model
+		additional []Model
+		want       []Model
+	}{
+		{
+			name:       "empty registry keeps additional order",
+			existing:   nil,
+			additional: []Model{product, account},
+			want:       []Model{product, account},
+		},
+		{
+			name:       "new model is unioned with the registry, not replacing it",
+			existing:   []Model{product, account},
+			additional: []Model{task},
+			want:       []Model{task, account, product},
+		},
+		{
+			name:       "duplicate between existing and additional is not repeated",
+			existing:   []Model{product},
+			additional: []Model{product, task},
+			want:       []Model{product, task},
+		},
+		{
+			name:       "no new models still returns the registry",
+			existing:   []Model{product, account},
+			additional: nil,
+			want:       []Model{account, product},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergeModels(tt.existing, tt.additional)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("MergeModels() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubtractModels(t *testing.T) {
+	product := Model{ImportPath: "github.com/example/app/internal/product", TypeName: "Product"}
+	account := Model{ImportPath: "github.com/example/app/internal/account", TypeName: "Account"}
+	task := Model{ImportPath: "github.com/example/app/internal/task", TypeName: "Task"}
+
+	tests := []struct {
+		name   string
+		models []Model
+		remove []Model
+		want   []Model
+	}{
+		{
+			name:   "removes a matching model",
+			models: []Model{product, account, task},
+			remove: []Model{account},
+			want:   []Model{product, task},
+		},
+		{
+			name:   "no-op when remove is empty",
+			models: []Model{product, account},
+			remove: nil,
+			want:   []Model{product, account},
+		},
+		{
+			name:   "removing everything yields empty, not nil-vs-empty ambiguity",
+			models: []Model{product},
+			remove: []Model{product},
+			want:   []Model{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SubtractModels(tt.models, tt.remove)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("SubtractModels() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/migrations/testmodels/account.go
+++ b/migrations/testmodels/account.go
@@ -1,0 +1,11 @@
+package testmodels
+
+import "gorm.io/gorm"
+
+// Account is a second, unrelated GORM model used by makemigrations
+// integration tests to exercise a migration that adds one new model without
+// repeating a model an earlier migration already covers.
+type Account struct {
+	gorm.Model
+	Owner string `gorm:"size:120;not null"`
+}


### PR DESCRIPTION
## Summary

Fixes #97: `gombit db makemigrations <name> --model X` treated the `--model` list passed to *that invocation* as the entire desired schema. Atlas replays every migration already in `database/migrations/` to compute "current state" and diffs it against only the models named on the command line — anything from an earlier migration not repeated here read as drift and got a silent `DROP TABLE`. The tutorial's own chapter 3 (one model per call, one feature at a time) sets readers up to hit this the moment they add a second feature.

- `MakeMigrations` now merges `opts.Models` with a persisted registry (`database/migrations/models.json`) before generating the Atlas loader, and saves the merged set back after a successful diff. A migration only needs to name what's *new* — everything named in earlier calls carries forward automatically.
- `models.json` is committed alongside the SQL it describes, the same way `atlas.sum` already is. Atlas ignores it (only `*.sql` and `atlas.sum` matter to `atlas migrate diff`/`apply`), and `gombit db status`/`migrate` skip it the same way they already skip `atlas.sum`.
- New `--forget-model` flag on `gombit db makemigrations`: the registry means a model is never dropped by accident anymore, so retiring one for real now needs an explicit, intentional call.
- Docs updated: `docs/migrations.md` (removes the "known issue" callout from the previous tutorial-fixes PR, documents the actual mechanism and `--forget-model`), `docs/cli.md` (`make resource`'s migration section, layout tree).

## Acceptance criteria

Issue #97's own "Suggested direction": persist the set of models used in previous invocations and automatically union new `--model` flags with it. Implemented as described; `--forget-model` additionally closes the "how do I ever intentionally drop a table now" gap that approach creates.

## Scope notes

Does **not** fix #96 (`AutoMigrate`/Atlas conflict — `gombit db migrate` failing with `table already exists` after `gombit make resource --force`). That's a separate, still-open problem: GORM `AutoMigrate` creates tables outside Atlas's knowledge entirely, independent of how `--model` lists are tracked across invocations. Confirmed while validating this fix — `make resource --force` in a freshly re-run tutorial still generates a migration that tries to `CREATE TABLE users` etc. (issue #96, unrelated to this PR), but critically it no longer contains any `DROP TABLE` for `tasks` (issue #97, now fixed).

## Validation

- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — 0 issues
- [x] Project `code-review` skill run against this diff — approved
- [x] **Reproduced the original bug with real Atlas** and turned it into a regression test: `TestMakeMigrationsSecondModelDoesNotDropTheFirst` runs two sequential `MakeMigrations` calls (Product, then Account without repeating Product) against the real `atlas` binary and asserts the second migration contains no `DROP TABLE`.
- [x] **Ran the entire tutorial end to end** against a locally built binary (via `go mod edit -replace` per `installation.md`'s documented dev workflow), chapter 1 through 11: scaffold → `gombit dev` (auth mounted from `.env` automatically) → model + migration (single clean migration, new `models.json` registry) → `make resource --force` (confirmed no `DROP TABLE`, only the pre-existing #96 `CREATE TABLE` behavior) → contract/routes → typed client (`client generate` + `client check --url`) → frontend (task list renders, "Title is required" shows) → auth (login, CSRF flow, CSRF rejection) → admin (API + browser UI) → management command (`--package task`, `backfill-done` runs) → `build --embed` (single binary serves API + SPA + admin, verified with curl).

## Working agreement checklist

- [x] New behavior has tests — `migrations/registry_test.go` (unit), `TestMakeMigrationsSecondModelDoesNotDropTheFirst` and `TestMakeMigrationsNoModelsDoesNotCreateMigrationDir` (integration, real Atlas), `cli/db_test.go` (flag wiring)
- [ ] DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — SQLite covered live (real Atlas, Docker-free); Postgres/MySQL covered only through the stubbed-runner test that asserts loader/config content, not a live DROP-detection run — Docker isn't available in this sandbox. The merge/subtract logic itself isn't driver-specific.
- [x] Stable features ship docs and appear in an example app — `docs/migrations.md` and `docs/cli.md` updated; no example app change needed (behavior, not a new command surface, beyond the additive `--forget-model` flag which is documented)
- [x] Extraction preserves contracts — N/A, no extraction
- [x] Generators are idempotent/additive, AST-safe, never overwrite user-owned files — N/A, this isn't a go/ast generator; `MakeMigrations` itself remains additive (still only ever writes new `*.sql` files plus the registry)
- [ ] API changes regenerate the OpenAPI doc + TS client — N/A, no API/contract changes
- [x] No secrets in generated frontend source — unaffected
- [x] Scope stays inside this issue's milestone — M2 migrations; explicitly did not fold in #96
- [x] This PR links its issue and states which acceptance criteria it satisfies — #97, above

🤖 Generated with [Claude Code](https://claude.com/claude-code)