### PR TITLE
fix: correct Atlas URLs for unix sockets, IPv6, and file:/// SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ version.
 
 ### Fixed
 
+- `AtlasURL` now converts Postgres unix-socket and IPv6 libpq DSNs, and
+  SQLite `file:///abs` URIs, into Atlas `--url` values that parse
+  ([#135](https://github.com/gombit-dev/gombit/issues/135)).
 - **Scaffolded apps now build with no manual steps.** `gombit new` wrote
   `require github.com/gombit-dev/gombit v0.0.0` — a version that
   has never existed on the module proxy — so `go build ./...` in a fresh tree

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -268,7 +268,10 @@ SQLite runs without Docker. PostgreSQL and MySQL use Atlas dev-database Docker
 URLs, so Docker must be available when generating those migrations.
 
 Apply/status convert the configured GORM DSN into an Atlas `--url` for the
-same three drivers.
+same three drivers. Libpq keyword/value DSNs with a slash-prefixed `host`
+become a unix-socket URI (`postgres://user@/dbname?host=/path/to/sockets`);
+IPv6 hosts are bracketed (`[::1]:5432`). SQLite `file:///abs/path` maps to
+`sqlite:///abs/path` (three slashes), not four.
 
 ## Model Registration
 

--- a/migrations/atlasurl.go
+++ b/migrations/atlasurl.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -30,14 +31,22 @@ func AtlasURL(cfg config.DatabaseConfig) (string, error) {
 }
 
 func sqliteAtlasURL(dsn string) (string, error) {
-	switch {
-	case strings.HasPrefix(dsn, "sqlite://"):
+	if strings.HasPrefix(dsn, "sqlite://") {
 		return dsn, nil
-	case strings.HasPrefix(dsn, "file:"):
-		rest := strings.TrimPrefix(dsn, "file:")
-		return "sqlite://" + rest, nil
+	}
+	path, query, hasQuery := strings.Cut(dsn, "?")
+	suffix := ""
+	if hasQuery {
+		suffix = "?" + query
+	}
+	switch {
+	case strings.HasPrefix(path, "file:///"):
+		// file:///tmp/app.db → sqlite:///tmp/app.db (three slashes, #135).
+		return "sqlite://" + strings.TrimPrefix(path, "file://") + suffix, nil
+	case strings.HasPrefix(path, "file:"):
+		return "sqlite://" + strings.TrimPrefix(path, "file:") + suffix, nil
 	default:
-		return "sqlite://" + dsn, nil
+		return "sqlite://" + path + suffix, nil
 	}
 }
 
@@ -76,18 +85,6 @@ func postgresKeyValueURL(dsn string) (string, error) {
 		return "", fmt.Errorf("migrations: postgres DSN missing dbname")
 	}
 
-	u := &url.URL{
-		Scheme: "postgres",
-		Host:   host + ":" + port,
-		Path:   "/" + dbname,
-	}
-	if user != "" {
-		if password != "" {
-			u.User = url.UserPassword(user, password)
-		} else {
-			u.User = url.User(user)
-		}
-	}
 	query := url.Values{}
 	for key, value := range values {
 		switch key {
@@ -97,8 +94,39 @@ func postgresKeyValueURL(dsn string) (string, error) {
 			query.Set(key, value)
 		}
 	}
+
+	u := &url.URL{
+		Scheme: "postgres",
+		Path:   "/" + dbname,
+	}
+	if user != "" {
+		if password != "" {
+			u.User = url.UserPassword(user, password)
+		} else {
+			u.User = url.User(user)
+		}
+	}
+	if isPostgresUnixSocket(host) {
+		// libpq URI form: empty host, socket directory in the host query
+		// parameter (postgres://user@/dbname?host=/var/run/postgresql).
+		query.Set("host", host)
+		query.Set("port", port)
+	} else {
+		u.Host = net.JoinHostPort(unbracketHost(host), port)
+	}
 	u.RawQuery = query.Encode()
 	return u.String(), nil
+}
+
+func isPostgresUnixSocket(host string) bool {
+	return strings.HasPrefix(host, "/")
+}
+
+func unbracketHost(host string) string {
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		return host[1 : len(host)-1]
+	}
+	return host
 }
 
 func mysqlAtlasURL(dsn string) (string, error) {

--- a/migrations/atlasurl_test.go
+++ b/migrations/atlasurl_test.go
@@ -22,6 +22,22 @@ func TestAtlasURL(t *testing.T) {
 			want: "sqlite://gombit.db?cache=shared&_fk=1",
 		},
 		{
+			name: "sqlite file absolute uri",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverSQLite,
+				DSN:    "file:///tmp/gombit.db",
+			},
+			want: "sqlite:///tmp/gombit.db",
+		},
+		{
+			name: "sqlite file absolute uri with query",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverSQLite,
+				DSN:    "file:///tmp/gombit.db?cache=shared&_fk=1",
+			},
+			want: "sqlite:///tmp/gombit.db?cache=shared&_fk=1",
+		},
+		{
 			name: "sqlite already atlas",
 			cfg: config.DatabaseConfig{
 				Driver: config.DatabaseDriverSQLite,
@@ -44,6 +60,22 @@ func TestAtlasURL(t *testing.T) {
 				DSN:    "host=localhost user=gombit password=secret dbname=app sslmode=disable", // #nosec G101 -- fake local test DSN.
 			},
 			want: "postgres://gombit:secret@localhost:5432/app?sslmode=disable", // #nosec G101 -- fake local test DSN.
+		},
+		{
+			name: "postgres unix socket",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverPostgres,
+				DSN:    "host=/var/run/postgresql user=gombit dbname=app",
+			},
+			want: "postgres://gombit@/app?host=%2Fvar%2Frun%2Fpostgresql&port=5432",
+		},
+		{
+			name: "postgres ipv6",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverPostgres,
+				DSN:    "host=::1 user=gombit dbname=app sslmode=disable",
+			},
+			want: "postgres://gombit@[::1]:5432/app?sslmode=disable",
 		},
 		{
 			name: "mysql tcp",


### PR DESCRIPTION
## Summary

`AtlasURL` built Atlas `--url` values that did not parse for three DSN shapes used by `gombit db migrate` / `status`:

- Libpq `host=/var/run/postgresql` became `postgres://user@/var/run/postgresql:5432/db`
- `host=::1` became `postgres://user@::1:5432/db` (unbracketed IPv6)
- SQLite `file:///tmp/app.db` became `sqlite:////tmp/app.db` (or five slashes)

Unix sockets now use the libpq empty-host form (`postgres://user@/dbname?host=/path`). IPv6 hosts use `net.JoinHostPort`. Absolute `file:///` URIs map to `sqlite:///abs/path`.

Closes #135

## Acceptance criteria

Issue #135 has no formal AC checklist; this PR satisfies the stated expected behavior:

- [x] Slash-prefixed Postgres `host` is a unix socket URI, not `host:port`
- [x] IPv6 hosts are bracketed (`[::1]:5432`)
- [x] `file:///abs` → `sqlite:///abs` (three slashes)
- [x] Existing relative `file:gombit.db`, Postgres TCP, and MySQL URL cases unchanged

## Scope notes

Quoted libpq values (`host='/tmp'`) and `hostaddr=` are not parsed. Windows named-pipe hosts are out of scope.

## Validation

- [x] `go test ./migrations -count=1`
- [x] New `TestAtlasURL` cases (`sqlite file absolute uri`, `postgres unix socket`, `postgres ipv6`) failed before the fix and pass after
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./migrations`
- [x] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — URL conversion unit tests cover sqlite + postgres; MySQL TCP path unchanged
- [x] Stable features ship docs and appear in an example app — `docs/migrations.md` + CHANGELOG
- [x] Extraction preserves contracts — N/A
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — N/A
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies