### PR TITLE
fix: name the admin data plane's row type so OpenAPI schema names are valid (fixes #100)

### DIFF
--- a/admin/meta_test.go
+++ b/admin/meta_test.go
@@ -3,6 +3,7 @@ package admin_test
 import (
 	"encoding/json"
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/LAA-Software-Engineering/gombit/config"
 	"github.com/LAA-Software-Engineering/gombit/framework"
 	"github.com/gin-gonic/gin"
+	"github.com/pb33f/libopenapi"
+	openapivalidator "github.com/pb33f/libopenapi-validator"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -295,5 +298,59 @@ func TestAdminRoutesAppearInOpenAPI(t *testing.T) {
 		if !strings.Contains(body, path) {
 			t.Fatalf("openapi.json missing %s", path)
 		}
+	}
+}
+
+// TestAdminOpenAPISchemaNamesAreValid is the regression test for #100: the
+// admin data plane's generic responses used map[string]any directly as a
+// generic type parameter (contract.Data[map[string]any], contract.DataMeta
+// [[]map[string]any, contract.PageMeta]). map[string]any has no
+// reflect.Type.Name(), so Huma's DefaultSchemaNamer fell back to Go's
+// unnamed-type string ("map[string]interface {}"), and that literal space
+// and braces survived into the OpenAPI component name — e.g.
+// "DataMetaListMapStringInterface {}PageMeta" — which fails OpenAPI 3.1
+// validation (component names must match ^[a-zA-Z0-9._-]+$).
+//
+// No admin.Register call is needed to reproduce this: the admin data-plane
+// routes (and their response schemas) are mounted unconditionally under
+// cookie auth, per newCookieApp.
+func TestAdminOpenAPISchemaNamesAreValid(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	rec := doRequest(app, nil, http.MethodGet, "/openapi.json", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("openapi status = %d", rec.Code)
+	}
+
+	var doc struct {
+		Components struct {
+			Schemas map[string]json.RawMessage `json:"schemas"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("decode openapi.json: %v", err)
+	}
+	if len(doc.Components.Schemas) == 0 {
+		t.Fatal("openapi.json has no component schemas to check")
+	}
+
+	validName := regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	for name := range doc.Components.Schemas {
+		if !validName.MatchString(name) {
+			t.Errorf("schema component name %q does not match OpenAPI 3.1's ^[a-zA-Z0-9._-]+$ pattern", name)
+		}
+	}
+
+	document, err := libopenapi.NewDocument(rec.Body.Bytes())
+	if err != nil {
+		t.Fatalf("parse OpenAPI document: %v", err)
+	}
+	validator, validatorErrs := openapivalidator.NewValidator(document)
+	if len(validatorErrs) > 0 {
+		t.Fatalf("create OpenAPI validator: %v", validatorErrs)
+	}
+	valid, documentErrs := validator.ValidateDocument()
+	if !valid || len(documentErrs) > 0 {
+		t.Fatalf("validate OpenAPI 3.1 document: valid=%v errors=%v", valid, documentErrs)
 	}
 }

--- a/admin/registry.go
+++ b/admin/registry.go
@@ -96,8 +96,8 @@ func (m *registered) columnFor(name string) (string, bool) {
 	return "", false
 }
 
-func (m *registered) toRow(inst any) map[string]any {
-	out := make(map[string]any, len(m.fields)+len(m.implicit))
+func (m *registered) toRow(inst any) row {
+	out := make(row, len(m.fields)+len(m.implicit))
 	for i := range m.fields {
 		f := &m.fields[i]
 		out[f.Name] = f.get(inst)

--- a/admin/resources.go
+++ b/admin/resources.go
@@ -40,12 +40,22 @@ type patchInput struct {
 	Body map[string]any `doc:"Writable field values keyed by registered field names"`
 }
 
+// row is a registered model's field values keyed by field name. It exists
+// so the admin data plane's generic responses have a named type: an
+// anonymous map[string]any as a generic type parameter has no
+// reflect.Type.Name(), so Huma's DefaultSchemaNamer falls back to Go's
+// unnamed-type string ("map[string]interface {}") and that literal space
+// and braces survive into the OpenAPI component name — producing e.g.
+// "DataMetaListMapStringInterface {}PageMeta", which fails OpenAPI 3.1
+// validation (component names must match ^[a-zA-Z0-9._-]+$).
+type row map[string]any
+
 type rowOutput struct {
-	Body contract.Data[map[string]any]
+	Body contract.Data[row]
 }
 
 type listOutput struct {
-	Body contract.DataMeta[[]map[string]any, contract.PageMeta]
+	Body contract.DataMeta[[]row, contract.PageMeta]
 }
 
 type deleteResult struct {
@@ -112,12 +122,12 @@ func (h *handlers) listResources(ctx context.Context, input *listInput) (*listOu
 		return nil, contract.WithContext(ctx, contract.Internal("list resources"))
 	}
 
-	rows := make([]map[string]any, 0)
+	rows := make([]row, 0)
 	m.forEach(slice, func(item any) {
 		rows = append(rows, m.toRow(item))
 	})
 	return &listOutput{
-		Body: contract.DataMeta[[]map[string]any, contract.PageMeta]{
+		Body: contract.DataMeta[[]row, contract.PageMeta]{
 			Data: rows,
 			Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
 		},
@@ -145,7 +155,7 @@ func (h *handlers) createResource(ctx context.Context, input *writeInput) (*rowO
 	if err := db.WithContext(ctx).Create(inst).Error; err != nil {
 		return nil, mapDBError(ctx, err)
 	}
-	return &rowOutput{Body: contract.Data[map[string]any]{Data: m.toRow(inst)}}, nil
+	return &rowOutput{Body: contract.Data[row]{Data: m.toRow(inst)}}, nil
 }
 
 func (h *handlers) getResource(ctx context.Context, input *itemInput) (*rowOutput, error) {
@@ -162,7 +172,7 @@ func (h *handlers) getResource(ctx context.Context, input *itemInput) (*rowOutpu
 	if err != nil {
 		return nil, err
 	}
-	return &rowOutput{Body: contract.Data[map[string]any]{Data: m.toRow(inst)}}, nil
+	return &rowOutput{Body: contract.Data[row]{Data: m.toRow(inst)}}, nil
 }
 
 func (h *handlers) updateResource(ctx context.Context, input *patchInput) (*rowOutput, error) {
@@ -189,7 +199,7 @@ func (h *handlers) updateResource(ctx context.Context, input *patchInput) (*rowO
 	if err := db.WithContext(ctx).Save(inst).Error; err != nil {
 		return nil, mapDBError(ctx, err)
 	}
-	return &rowOutput{Body: contract.Data[map[string]any]{Data: m.toRow(inst)}}, nil
+	return &rowOutput{Body: contract.Data[row]{Data: m.toRow(inst)}}, nil
 }
 
 func (h *handlers) deleteResource(ctx context.Context, input *itemInput) (*deleteOutput, error) {


### PR DESCRIPTION
## Summary

Fixes #100: `gombit openapi generate` failed OpenAPI 3.1 validation for **any** app scaffolded with `--auth cookie`, even one that never calls `admin.Register` for any model, because the admin data plane's generic responses used `map[string]any` directly as a generic type parameter:

```go
type rowOutput struct { Body contract.Data[map[string]any] }
type listOutput struct { Body contract.DataMeta[[]map[string]any, contract.PageMeta] }
```

`map[string]any` is unnamed, so it has no `reflect.Type.Name()`. Huma's `DefaultSchemaNamer` falls back to Go's default type string for unnamed types (`map[string]interface {}` — note the literal space before the braces), and that space and the braces survive verbatim into the generated OpenAPI component name: `DataMetaListMapStringInterface {}PageMeta`, which fails the 3.1 spec's `^[a-zA-Z0-9._-]+$` component-name pattern. The admin data-plane routes are mounted unconditionally whenever `--auth cookie` is active, so this affected every such app from the moment it was scaffolded.

- Gives the type a name — `admin`'s unexported `row`, an alias for `map[string]any` — so Huma's namer takes the normal path instead of the anonymous-type fallback. Huma capitalizes for the schema name regardless of Go export status, so this produces clean names (`DataRow`, `DataMetaListRowPageMeta`) without adding new public API surface.
- No change to the actual JSON responses: `row`'s underlying type is still plain `map[string]any`, so serialization is byte-identical.
- No committed fixtures needed regenerating: `client.SampleApp()` (the framework's own `examples/client/` dogfooding target) never touches the `admin` package, and `examples/tutorial/` has no committed OpenAPI/TS-client artifacts.

## Acceptance criteria

Issue #100's own repro and suggested direction — give the admin data plane's generic row/list types a named Go type. Verified directly (see Validation).

## Scope notes

While validating this end to end against the tutorial's literal chapter order, I found a **separate, new bug**: the bootstrap migration `gombit new` seeds (#101, closing #96) is itself unappliable if `gombit dev` (chapter 2) starts before `gombit db migrate` is ever run (chapter 3) — `AutoMigrate` creates the tables live first, and applying the bootstrap migration afterward fails with the same `table already exists` symptom #96 described. Filed as **#102**, not fixed here — it's unrelated to OpenAPI schema naming and deserves its own PR. My earlier #101 validation didn't hit this because I happened to apply migrations before ever starting `gombit dev`, which isn't the order the tutorial actually documents.

## Validation

- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — 0 issues
- [x] Project `code-review` skill run against this diff — approved (tightened `Row` → unexported `row` per that review; no other findings)
- [x] **Reproduced the exact validation failure** against a freshly scaffolded `--auth cookie` app with zero models registered, confirming it's unconditional, not admin-specific usage: `gombit openapi generate` → the exact error from the issue. After the fix, the same command succeeds and the document's `components.schemas` contains zero names with spaces/braces.
- [x] **Regression test validates against the real OpenAPI 3.1 validator**, not a string check: `TestAdminOpenAPISchemaNamesAreValid` parses the live document with `libopenapi`/`libopenapi-validator` and asserts every component name matches `^[a-zA-Z0-9._-]+$`. Confirmed it actually catches the bug — temporarily reverted `admin/resources.go` and `admin/registry.go`, reran (test failed with the exact reported error), restored, reran (passes).
- [x] Ran the affected tutorial steps (chapter 5's `gombit openapi generate`, chapter 6's `gombit client generate`/`client check --url`) against a locally built binary and confirmed both now succeed where they previously required the `curl`-direct workaround I used in earlier PRs' validation.

## Working agreement checklist

- [x] New behavior has tests — `admin/meta_test.go` (`TestAdminOpenAPISchemaNamesAreValid`), verified to actually catch the regression
- [ ] DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A, no DB-touching code (pure OpenAPI schema naming)
- [x] Stable features ship docs and appear in an example app — N/A, internal type rename with no documented API surface change
- [x] Extraction preserves contracts — N/A, no extraction
- [x] Generators are idempotent/additive, AST-safe, never overwrite user-owned files — N/A, not a generator change
- [x] API changes regenerate the OpenAPI doc + TS client in the same PR — N/A, no committed OpenAPI/TS-client fixtures reference the admin package (verified above)
- [x] No secrets in generated frontend source — unaffected
- [x] Scope stays inside this issue's milestone — did not fold in #102 (filed separately)
- [x] This PR links its issue and states which acceptance criteria it satisfies — #100, above

🤖 Generated with [Claude Code](https://claude.com/claude-code)