### PR TITLE
fix: redact libpq keyword DSN passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ version.
 
 ### Fixed
 
+- `RedactDSN` / `SanitizeError` now redact libpq keyword/value DSN passwords
+  (`password=secret dbname=app`) without swallowing the rest of the DSN, and
+  strip the password token from driver errors that do not echo the full DSN
+  ([#136](https://github.com/gombit-dev/gombit/issues/136)).
 - **Scaffolded apps now build with no manual steps.** `gombit new` wrote
   `require github.com/gombit-dev/gombit v0.0.0` — a version that
   has never existed on the module proxy — so `go build ./...` in a fresh tree

--- a/config/redact.go
+++ b/config/redact.go
@@ -9,7 +9,11 @@ import (
 // RedactedSecret is the placeholder used in place of passwords and DSN userinfo.
 const RedactedSecret = "*****"
 
-var querySecretPattern = regexp.MustCompile(`(?i)((?:password|pwd|pass)=)([^&]*)`)
+// keywordSecretPattern matches password-like keys in URL query strings and
+// libpq keyword/value DSNs. Values stop at '&' or whitespace so
+// `password=secret dbname=app` does not swallow the rest of the DSN (#136).
+// Quoted libpq values (`password='has spaces'`) are consumed as one token.
+var keywordSecretPattern = regexp.MustCompile(`(?i)((?:password|pwd|pass)=)('[^']*'|"[^"]*"|[^&\s]*)`)
 
 // Redacted returns a copy of c with secret-bearing fields replaced so it is
 // safe to print (DSN userinfo/passwords and Redis password).
@@ -25,8 +29,9 @@ func (c Config) Redacted() Config {
 	return out
 }
 
-// RedactDSN returns dsn with userinfo passwords and password-like query
-// parameters replaced. SQLite file paths without userinfo are unchanged.
+// RedactDSN returns dsn with userinfo passwords, libpq keyword passwords
+// (password=/pwd=/pass=), and password-like query parameters replaced.
+// SQLite file paths without those keys are unchanged.
 func RedactDSN(dsn string) string {
 	trimmed := strings.TrimSpace(dsn)
 	if trimmed == "" {
@@ -83,6 +88,9 @@ func SanitizeSecretText(text string, cfg Config) string {
 				}
 			}
 		}
+		for _, secret := range keywordSecretValues(dsn) {
+			text = strings.ReplaceAll(text, secret, RedactedSecret)
+		}
 	}
 	if password := cfg.Cache.Redis.Password; password != "" {
 		text = strings.ReplaceAll(text, password, RedactedSecret)
@@ -94,7 +102,30 @@ func SanitizeSecretText(text string, cfg Config) string {
 }
 
 func redactQuerySecrets(value string) string {
-	return querySecretPattern.ReplaceAllString(value, "${1}"+RedactedSecret)
+	return keywordSecretPattern.ReplaceAllString(value, "${1}"+RedactedSecret)
+}
+
+func keywordSecretValues(dsn string) []string {
+	matches := keywordSecretPattern.FindAllStringSubmatch(dsn, -1)
+	out := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+		if secret := unquoteDSNValue(match[2]); secret != "" {
+			out = append(out, secret)
+		}
+	}
+	return out
+}
+
+func unquoteDSNValue(value string) string {
+	if len(value) >= 2 {
+		if (value[0] == '\'' && value[len(value)-1] == '\'') || (value[0] == '"' && value[len(value)-1] == '"') {
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
 }
 
 func redactURL(u *url.URL) string {

--- a/config/redact_test.go
+++ b/config/redact_test.go
@@ -57,6 +57,34 @@ func TestRedactDSNHidesQueryPassword(t *testing.T) {
 	}
 }
 
+func TestRedactDSNHidesLibpqKeywordPassword(t *testing.T) {
+	t.Parallel()
+
+	dsn := "host=localhost user=gombit password=s3cret dbname=app sslmode=disable" // #nosec G101 -- fake local test DSN.
+	got := RedactDSN(dsn)
+	if strings.Contains(got, "s3cret") {
+		t.Fatalf("RedactDSN() = %q, still contains password", got)
+	}
+	want := "host=localhost user=gombit password=" + RedactedSecret + " dbname=app sslmode=disable"
+	if got != want {
+		t.Fatalf("RedactDSN() = %q, want %q", got, want)
+	}
+}
+
+func TestRedactDSNHidesQuotedLibpqPassword(t *testing.T) {
+	t.Parallel()
+
+	dsn := `host=localhost password='has spaces' dbname=app` // #nosec G101 -- fake local test DSN.
+	got := RedactDSN(dsn)
+	if strings.Contains(got, "has spaces") {
+		t.Fatalf("RedactDSN() = %q, still contains password", got)
+	}
+	want := "host=localhost password=" + RedactedSecret + " dbname=app"
+	if got != want {
+		t.Fatalf("RedactDSN() = %q, want %q", got, want)
+	}
+}
+
 func TestConfigRedactedHidesRedisPassword(t *testing.T) {
 	t.Parallel()
 
@@ -95,5 +123,20 @@ func TestSanitizeErrorRemovesSecrets(t *testing.T) {
 	got := SanitizeError(err, cfg)
 	if strings.Contains(got, "db-secret") || strings.Contains(got, "redis-secret") || strings.Contains(got, "jwt-super-secret") {
 		t.Fatalf("SanitizeError() = %q, still contains secrets", got)
+	}
+}
+
+func TestSanitizeErrorRemovesLibpqKeywordPassword(t *testing.T) {
+	t.Parallel()
+
+	cfg := Default()
+	cfg.Database.DSN = "host=localhost user=gombit password=s3cret dbname=app sslmode=disable" // #nosec G101 -- fake local test DSN.
+
+	got := SanitizeError(errors.New("pq: password=s3cret authentication failed"), cfg)
+	if strings.Contains(got, "s3cret") {
+		t.Fatalf("SanitizeError() = %q, still contains libpq password", got)
+	}
+	if !strings.Contains(got, RedactedSecret) {
+		t.Fatalf("SanitizeError() = %q, want redacted password", got)
 	}
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -97,9 +97,11 @@ Validation returns `config.FieldErrors`, which names the typed field, the
 environment variable, the invalid value, and the validation message.
 
 `gombit config show` prints this typed result as aligned key/value lines.
-DSN userinfo/passwords, the Redis password, and the JWT secret are redacted
-(`*****`); `Config.Redacted()` / `RedactDSN` are the helpers. Do not log raw
-DSNs or JWT secrets.
+DSN userinfo/passwords (URL form, MySQL `user:pass@tcp`, libpq
+`password=`/`pwd=`/`pass=` keywords, and `?password=` query params), the Redis
+password, and the JWT secret are redacted (`*****`); `Config.Redacted()` /
+`RedactDSN` / `SanitizeError` are the helpers. Do not log raw DSNs or JWT
+secrets.
 
 Appendix C production checks fail loudly for a **non-empty** JWT secret
 shorter than 32 characters, for the generated-app development placeholder,


### PR DESCRIPTION
## Summary

`RedactDSN` / `SanitizeError` missed Postgres libpq keyword/value DSNs (`host=… password=secret dbname=app`). The old `password=([^&]*)` pattern swallowed the rest of the DSN, and driver errors that only echoed `password=secret` were not scrubbed.

Closes #136

## Acceptance criteria

Issue #136 has no formal AC checklist; this PR satisfies the stated expected behavior:

- [x] Space-separated `password=` / `pwd=` / `pass=` values are redacted without dropping later keys (`dbname`, `sslmode`)
- [x] Quoted libpq values (`password='has spaces'`) are treated as one token
- [x] `SanitizeError` strips the password token when the error does not contain the full DSN
- [x] Existing URL, MySQL `user:pass@tcp`, and `?password=` query redaction still works

## Scope notes

Libpq backslash-escaped quotes inside `'…'` are not parsed (same class as the previous query-string regex). Empty `password=` stays a keyword-only replace.

## Validation

- [x] `go test ./config ./cli ./database ./migrations -count=1`
- [x] `go test ./config -run 'TestRedactDSNHidesLibpqKeywordPassword|TestRedactDSNHidesQuotedLibpqPassword|TestSanitizeErrorRemovesLibpqKeywordPassword'` (failed before the fix, passes after)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./config`
- [x] Project `code-review` skill run against this diff
- [ ] Full `go test ./...` — `cmd/gombit` / `goldentest` compile cases failed here with `error obtaining VCS status: exit status 128` / `-buildvcs=false` (environment, not this change). `./config` and other unit packages passed.

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A: string redaction only; no driver I/O
- [x] Stable features ship docs and appear in an example app — `docs/config.md` + CHANGELOG; no example app change (CLI already uses these helpers)
- [x] Extraction preserves contracts — N/A
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — N/A
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies