### PR TITLE
fix: seed a bootstrap migration so AutoMigrate and Atlas never diverge (fixes #96)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,6 +74,12 @@ the binary that scaffolded it**, and `gombit new` then runs `go mod tidy` to
 populate `go.sum`. An installed release therefore produces a tree that builds
 immediately.
 
+Once `go mod tidy` succeeds, `gombit new` also seeds an initial `bootstrap`
+migration under `database/migrations/` for the framework's own auth tables —
+requires Atlas on `PATH`; prints the equivalent `gombit db makemigrations`
+command instead of failing when it isn't. See
+[migrations.md](migrations.md#the-bootstrap-migration) for why this exists.
+
 Version resolution follows `gombit version` (see below) and falls back to
 `v0.0.0` — which the proxy cannot resolve — when the CLI reports something
 unpublishable:
@@ -104,7 +110,7 @@ go mod tidy
 | `--ui` | `minimal`, `mui` | `minimal` |
 | `--module` | Go module path | `github.com/example/<name>` |
 | `--framework-version` | gombit version the generated `go.mod` requires | this binary's version |
-| `--skip-tidy` | | do not run `go mod tidy` (offline) |
+| `--skip-tidy` | | do not run `go mod tidy` (offline); also skips seeding the bootstrap migration, which needs a tidied module |
 | `--dry-run` | | print the file list without writing |
 | `--force` | | required to write into a non-empty destination |
 
@@ -137,7 +143,7 @@ demo/
 │   ├── platform/
 │   ├── product/          # model, handler.go, routes.go, commands.go
 │   └── web/              # go:embed hook (static/.keep placeholder; no index.html)
-├── database/migrations/
+├── database/migrations/  # a bootstrap_*.sql migration + models.json are seeded here (Tidy + Atlas)
 ├── database/seeds/
 ├── config/
 ├── frontend/             # Vite + React skeleton (main.tsx, router, generated client)

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -4,6 +4,28 @@ M2 introduces `gombit db` migration commands as a thin wrapper around Atlas
 versioned migrations and `ariga.io/atlas-provider-gorm` Program Mode. Gombit
 does not define its own migration DSL.
 
+## The bootstrap migration
+
+`gombit new` seeds `database/migrations/<timestamp>_bootstrap.sql` (and the
+`models.json` registry entry for it — see [Generate A
+Migration](#generate-a-migration)) covering every model
+`internal/platform/database.go`'s `AutoMigrate` call registers — the
+framework's own auth tables (`users`, `permissions`, `groups`,
+`refresh_tokens`, their join tables) plus the `product/` example — when Atlas
+is on `PATH` and `go mod tidy` succeeded. If Atlas isn't installed yet,
+`gombit new` prints the equivalent `gombit db makemigrations bootstrap
+--model ...` command to run once it is.
+
+This exists because `AutoMigrate` also runs at every app startup
+(`app.OnStart`), creating those tables directly through GORM. Without a
+migration for them from the start, Atlas's tracked history never learns they
+exist, and the model registry has nothing to merge new models into — so the
+first later diff that names a model not yet tracked would "discover" the
+`AutoMigrate` tables as missing too and try to `CREATE` tables that already
+exist, and `gombit db migrate` would fail with `table users already exists`.
+Run `gombit db migrate` right after `gombit new` to apply the bootstrap
+migration before anything else is added.
+
 ## Generate A Migration
 
 Run the command from the application module root:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -164,7 +164,13 @@ gombit db status
 `status` lists applied and pending revisions. `gombit db rollback` undoes the
 last batch.
 
-**✅ Checkpoint** — `gombit db status` shows your migration as applied.
+`gombit new` already seeded one migration ahead of yours: a `bootstrap`
+migration for the framework's own auth tables (see
+[migrations.md](migrations.md#the-bootstrap-migration)). `gombit db migrate`
+applies both in this batch — that's expected, not a second copy of `tasks`.
+
+**✅ Checkpoint** — `gombit db status` shows `bootstrap` and `create_tasks` as
+applied.
 
 > If you get `atlas: executable file not found in $PATH`, install Atlas
 > Community Edition (see [installation.md](installation.md)). The GORM model is

--- a/migrations/makemigrations_test.go
+++ b/migrations/makemigrations_test.go
@@ -342,6 +342,104 @@ func TestMakeMigrationsSecondModelDoesNotDropTheFirst(t *testing.T) {
 	}
 }
 
+// TestMakeMigrationsFullListAfterIncrementalCallsIsNoop is the regression
+// test for #96: gombit make resource always diffs the *entire* AutoMigrate
+// model list (resourcegen.CollectAutoMigrateModels), not just the resource
+// being generated. Before the bootstrap migration (seeded by gombit new)
+// and the model registry (#97) existed together, a full-list call like that
+// would "discover" AutoMigrate-created tables the registry had never heard
+// of and try to CREATE them again, and applying that migration failed with
+// "table already exists" because AutoMigrate had already created them live.
+//
+// With bootstrap migration + registry both in place, a later call that
+// names every currently-registered model (exactly what resourcegen does)
+// must be a no-op: nothing left to create, so Atlas writes no new
+// migration file at all.
+func TestMakeMigrationsFullListAfterIncrementalCallsIsNoop(t *testing.T) {
+	atlasBin := os.Getenv("ATLAS_BINARY")
+	if atlasBin == "" {
+		var err error
+		atlasBin, err = exec.LookPath("atlas")
+		if err != nil {
+			t.Skip("Atlas CLI not found; set ATLAS_BINARY to run the real SQLite makemigrations smoke test")
+		}
+	}
+
+	migrationDir := t.TempDir()
+	ctx := context.Background()
+	root := projectRoot(t)
+	const testmodelsPkg = "github.com/LAA-Software-Engineering/gombit/migrations/testmodels"
+
+	// "bootstrap": Product only, the way gombit new would seed it.
+	err := MakeMigrations(ctx, Options{
+		WorkDir:      root,
+		Name:         "bootstrap",
+		Driver:       config.DatabaseDriverSQLite,
+		MigrationDir: migrationDir,
+		AtlasBinary:  atlasBin,
+		Models:       []Model{{ImportPath: testmodelsPkg, TypeName: "Product"}},
+		Stdout:       io.Discard,
+		Stderr:       io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("MakeMigrations() [bootstrap] error = %v, want nil", err)
+	}
+
+	// chapter 3's own pattern: a single new model, not repeating Product.
+	err = MakeMigrations(ctx, Options{
+		WorkDir:      root,
+		Name:         "create_accounts",
+		Driver:       config.DatabaseDriverSQLite,
+		MigrationDir: migrationDir,
+		AtlasBinary:  atlasBin,
+		Models:       []Model{{ImportPath: testmodelsPkg, TypeName: "Account"}},
+		Stdout:       io.Discard,
+		Stderr:       io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("MakeMigrations() [create_accounts] error = %v, want nil", err)
+	}
+
+	before, err := filepath.Glob(filepath.Join(migrationDir, "*.sql"))
+	if err != nil {
+		t.Fatalf("glob migration files before: %v", err)
+	}
+	if len(before) != 2 {
+		t.Fatalf("migration files before = %v, want two", before)
+	}
+
+	// resourcegen's own call shape: every currently-registered model, not
+	// just the one being added — both are already tracked, so this must not
+	// try to CREATE anything, since AutoMigrate would already have made
+	// both tables live and Atlas now knows about them too.
+	stdout := new(bytes.Buffer)
+	err = MakeMigrations(ctx, Options{
+		WorkDir:      root,
+		Name:         "create_accounts", // resourcegen names it after the new resource, same as chapter 4
+		Driver:       config.DatabaseDriverSQLite,
+		MigrationDir: migrationDir,
+		AtlasBinary:  atlasBin,
+		Models: []Model{
+			{ImportPath: testmodelsPkg, TypeName: "Product"},
+			{ImportPath: testmodelsPkg, TypeName: "Account"},
+		},
+		Stdout: stdout,
+		Stderr: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("MakeMigrations() [full list] error = %v, want nil (this is #96 if it fails)", err)
+	}
+
+	after, err := filepath.Glob(filepath.Join(migrationDir, "*.sql"))
+	if err != nil {
+		t.Fatalf("glob migration files after: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("migration files after full-list call = %v, want no new file (got %d, had %d): %s",
+			after, len(after), len(before), stdout.String())
+	}
+}
+
 func TestMakeMigrationsValidatesOptions(t *testing.T) {
 	tests := []struct {
 		name string

--- a/scaffold/bootstrap_migration.go
+++ b/scaffold/bootstrap_migration.go
@@ -1,0 +1,95 @@
+package scaffold
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/migrations"
+)
+
+// bootstrapModels lists the GORM models internal/platform/database.go.tmpl
+// registers for AutoMigrate: the framework's own auth tables plus the
+// product/ example, in the same order the template writes them.
+//
+// AutoMigrate runs at every app startup (app.OnStart), creating these tables
+// directly through GORM. Without a migration on disk for them from the
+// start, Atlas's tracked history never learns they exist, so the first later
+// diff that names a model not yet in the registry "discovers" them as
+// missing too and tries to CREATE tables that are already there — and
+// applying that migration fails with "table already exists" (#96). Seeding
+// this migration, and the model registry it writes (see #97's
+// migrations.MakeMigrations / database/migrations/models.json), at scaffold
+// time keeps Atlas's history in sync with what AutoMigrate creates from the
+// very first run: a later `gombit db makemigrations create_x --model X`
+// (chapter 3's own pattern) merges with this registry instead of treating
+// its single model as the entire desired schema.
+func bootstrapModels(module string) []migrations.Model {
+	const authImport = "github.com/LAA-Software-Engineering/gombit/auth"
+	return []migrations.Model{
+		{ImportPath: authImport, TypeName: "User"},
+		{ImportPath: authImport, TypeName: "RefreshToken"},
+		{ImportPath: authImport, TypeName: "Group"},
+		{ImportPath: authImport, TypeName: "Permission"},
+		{ImportPath: module + "/internal/product", TypeName: "Product"},
+	}
+}
+
+// seedBootstrapMigration writes the initial database/migrations/ entry
+// covering bootstrapModels. It requires a module that already resolves
+// (go mod tidy succeeded) and the atlas binary. Any failure to seed it —
+// atlas missing, or atlas present but unable to run (e.g. --database
+// postgres/mysql need a running Docker daemon for Atlas's dev-database, and
+// gombit new never required Docker before) — prints the equivalent
+// gombit db makemigrations command instead of failing gombit new outright.
+// Bootstrapping the migration is an automation on top of an otherwise
+// complete, working scaffold, not a precondition for one — the same
+// reasoning behind resourcegen's own atlas-missing fallback, extended here
+// to cover atlas errors too since this runs unprompted, not because the
+// user explicitly asked to generate a migration.
+func seedBootstrapMigration(ctx context.Context, opts Options) error {
+	models := bootstrapModels(opts.Module)
+
+	atlasPath, lookErr := scaffoldLookPath("atlas")
+	if lookErr != nil || atlasPath == "" {
+		return printBootstrapMigrationHint(opts, models, "atlas not on PATH")
+	}
+
+	driver := config.DatabaseDriver(opts.Database)
+	err := scaffoldMakeMigrations(ctx, migrations.Options{
+		WorkDir:      opts.Dest,
+		Name:         "bootstrap",
+		Driver:       driver,
+		MigrationDir: "database/migrations",
+		Models:       models,
+		Stdout:       opts.Stdout,
+		Stderr:       opts.Stderr,
+	})
+	if err != nil {
+		return printBootstrapMigrationHint(opts, models, fmt.Sprintf("could not seed it (%v)", err))
+	}
+	return nil
+}
+
+func printBootstrapMigrationHint(opts Options, models []migrations.Model, reason string) error {
+	var args string
+	for _, model := range models {
+		args += " --model " + model.ImportPath + "." + model.TypeName
+	}
+	_, err := fmt.Fprintf(
+		opts.Stdout,
+		"note: %s; run this once before gombit db migrate so Atlas's history matches "+
+			"what AutoMigrate creates at startup:\n  gombit db makemigrations bootstrap%s\n",
+		reason, args,
+	)
+	return err
+}
+
+// scaffoldLookPath and scaffoldMakeMigrations are indirected for tests, the
+// same pattern resourcegen uses for its own atlas/makemigrations seams.
+var scaffoldLookPath = func(name string) (string, error) {
+	return exec.LookPath(name)
+}
+
+var scaffoldMakeMigrations = migrations.MakeMigrations

--- a/scaffold/generate.go
+++ b/scaffold/generate.go
@@ -107,8 +107,17 @@ func Generate(ctx context.Context, opts Options) error {
 	// fails with "missing go.sum entry" rather than fetching. Only worth
 	// attempting when the pin is resolvable.
 	if opts.Tidy && !opts.DryRun && fallbackReason == "" {
-		if err := tidyModule(ctx, opts); err != nil {
+		tidied, err := tidyModule(ctx, opts)
+		if err != nil {
 			return err
+		}
+		// The bootstrap migration shells out to `go run` on a loader that
+		// imports the module's own dependencies; without a tidied go.sum
+		// that fails, so only attempt it once the module actually resolves.
+		if tidied && !opts.skipAtlas {
+			if err := seedBootstrapMigration(ctx, opts); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -125,21 +134,22 @@ var goModTidy = func(ctx context.Context, dir string) ([]byte, error) {
 // tidyModule populates go.sum so the generated app builds as-is. A failure
 // here (no network, no toolchain) is reported but not fatal: the tree is
 // already written and correct, and the user can rerun the command themselves.
-func tidyModule(ctx context.Context, opts Options) error {
+// The returned bool reports whether go.sum is now actually usable.
+func tidyModule(ctx context.Context, opts Options) (bool, error) {
 	if _, err := fmt.Fprintln(opts.Stdout, "go mod tidy"); err != nil {
-		return err
+		return false, err
 	}
 	output, err := goModTidy(ctx, opts.Dest)
 	if err == nil {
-		return nil
+		return true, nil
 	}
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		return ctxErr
+		return false, ctxErr
 	}
 	_, writeErr := fmt.Fprintf(opts.Stderr,
 		"warning: go mod tidy failed: %v\n%s  %s will not build until you run it yourself:\n    cd %s && go mod tidy\n",
 		err, indentOutput(output), opts.Module, opts.Name)
-	return writeErr
+	return false, writeErr
 }
 
 func indentOutput(output []byte) string {

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/LAA-Software-Engineering/gombit/config"
+	"github.com/LAA-Software-Engineering/gombit/migrations"
 )
 
 func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
@@ -726,6 +728,7 @@ func TestGenerateRunsTidyForResolvableVersion(t *testing.T) {
 		WorkDir:          workDir,
 		Stdout:           stdout,
 		Stderr:           new(bytes.Buffer),
+		skipAtlas:        true, // this test only cares about the tidy step
 	})
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
@@ -810,5 +813,137 @@ func TestGenerateTidyFailureIsNotFatal(t *testing.T) {
 		if !strings.Contains(stderr.String(), fragment) {
 			t.Errorf("warning = %q, want it to mention %q", stderr.String(), fragment)
 		}
+	}
+}
+
+func stubScaffoldLookPath(t *testing.T, fn func(name string) (string, error)) {
+	t.Helper()
+	prev := scaffoldLookPath
+	scaffoldLookPath = fn
+	t.Cleanup(func() { scaffoldLookPath = prev })
+}
+
+func stubScaffoldMakeMigrations(t *testing.T, fn func(ctx context.Context, opts migrations.Options) error) {
+	t.Helper()
+	prev := scaffoldMakeMigrations
+	scaffoldMakeMigrations = fn
+	t.Cleanup(func() { scaffoldMakeMigrations = prev })
+}
+
+// TestGenerateSeedsBootstrapMigrationForResolvableVersion guards the fix for
+// #96: gombit new must seed an initial migration covering every model
+// internal/platform/database.go.tmpl registers for AutoMigrate, so Atlas's
+// tracked history matches what AutoMigrate creates at every app startup
+// from the very first run.
+func TestGenerateSeedsBootstrapMigrationForResolvableVersion(t *testing.T) {
+	stubGoModTidy(t, func(context.Context, string) ([]byte, error) { return nil, nil })
+	stubScaffoldLookPath(t, func(string) (string, error) { return "/usr/bin/atlas", nil })
+
+	var got migrations.Options
+	calls := 0
+	stubScaffoldMakeMigrations(t, func(_ context.Context, opts migrations.Options) error {
+		calls++
+		got = opts
+		return nil
+	})
+
+	workDir := t.TempDir()
+	err := Generate(context.Background(), Options{
+		Name:             "demo",
+		Module:           "github.com/example/demo",
+		Database:         "postgres",
+		FrameworkVersion: "v0.1.0",
+		Tidy:             true,
+		WorkDir:          workDir,
+		Stdout:           new(bytes.Buffer),
+		Stderr:           new(bytes.Buffer),
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("bootstrap migration ran %d times, want 1", calls)
+	}
+	if got.Name != "bootstrap" {
+		t.Errorf("migration name = %q, want bootstrap", got.Name)
+	}
+	if got.Driver != config.DatabaseDriverPostgres {
+		t.Errorf("migration driver = %q, want postgres", got.Driver)
+	}
+	if got.WorkDir != filepath.Join(workDir, "demo") {
+		t.Errorf("migration workdir = %q, want %q", got.WorkDir, filepath.Join(workDir, "demo"))
+	}
+	wantModels := []migrations.Model{
+		{ImportPath: "github.com/LAA-Software-Engineering/gombit/auth", TypeName: "User"},
+		{ImportPath: "github.com/LAA-Software-Engineering/gombit/auth", TypeName: "RefreshToken"},
+		{ImportPath: "github.com/LAA-Software-Engineering/gombit/auth", TypeName: "Group"},
+		{ImportPath: "github.com/LAA-Software-Engineering/gombit/auth", TypeName: "Permission"},
+		{ImportPath: "github.com/example/demo/internal/product", TypeName: "Product"},
+	}
+	if !reflect.DeepEqual(got.Models, wantModels) {
+		t.Errorf("migration models = %#v, want %#v", got.Models, wantModels)
+	}
+}
+
+func TestGenerateWithoutAtlasHintsBootstrapMigration(t *testing.T) {
+	stubGoModTidy(t, func(context.Context, string) ([]byte, error) { return nil, nil })
+	stubScaffoldLookPath(t, func(string) (string, error) { return "", errors.New("not found") })
+	stubScaffoldMakeMigrations(t, func(context.Context, migrations.Options) error {
+		t.Fatal("makemigrations must not run when atlas is missing")
+		return nil
+	})
+
+	stdout := new(bytes.Buffer)
+	err := Generate(context.Background(), Options{
+		Name:             "demo",
+		Database:         "sqlite",
+		FrameworkVersion: "v0.1.0",
+		Tidy:             true,
+		WorkDir:          t.TempDir(),
+		Stdout:           stdout,
+		Stderr:           new(bytes.Buffer),
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "gombit db makemigrations bootstrap") {
+		t.Fatalf("stdout = %q, want a makemigrations hint", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "--model github.com/LAA-Software-Engineering/gombit/auth.User") {
+		t.Fatalf("stdout = %q, want auth models in hint", stdout.String())
+	}
+}
+
+// TestGenerateBootstrapMigrationFailureHintsInsteadOfFailing guards a real
+// deployment risk: --database postgres/mysql need a running Docker daemon
+// for Atlas's dev-database (see devURL in migrations/makemigrations.go),
+// which gombit new never required before this feature existed. A user with
+// atlas installed but no Docker running must still get a working scaffold
+// out of `gombit new --database postgres`, not a fatal error.
+func TestGenerateBootstrapMigrationFailureHintsInsteadOfFailing(t *testing.T) {
+	stubGoModTidy(t, func(context.Context, string) ([]byte, error) { return nil, nil })
+	stubScaffoldLookPath(t, func(string) (string, error) { return "/usr/bin/atlas", nil })
+	stubScaffoldMakeMigrations(t, func(context.Context, migrations.Options) error {
+		return errors.New("atlas migrate diff: docker: command not found")
+	})
+
+	stdout := new(bytes.Buffer)
+	err := Generate(context.Background(), Options{
+		Name:             "demo",
+		Database:         "postgres",
+		FrameworkVersion: "v0.1.0",
+		Tidy:             true,
+		WorkDir:          t.TempDir(),
+		Stdout:           stdout,
+		Stderr:           new(bytes.Buffer),
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v, want bootstrap migration failure to be non-fatal", err)
+	}
+	if !strings.Contains(stdout.String(), "gombit db makemigrations bootstrap") {
+		t.Fatalf("stdout = %q, want a makemigrations hint", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "docker: command not found") {
+		t.Fatalf("stdout = %q, want the underlying atlas error surfaced", stdout.String())
 	}
 }

--- a/scaffold/options.go
+++ b/scaffold/options.go
@@ -53,6 +53,10 @@ type Options struct {
 	Dest    string
 	DryRun  bool
 	Force   bool
+	// skipAtlas bypasses the initial bootstrap migration in tests that stub
+	// go.sum population without a real go.mod/go.sum, mirroring resourcegen's
+	// own skipAtlas seam.
+	skipAtlas        bool
 	Stdin            io.Reader
 	Stdout           io.Writer
 	Stderr           io.Writer


### PR DESCRIPTION
## Summary

Fixes #96: `gombit db migrate` failed with `table already exists` after `gombit make resource --force`. `AutoMigrate` runs at every app startup (`app.OnStart`), creating the framework's own auth tables directly through GORM — Atlas's tracked history never learned they existed, so the first later diff naming the full `AutoMigrate` model list (`make resource` always does) "discovered" them as missing and tried to `CREATE` tables that were already there.

**This was already attempted once, in an earlier PR, and reverted.** Before #97 was fixed, seeding a migration for the `AutoMigrate` models and then having a later single-model `gombit db makemigrations` call (chapter 3's own pattern) would itself *drop everything the seed migration created*, since each invocation was treated as the complete desired schema. With #97's model registry now merging `--model` flags instead of replacing the desired schema, that failure mode is gone, and re-attempting the bootstrap-migration approach now works — see my comment on #96 from when #97 merged for the reasoning that led here.

- `gombit new` seeds `database/migrations/<timestamp>_bootstrap.sql` (and the model registry entry for it, per #97) covering the same models `internal/platform/database.go`'s `AutoMigrate` call registers, once `go mod tidy` succeeds and `atlas` is on `PATH`.
- **Caught during self-review, not in the original attempt:** `--database postgres`/`mysql` need a running Docker daemon for Atlas's dev-database (`migrations.devURL`) — a requirement `gombit new` never had before this feature existed. Any failure to seed the bootstrap migration — atlas missing, *or* atlas present but unable to run — now prints the equivalent `gombit db makemigrations bootstrap` command instead of failing `gombit new` outright, so a Docker-less machine still gets a working scaffold. This is covered by `TestGenerateBootstrapMigrationFailureHintsInsteadOfFailing`.
- Docs restored/updated: `docs/migrations.md` (`## The bootstrap migration`, previously reverted, now accurate), `docs/cli.md`, `docs/tutorial.md` chapter 3.

## Acceptance criteria

Issue #96's own description: `gombit db migrate` must not fail with `table already exists` after `gombit make resource --force`. Verified directly (see Validation).

## Scope notes

None — this closes out the migration-related findings from the original tutorial QA pass (#96, #97 both now fixed). #100 (unrelated OpenAPI schema-naming bug in the admin data plane) remains open and untouched.

## Validation

- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — 0 issues
- [x] Project `code-review` skill run against this diff — approved (after fixing the Docker-dependency risk found during that review)
- [x] **Reproduced the original bug's exact repro with real Atlas** and turned it into a regression test: `TestMakeMigrationsFullListAfterIncrementalCallsIsNoop` runs bootstrap → chapter 3's single-model call → a resourcegen-style full-list call, and asserts the third call writes **no new migration file** — not a `CREATE` that would fail against tables `AutoMigrate` already made live.
- [x] **Ran the entire tutorial end to end** against a locally built binary (via `go mod edit -replace` per `installation.md`'s documented dev workflow), chapter 1 through 11 — scaffold, bootstrap migration, chapter 3's model + migration, the exact `make resource --force` step from the issue repro (now prints `The migration directory is synced with the desired state, no changes to be made` instead of generating a doomed migration), contract, typed client, auth (CSRF flow), admin (API + browser UI), management command, and the embedded single-binary build.
- [x] **`gombit doctor` confirms the fix**: `ok migrations 2 applied, none pending` after the full flow, versus the previous `warn migrations 1 pending: ..._create_tasks` that could never apply cleanly (`table already exists`).

## Working agreement checklist

- [x] New behavior has tests — `scaffold/generate_test.go` (wiring, atlas-missing hint, non-fatal Docker-failure hint), `migrations/makemigrations_test.go` (`TestMakeMigrationsFullListAfterIncrementalCallsIsNoop`, real Atlas)
- [ ] DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — SQLite covered live (real Atlas, Docker-free); the scaffold-wiring test exercises a `postgres`-configured `Generate()` call through a stubbed runner (asserts driver/model-list correctness), not a live Postgres/MySQL Atlas run — Docker isn't available in this sandbox, same acceptable gap as #99's PR. The graceful-degradation path is exactly what protects Postgres/MySQL users without Docker.
- [x] Stable features ship docs and appear in an example app — `docs/migrations.md`, `docs/cli.md`, `docs/tutorial.md` updated
- [x] Extraction preserves contracts — N/A, no extraction
- [x] Generators are idempotent/additive, AST-safe, never overwrite user-owned files — N/A, not a go/ast generator; reuses `migrations.MakeMigrations` unchanged
- [ ] API changes regenerate the OpenAPI doc + TS client — N/A, no API/contract changes
- [x] No secrets in generated frontend source — unaffected
- [x] Scope stays inside this issue's milestone — M2 migrations; did not fold in #100
- [x] This PR links its issue and states which acceptance criteria it satisfies — #96, above

🤖 Generated with [Claude Code](https://claude.com/claude-code)