### PR TITLE
fix: correct Atlas URLs for unix sockets, IPv6, and file:/// SQLite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,11 @@ jobs:
         working-directory: internal/adminui
         run: npm ci && npm test
 
+      # Parallel packages all shell out to npx; a cold _npx extract races
+      # (TAR_ENTRY_ERROR / missing js-yaml) and fails client generation tests.
+      - name: Warm npx openapi-typescript cache
+        run: npx --yes openapi-typescript@7.13.0 --help >/dev/null
+
       - name: Run tests
         run: go test ./...
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ version.
 
 ### Fixed
 
+- `AtlasURL` now converts Postgres unix-socket and IPv6 libpq DSNs, and
+  SQLite `file:///abs` URIs, into Atlas `--url` values that parse
+  ([#135](https://github.com/gombit-dev/gombit/issues/135)).
 - `RedactDSN` / `SanitizeError` now redact libpq keyword/value DSN passwords
   (`password=secret dbname=app`) without swallowing the rest of the DSN, and
   strip the password token from driver errors that do not echo the full DSN

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -268,7 +268,10 @@ SQLite runs without Docker. PostgreSQL and MySQL use Atlas dev-database Docker
 URLs, so Docker must be available when generating those migrations.
 
 Apply/status convert the configured GORM DSN into an Atlas `--url` for the
-same three drivers.
+same three drivers. Libpq keyword/value DSNs with a slash-prefixed `host`
+become a unix-socket URI (`postgres://user@/dbname?host=/path/to/sockets`);
+IPv6 hosts are bracketed (`[::1]:5432`). SQLite `file:///abs/path` maps to
+`sqlite:///abs/path` (three slashes), not four.
 
 ## Model Registration
 

--- a/migrations/atlasurl.go
+++ b/migrations/atlasurl.go
@@ -34,20 +34,28 @@ func sqliteAtlasURL(dsn string) (string, error) {
 	if strings.HasPrefix(dsn, "sqlite://") {
 		return dsn, nil
 	}
-	path, query, hasQuery := strings.Cut(dsn, "?")
-	suffix := ""
-	if hasQuery {
-		suffix = "?" + query
+	if strings.HasPrefix(dsn, "file:") {
+		return sqliteFileURIToAtlas(dsn), nil
 	}
-	switch {
-	case strings.HasPrefix(path, "file:///"):
-		// file:///tmp/app.db → sqlite:///tmp/app.db (three slashes, #135).
-		return "sqlite://" + strings.TrimPrefix(path, "file://") + suffix, nil
-	case strings.HasPrefix(path, "file:"):
-		return "sqlite://" + strings.TrimPrefix(path, "file:") + suffix, nil
-	default:
-		return "sqlite://" + path + suffix, nil
+	return "sqlite://" + dsn, nil
+}
+
+// sqliteFileURIToAtlas maps a SQLite file: URI onto Atlas's sqlite:// form.
+// url.Parse is required so file:///abs (three slashes) becomes sqlite:///abs,
+// not sqlite:////abs or sqlite://///abs from a naive "file:" strip (#135).
+func sqliteFileURIToAtlas(dsn string) string {
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "sqlite://" + strings.TrimPrefix(dsn, "file:")
 	}
+	path := u.Opaque
+	if path == "" {
+		path = u.Path
+	}
+	if u.RawQuery == "" {
+		return "sqlite://" + path
+	}
+	return "sqlite://" + path + "?" + u.RawQuery
 }
 
 func postgresAtlasURL(dsn string) (string, error) {

--- a/migrations/atlasurl.go
+++ b/migrations/atlasurl.go
@@ -35,7 +35,7 @@ func sqliteAtlasURL(dsn string) (string, error) {
 		return dsn, nil
 	}
 	if strings.HasPrefix(dsn, "file:") {
-		return sqliteFileURIToAtlas(dsn), nil
+		return sqliteFileURIToAtlas(dsn)
 	}
 	return "sqlite://" + dsn, nil
 }
@@ -43,19 +43,19 @@ func sqliteAtlasURL(dsn string) (string, error) {
 // sqliteFileURIToAtlas maps a SQLite file: URI onto Atlas's sqlite:// form.
 // url.Parse is required so file:///abs (three slashes) becomes sqlite:///abs,
 // not sqlite:////abs or sqlite://///abs from a naive "file:" strip (#135).
-func sqliteFileURIToAtlas(dsn string) string {
+func sqliteFileURIToAtlas(dsn string) (string, error) {
 	u, err := url.Parse(dsn)
 	if err != nil {
-		return "sqlite://" + strings.TrimPrefix(dsn, "file:")
+		return "", fmt.Errorf("migrations: sqlite file URI: %w", err)
 	}
 	path := u.Opaque
 	if path == "" {
 		path = u.Path
 	}
 	if u.RawQuery == "" {
-		return "sqlite://" + path
+		return "sqlite://" + path, nil
 	}
-	return "sqlite://" + path + "?" + u.RawQuery
+	return "sqlite://" + path + "?" + u.RawQuery, nil
 }
 
 func postgresAtlasURL(dsn string) (string, error) {

--- a/migrations/atlasurl.go
+++ b/migrations/atlasurl.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -30,14 +31,22 @@ func AtlasURL(cfg config.DatabaseConfig) (string, error) {
 }
 
 func sqliteAtlasURL(dsn string) (string, error) {
-	switch {
-	case strings.HasPrefix(dsn, "sqlite://"):
+	if strings.HasPrefix(dsn, "sqlite://") {
 		return dsn, nil
-	case strings.HasPrefix(dsn, "file:"):
-		rest := strings.TrimPrefix(dsn, "file:")
-		return "sqlite://" + rest, nil
+	}
+	path, query, hasQuery := strings.Cut(dsn, "?")
+	suffix := ""
+	if hasQuery {
+		suffix = "?" + query
+	}
+	switch {
+	case strings.HasPrefix(path, "file:///"):
+		// file:///tmp/app.db → sqlite:///tmp/app.db (three slashes, #135).
+		return "sqlite://" + strings.TrimPrefix(path, "file://") + suffix, nil
+	case strings.HasPrefix(path, "file:"):
+		return "sqlite://" + strings.TrimPrefix(path, "file:") + suffix, nil
 	default:
-		return "sqlite://" + dsn, nil
+		return "sqlite://" + path + suffix, nil
 	}
 }
 
@@ -76,18 +85,6 @@ func postgresKeyValueURL(dsn string) (string, error) {
 		return "", fmt.Errorf("migrations: postgres DSN missing dbname")
 	}
 
-	u := &url.URL{
-		Scheme: "postgres",
-		Host:   host + ":" + port,
-		Path:   "/" + dbname,
-	}
-	if user != "" {
-		if password != "" {
-			u.User = url.UserPassword(user, password)
-		} else {
-			u.User = url.User(user)
-		}
-	}
 	query := url.Values{}
 	for key, value := range values {
 		switch key {
@@ -97,8 +94,39 @@ func postgresKeyValueURL(dsn string) (string, error) {
 			query.Set(key, value)
 		}
 	}
+
+	u := &url.URL{
+		Scheme: "postgres",
+		Path:   "/" + dbname,
+	}
+	if user != "" {
+		if password != "" {
+			u.User = url.UserPassword(user, password)
+		} else {
+			u.User = url.User(user)
+		}
+	}
+	if isPostgresUnixSocket(host) {
+		// libpq URI form: empty host, socket directory in the host query
+		// parameter (postgres://user@/dbname?host=/var/run/postgresql).
+		query.Set("host", host)
+		query.Set("port", port)
+	} else {
+		u.Host = net.JoinHostPort(unbracketHost(host), port)
+	}
 	u.RawQuery = query.Encode()
 	return u.String(), nil
+}
+
+func isPostgresUnixSocket(host string) bool {
+	return strings.HasPrefix(host, "/")
+}
+
+func unbracketHost(host string) string {
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		return host[1 : len(host)-1]
+	}
+	return host
 }
 
 func mysqlAtlasURL(dsn string) (string, error) {

--- a/migrations/atlasurl_test.go
+++ b/migrations/atlasurl_test.go
@@ -22,6 +22,22 @@ func TestAtlasURL(t *testing.T) {
 			want: "sqlite://gombit.db?cache=shared&_fk=1",
 		},
 		{
+			name: "sqlite file absolute uri",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverSQLite,
+				DSN:    "file:///tmp/gombit.db",
+			},
+			want: "sqlite:///tmp/gombit.db",
+		},
+		{
+			name: "sqlite file absolute uri with query",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverSQLite,
+				DSN:    "file:///tmp/gombit.db?cache=shared&_fk=1",
+			},
+			want: "sqlite:///tmp/gombit.db?cache=shared&_fk=1",
+		},
+		{
 			name: "sqlite already atlas",
 			cfg: config.DatabaseConfig{
 				Driver: config.DatabaseDriverSQLite,
@@ -44,6 +60,22 @@ func TestAtlasURL(t *testing.T) {
 				DSN:    "host=localhost user=gombit password=secret dbname=app sslmode=disable", // #nosec G101 -- fake local test DSN.
 			},
 			want: "postgres://gombit:secret@localhost:5432/app?sslmode=disable", // #nosec G101 -- fake local test DSN.
+		},
+		{
+			name: "postgres unix socket",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverPostgres,
+				DSN:    "host=/var/run/postgresql user=gombit dbname=app",
+			},
+			want: "postgres://gombit@/app?host=%2Fvar%2Frun%2Fpostgresql&port=5432",
+		},
+		{
+			name: "postgres ipv6",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverPostgres,
+				DSN:    "host=::1 user=gombit dbname=app sslmode=disable",
+			},
+			want: "postgres://gombit@[::1]:5432/app?sslmode=disable",
 		},
 		{
 			name: "mysql tcp",

--- a/migrations/atlasurl_test.go
+++ b/migrations/atlasurl_test.go
@@ -1,6 +1,7 @@
 package migrations
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/gombit-dev/gombit/config"
@@ -36,6 +37,22 @@ func TestAtlasURL(t *testing.T) {
 				DSN:    "file:///tmp/gombit.db?cache=shared&_fk=1",
 			},
 			want: "sqlite:///tmp/gombit.db?cache=shared&_fk=1",
+		},
+		{
+			name: "sqlite file single-slash absolute",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverSQLite,
+				DSN:    "file:/tmp/gombit.db",
+			},
+			want: "sqlite:///tmp/gombit.db",
+		},
+		{
+			name: "sqlite file memory uri",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverSQLite,
+				DSN:    "file::memory:?cache=shared&_fk=1",
+			},
+			want: "sqlite://:memory:?cache=shared&_fk=1",
 		},
 		{
 			name: "sqlite already atlas",
@@ -76,6 +93,22 @@ func TestAtlasURL(t *testing.T) {
 				DSN:    "host=::1 user=gombit dbname=app sslmode=disable",
 			},
 			want: "postgres://gombit@[::1]:5432/app?sslmode=disable",
+		},
+		{
+			name: "postgres ipv6 already bracketed",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverPostgres,
+				DSN:    "host=[::1] user=gombit dbname=app sslmode=disable",
+			},
+			want: "postgres://gombit@[::1]:5432/app?sslmode=disable",
+		},
+		{
+			name: "postgres unix socket with sslmode",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverPostgres,
+				DSN:    "host=/var/run/postgresql user=gombit dbname=app sslmode=disable",
+			},
+			want: "postgres://gombit@/app?host=%2Fvar%2Frun%2Fpostgresql&port=5432&sslmode=disable",
 		},
 		{
 			name: "mysql tcp",
@@ -125,6 +158,27 @@ func TestAtlasURL(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Fatalf("AtlasURL() = %q, want %q", got, tt.want)
+			}
+			parsed, err := url.Parse(got)
+			if err != nil {
+				t.Fatalf("AtlasURL() produced unparseable URL %q: %v", got, err)
+			}
+			switch tt.name {
+			case "postgres unix socket", "postgres unix socket with sslmode":
+				if parsed.Host != "" {
+					t.Fatalf("unix socket URL host = %q, want empty (libpq ?host= form)", parsed.Host)
+				}
+				if gotHost := parsed.Query().Get("host"); gotHost != "/var/run/postgresql" {
+					t.Fatalf("unix socket query host = %q, want %q", gotHost, "/var/run/postgresql")
+				}
+			case "postgres ipv6", "postgres ipv6 already bracketed":
+				if parsed.Hostname() != "::1" || parsed.Port() != "5432" {
+					t.Fatalf("ipv6 URL hostname:port = %q:%q, want [::1]:5432", parsed.Hostname(), parsed.Port())
+				}
+			case "sqlite file absolute uri", "sqlite file single-slash absolute":
+				if parsed.Path != "/tmp/gombit.db" {
+					t.Fatalf("sqlite absolute path = %q, want %q", parsed.Path, "/tmp/gombit.db")
+				}
 			}
 		})
 	}

--- a/migrations/atlasurl_test.go
+++ b/migrations/atlasurl_test.go
@@ -142,6 +142,14 @@ func TestAtlasURL(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "sqlite file uri invalid percent escape",
+			cfg: config.DatabaseConfig{
+				Driver: config.DatabaseDriverSQLite,
+				DSN:    "file:///tmp/foo%2.db",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`AtlasURL` built Atlas `--url` values that did not parse for three DSN shapes used by `gombit db migrate` / `status`:

- Libpq `host=/var/run/postgresql` became `postgres://user@/var/run/postgresql:5432/db`
- `host=::1` became `postgres://user@::1:5432/db` (unbracketed IPv6)
- SQLite `file:///tmp/app.db` became `sqlite:////tmp/app.db` (or five slashes)

Unix sockets now use the libpq empty-host form (`postgres://user@/dbname?host=/path`). IPv6 hosts use `net.JoinHostPort`. SQLite `file:` URIs are parsed with `net/url` so `file:///abs` maps to `sqlite:///abs`. Unparseable `file:` URIs return an error instead of falling back to a `file:` strip that recreates the extra-slash bug.

This continues [#140](https://github.com/gombit-dev/gombit/pull/140): that PR’s Test job failed when parallel `npx openapi-typescript` extracts raced on the runner cache. This branch rebases onto current `main`, keeps the Atlas URL conversion, and warms the pinned `openapi-typescript@7.13.0` cache before `go test ./...`.

Closes #135

## Acceptance criteria

Issue #135 has no formal AC checklist; this PR satisfies the stated expected behavior:

- [x] Slash-prefixed Postgres `host` is a unix socket URI, not `host:port`
- [x] IPv6 hosts are bracketed (`[::1]:5432`)
- [x] `file:///abs` → `sqlite:///abs` (three slashes)
- [x] Existing relative `file:gombit.db`, Postgres TCP, and MySQL URL cases unchanged
- [x] Generated URLs parse with `net/url` (the same parser Atlas uses)
- [x] Unparseable `file:` URIs error instead of emitting `sqlite:////…`

## Scope notes

Quoted libpq values (`host='/tmp'`) and `hostaddr=` are not parsed. Windows named-pipe hosts are out of scope. The CI npx warmup is included because it is why Test is green under `go test ./...`; it is not Atlas URL conversion.

## Validation

- [x] `go test ./migrations -count=1 -run TestAtlasURL`
- [x] New `TestAtlasURL` cases (`sqlite file absolute uri`, `postgres unix socket`, `postgres ipv6`, already-bracketed IPv6, `file:/abs`, `file::memory:`, invalid percent-escape) pass
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./migrations`
- [x] GitHub CI (lint, build, test, contract-drift, database/migrations/conformance matrix) green on `89f02a5`
- [x] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — URL conversion unit tests cover sqlite + postgres; MySQL TCP path unchanged
- [x] Stable features ship docs and appear in an example app — `docs/migrations.md` + CHANGELOG
- [x] Extraction preserves contracts — N/A (bugfix, not an extraction)
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — N/A
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9ef9a38-b5f2-43d1-a588-fabab5133a71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9ef9a38-b5f2-43d1-a588-fabab5133a71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

