### PR TITLE
fix: retry 401s with a fresh body instead of cloning a consumed Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ version.
 
 ### Fixed
 
+- Generated SPA 401 interceptor no longer clones a consumed `Request` after
+  silent refresh. POST/PATCH retries now resend the buffered JSON body
+  ([#106](https://github.com/gombit-dev/gombit/issues/106)).
 - XSS JSON sanitization no longer `io.ReadAll`s request bodies without a
   bound: JSON sanitizer buffering is capped at 8MiB (HTTP 413, D10
   `payload_too_large`), and `http.Server.ReadTimeout` follows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ version.
 ### Fixed
 
 - Generated SPA 401 interceptor no longer clones a consumed `Request` after
-  silent refresh. POST/PATCH retries now resend the buffered JSON body
-  ([#106](https://github.com/gombit-dev/gombit/issues/106)).
+  silent refresh. POST/PATCH retries buffer via `clone().arrayBuffer()` gated
+  on method (Firefox's `Request.body` getter is undefined) and resend those
+  bytes ([#106](https://github.com/gombit-dev/gombit/issues/106)).
 - XSS JSON sanitization no longer `io.ReadAll`s request bodies without a
   bound: JSON sanitizer buffering is capped at 8MiB (HTTP 413, D10
   `payload_too_large`), and `http.Server.ReadTimeout` follows

--- a/docs/auth-cookie.md
+++ b/docs/auth-cookie.md
@@ -118,11 +118,12 @@ production JWT-secret-strength check.
 "authenticated" flag and the in-memory CSRF token — never the session
 tokens themselves, which the browser holds as HttpOnly cookies this code
 cannot read. `frontend/src/api/client.ts` attaches `X-CSRF-Token` on unsafe
-requests and retries once after a silent `/auth/refresh` on 401.
-`RequireAuth` confirms a session by calling `GET /me` (it cannot check an
-in-memory token, unlike Bearer mode). `LoginPage` calls `bootstrapCSRF()` on
-mount so the login `POST` itself has a token to double-submit. See the
-templates under
+requests and retries once after a silent `/auth/refresh` on 401. The retry
+rebuilds the request from buffered body bytes so POST/PATCH JSON survives
+that refresh. `RequireAuth` confirms a session by calling `GET /me` (it
+cannot check an in-memory token, unlike Bearer mode). `LoginPage` calls
+`bootstrapCSRF()` on mount so the login `POST` itself has a token to
+double-submit. See the templates under
 [`scaffold/templates/frontend/src`](../scaffold/templates/frontend/src) for
 the exact `{{if eq .Auth "cookie"}}` branches.
 

--- a/docs/auth-cookie.md
+++ b/docs/auth-cookie.md
@@ -120,10 +120,11 @@ tokens themselves, which the browser holds as HttpOnly cookies this code
 cannot read. `frontend/src/api/client.ts` attaches `X-CSRF-Token` on unsafe
 requests and retries once after a silent `/auth/refresh` on 401. The retry
 rebuilds the request from buffered body bytes so POST/PATCH JSON survives
-that refresh. `RequireAuth` confirms a session by calling `GET /me` (it
-cannot check an in-memory token, unlike Bearer mode). `LoginPage` calls
-`bootstrapCSRF()` on mount so the login `POST` itself has a token to
-double-submit. See the templates under
+that refresh (buffering is gated on method; Firefox does not implement
+the Request.body getter). `RequireAuth` confirms a session by calling
+`GET /me` (it cannot check an in-memory token, unlike Bearer mode).
+`LoginPage` calls `bootstrapCSRF()` on mount so the login `POST` itself
+has a token to double-submit. See the templates under
 [`scaffold/templates/frontend/src`](../scaffold/templates/frontend/src) for
 the exact `{{if eq .Auth "cookie"}}` branches.
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -76,7 +76,8 @@ Generated `.env.example` keeps a short development placeholder so
 `createAppClient` sends the access token and, on 401, rotates `/auth/refresh`
 once. Concurrent 401s wait on that same refresh and retry instead of failing
 with the stale response. The retry rebuilds the request from buffered body
-bytes so POST/PATCH JSON is resent after silent refresh. `RequireAuth`
+bytes so POST/PATCH JSON is resent after silent refresh (buffering is gated
+on method because Firefox's Request.body getter is unimplemented). `RequireAuth`
 sends anonymous users to `/login`.
 Logout clears memory and revokes the refresh token.
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -75,7 +75,9 @@ Generated `.env.example` keeps a short development placeholder so
 `frontend/src/auth/session.ts` holds both tokens in module variables.
 `createAppClient` sends the access token and, on 401, rotates `/auth/refresh`
 once. Concurrent 401s wait on that same refresh and retry instead of failing
-with the stale response. `RequireAuth` sends anonymous users to `/login`.
+with the stale response. The retry rebuilds the request from buffered body
+bytes so POST/PATCH JSON is resent after silent refresh. `RequireAuth`
+sends anonymous users to `/login`.
 Logout clears memory and revokes the refresh token.
 
 Product pages sit behind `RequireAuth`. Register from the login page is a

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -36,6 +36,7 @@ frontend/src/
 │   └── router.tsx      # /login, RequireAuth, /, /products/new
 ├── api/
 │   ├── client.ts       # createAppClient + 401 refresh + useApiClient
+│   ├── retry.ts        # buffer POST/PATCH body; rebuild 401 retry init
 │   ├── formErrors.ts   # D10 fields → RHF setError
 │   └── generated/      # schema.ts, client.ts, error.ts
 ├── auth/
@@ -73,6 +74,7 @@ variables. `getAccessToken` is passed into `createGombitClient`.
 `POST /api/v1/auth/refresh` once using the in-memory refresh token.
 Concurrent 401s wait on that refresh and retry instead of returning the
 stale failure. The retry rebuilds the request from buffered body bytes
+(gated on method, not the Request.body getter — unimplemented in Firefox)
 rather than cloning the consumed `Request`, so POST/PATCH JSON survives
 silent refresh. `RequireAuth` sends anonymous users to `/login`. Logout
 clears memory and revokes the refresh token. Generated source never reads

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -72,7 +72,9 @@ variables. `getAccessToken` is passed into `createGombitClient`.
 `createAppClient` attaches `Authorization: Bearer` and, on 401, calls
 `POST /api/v1/auth/refresh` once using the in-memory refresh token.
 Concurrent 401s wait on that refresh and retry instead of returning the
-stale failure. `RequireAuth` sends anonymous users to `/login`. Logout
+stale failure. The retry rebuilds the request from buffered body bytes
+rather than cloning the consumed `Request`, so POST/PATCH JSON survives
+silent refresh. `RequireAuth` sends anonymous users to `/login`. Logout
 clears memory and revokes the refresh token. Generated source never reads
 `localStorage` or `sessionStorage`. See [auth.md](auth.md).
 

--- a/goldentest/testdata/golden/make-command/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/make-command/frontend/src/api/client.ts
@@ -18,7 +18,8 @@ export const ApiClientContext = createContext<ApiClient | null>(null);
  *
  * On 401, rotate the in-memory refresh token once and retry. Concurrent
  * 401s share that refresh instead of returning stale failures. Tokens are
- * never written to web storage.
+ * never written to web storage. The retry rebuilds fetch() from buffered
+ * body bytes so POST/PATCH JSON survives silent refresh.
  */
 export function createAppClient(): ApiClient {
   const baseUrl = import.meta.env.VITE_API_URL ?? "";
@@ -28,6 +29,7 @@ export function createAppClient(): ApiClient {
   });
 
   let refreshInFlight: Promise<boolean> | null = null;
+  const retryBodies = new WeakMap<Request, ArrayBuffer>();
 
   async function refreshSession(): Promise<boolean> {
     if (refreshInFlight) {
@@ -57,6 +59,14 @@ export function createAppClient(): ApiClient {
   }
 
   client.use({
+    async onRequest({ request }) {
+      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
+      // POST/PATCH JSON after silent refresh.
+      if (request.body != null) {
+        retryBodies.set(request, await request.clone().arrayBuffer());
+      }
+      return request;
+    },
     async onResponse({ request, response }) {
       if (response.status !== 401 || isAuthURL(request.url)) {
         return response;
@@ -65,14 +75,12 @@ export function createAppClient(): ApiClient {
       if (!ok) {
         return response;
       }
-      const retry = new Request(request, {
-        headers: new Headers(request.headers),
-      });
+      const headers = new Headers(request.headers);
       const access = getAccessToken();
       if (access) {
-        retry.headers.set("Authorization", `Bearer ${access}`);
+        headers.set("Authorization", `Bearer ${access}`);
       }
-      return fetch(retry);
+      return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
     },
   });
   return client;
@@ -84,6 +92,18 @@ export function useApiClient(): ApiClient {
     throw new Error("useApiClient must be used within AppProviders");
   }
   return client;
+}
+
+function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/goldentest/testdata/golden/make-command/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/make-command/frontend/src/api/client.ts
@@ -7,6 +7,7 @@ import {
   getRefreshToken,
 } from "../auth/session";
 import { createGombitClient, unwrap } from "./generated/client";
+import { bufferRetryBody, retryInit } from "./retry";
 
 export type ApiClient = ReturnType<typeof createGombitClient>;
 
@@ -60,11 +61,7 @@ export function createAppClient(): ApiClient {
 
   client.use({
     async onRequest({ request }) {
-      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
-      // POST/PATCH JSON after silent refresh.
-      if (request.body != null) {
-        retryBodies.set(request, await request.clone().arrayBuffer());
-      }
+      await bufferRetryBody(request, retryBodies);
       return request;
     },
     async onResponse({ request, response }) {
@@ -92,18 +89,6 @@ export function useApiClient(): ApiClient {
     throw new Error("useApiClient must be used within AppProviders");
   }
   return client;
-}
-
-function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
-  const init: RequestInit = {
-    method: request.method,
-    headers,
-    credentials: request.credentials,
-  };
-  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
-    init.body = body;
-  }
-  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/goldentest/testdata/golden/make-command/frontend/src/api/retry.ts
+++ b/goldentest/testdata/golden/make-command/frontend/src/api/retry.ts
@@ -1,0 +1,41 @@
+/**
+ * 401 retry helpers for createAppClient.
+ *
+ * Fetch consumes a Request's body stream. Firefox's Request.body getter is
+ * unimplemented (always undefined; MDN / Bugzilla 1387483), so buffering
+ * MUST be gated on method, not the Request.body getter. clone() and
+ * arrayBuffer() are implemented there and still yield the JSON bytes.
+ */
+
+export async function bufferRetryBody(
+  request: Request,
+  bodies: WeakMap<Request, ArrayBuffer>,
+): Promise<void> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    bodies.set(request, await request.clone().arrayBuffer());
+  }
+}
+
+export function retryInit(
+  request: Request,
+  headers: Headers,
+  body: ArrayBuffer | undefined,
+): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+    cache: request.cache,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    signal: request.signal,
+    mode: request.mode,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
+}

--- a/goldentest/testdata/golden/make-resource/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/make-resource/frontend/src/api/client.ts
@@ -18,7 +18,8 @@ export const ApiClientContext = createContext<ApiClient | null>(null);
  *
  * On 401, rotate the in-memory refresh token once and retry. Concurrent
  * 401s share that refresh instead of returning stale failures. Tokens are
- * never written to web storage.
+ * never written to web storage. The retry rebuilds fetch() from buffered
+ * body bytes so POST/PATCH JSON survives silent refresh.
  */
 export function createAppClient(): ApiClient {
   const baseUrl = import.meta.env.VITE_API_URL ?? "";
@@ -28,6 +29,7 @@ export function createAppClient(): ApiClient {
   });
 
   let refreshInFlight: Promise<boolean> | null = null;
+  const retryBodies = new WeakMap<Request, ArrayBuffer>();
 
   async function refreshSession(): Promise<boolean> {
     if (refreshInFlight) {
@@ -57,6 +59,14 @@ export function createAppClient(): ApiClient {
   }
 
   client.use({
+    async onRequest({ request }) {
+      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
+      // POST/PATCH JSON after silent refresh.
+      if (request.body != null) {
+        retryBodies.set(request, await request.clone().arrayBuffer());
+      }
+      return request;
+    },
     async onResponse({ request, response }) {
       if (response.status !== 401 || isAuthURL(request.url)) {
         return response;
@@ -65,14 +75,12 @@ export function createAppClient(): ApiClient {
       if (!ok) {
         return response;
       }
-      const retry = new Request(request, {
-        headers: new Headers(request.headers),
-      });
+      const headers = new Headers(request.headers);
       const access = getAccessToken();
       if (access) {
-        retry.headers.set("Authorization", `Bearer ${access}`);
+        headers.set("Authorization", `Bearer ${access}`);
       }
-      return fetch(retry);
+      return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
     },
   });
   return client;
@@ -84,6 +92,18 @@ export function useApiClient(): ApiClient {
     throw new Error("useApiClient must be used within AppProviders");
   }
   return client;
+}
+
+function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/goldentest/testdata/golden/make-resource/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/make-resource/frontend/src/api/client.ts
@@ -7,6 +7,7 @@ import {
   getRefreshToken,
 } from "../auth/session";
 import { createGombitClient, unwrap } from "./generated/client";
+import { bufferRetryBody, retryInit } from "./retry";
 
 export type ApiClient = ReturnType<typeof createGombitClient>;
 
@@ -60,11 +61,7 @@ export function createAppClient(): ApiClient {
 
   client.use({
     async onRequest({ request }) {
-      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
-      // POST/PATCH JSON after silent refresh.
-      if (request.body != null) {
-        retryBodies.set(request, await request.clone().arrayBuffer());
-      }
+      await bufferRetryBody(request, retryBodies);
       return request;
     },
     async onResponse({ request, response }) {
@@ -92,18 +89,6 @@ export function useApiClient(): ApiClient {
     throw new Error("useApiClient must be used within AppProviders");
   }
   return client;
-}
-
-function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
-  const init: RequestInit = {
-    method: request.method,
-    headers,
-    credentials: request.credentials,
-  };
-  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
-    init.body = body;
-  }
-  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/goldentest/testdata/golden/make-resource/frontend/src/api/retry.ts
+++ b/goldentest/testdata/golden/make-resource/frontend/src/api/retry.ts
@@ -1,0 +1,41 @@
+/**
+ * 401 retry helpers for createAppClient.
+ *
+ * Fetch consumes a Request's body stream. Firefox's Request.body getter is
+ * unimplemented (always undefined; MDN / Bugzilla 1387483), so buffering
+ * MUST be gated on method, not the Request.body getter. clone() and
+ * arrayBuffer() are implemented there and still yield the JSON bytes.
+ */
+
+export async function bufferRetryBody(
+  request: Request,
+  bodies: WeakMap<Request, ArrayBuffer>,
+): Promise<void> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    bodies.set(request, await request.clone().arrayBuffer());
+  }
+}
+
+export function retryInit(
+  request: Request,
+  headers: Headers,
+  body: ArrayBuffer | undefined,
+): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+    cache: request.cache,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    signal: request.signal,
+    mode: request.mode,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
+}

--- a/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
@@ -20,7 +20,8 @@ const REFRESH_PATH = "/api/v1/auth/refresh";
  * (M5-3). Session cookies (HttpOnly) and the CSRF cookie are managed by the
  * browser on same-origin requests; this wiring adds the X-CSRF-Token
  * double-submit header on state-changing requests and retries once after a
- * silent cookie refresh on 401. See docs/auth-cookie.md.
+ * silent cookie refresh on 401. The retry rebuilds fetch() from buffered
+ * body bytes so POST/PATCH JSON survives that refresh. See docs/auth-cookie.md.
  *
  * The CSRF bootstrap and refresh calls below use fetch directly instead of
  * the typed client: they are session infrastructure, not part of the
@@ -43,6 +44,7 @@ export function createAppClient(): ApiClient {
   });
 
   let refreshInFlight: Promise<boolean> | null = null;
+  const retryBodies = new WeakMap<Request, ArrayBuffer>();
 
   async function refreshSession(): Promise<boolean> {
     if (refreshInFlight) {
@@ -71,6 +73,14 @@ export function createAppClient(): ApiClient {
   }
 
   client.use({
+    async onRequest({ request }) {
+      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
+      // POST/PATCH JSON after silent refresh.
+      if (request.body != null) {
+        retryBodies.set(request, await request.clone().arrayBuffer());
+      }
+      return request;
+    },
     async onResponse({ request, response }) {
       if (response.status !== 401 || isAuthURL(request.url)) {
         return response;
@@ -79,12 +89,12 @@ export function createAppClient(): ApiClient {
       if (!ok) {
         return response;
       }
-      const retry = new Request(request, { headers: new Headers(request.headers) });
+      const headers = new Headers(request.headers);
       const token = getCSRFToken();
       if (token) {
-        retry.headers.set("X-CSRF-Token", token);
+        headers.set("X-CSRF-Token", token);
       }
-      return fetch(retry);
+      return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
     },
   });
   return client;
@@ -122,6 +132,18 @@ export function useApiClient(): ApiClient {
 
 function isUnsafeMethod(method: string): boolean {
   return method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
+}
+
+function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
@@ -7,6 +7,7 @@ import {
   setCSRFToken,
 } from "../auth/session";
 import { createGombitClient } from "./generated/client";
+import { bufferRetryBody, retryInit } from "./retry";
 
 export type ApiClient = ReturnType<typeof createGombitClient>;
 
@@ -74,11 +75,7 @@ export function createAppClient(): ApiClient {
 
   client.use({
     async onRequest({ request }) {
-      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
-      // POST/PATCH JSON after silent refresh.
-      if (request.body != null) {
-        retryBodies.set(request, await request.clone().arrayBuffer());
-      }
+      await bufferRetryBody(request, retryBodies);
       return request;
     },
     async onResponse({ request, response }) {
@@ -132,18 +129,6 @@ export function useApiClient(): ApiClient {
 
 function isUnsafeMethod(method: string): boolean {
   return method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
-}
-
-function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
-  const init: RequestInit = {
-    method: request.method,
-    headers,
-    credentials: request.credentials,
-  };
-  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
-    init.body = body;
-  }
-  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/goldentest/testdata/golden/new-cookie/frontend/src/api/retry.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/api/retry.ts
@@ -1,0 +1,41 @@
+/**
+ * 401 retry helpers for createAppClient.
+ *
+ * Fetch consumes a Request's body stream. Firefox's Request.body getter is
+ * unimplemented (always undefined; MDN / Bugzilla 1387483), so buffering
+ * MUST be gated on method, not the Request.body getter. clone() and
+ * arrayBuffer() are implemented there and still yield the JSON bytes.
+ */
+
+export async function bufferRetryBody(
+  request: Request,
+  bodies: WeakMap<Request, ArrayBuffer>,
+): Promise<void> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    bodies.set(request, await request.clone().arrayBuffer());
+  }
+}
+
+export function retryInit(
+  request: Request,
+  headers: Headers,
+  body: ArrayBuffer | undefined,
+): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+    cache: request.cache,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    signal: request.signal,
+    mode: request.mode,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
+}

--- a/goldentest/testdata/golden/new-mui/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new-mui/frontend/src/api/client.ts
@@ -18,7 +18,8 @@ export const ApiClientContext = createContext<ApiClient | null>(null);
  *
  * On 401, rotate the in-memory refresh token once and retry. Concurrent
  * 401s share that refresh instead of returning stale failures. Tokens are
- * never written to web storage.
+ * never written to web storage. The retry rebuilds fetch() from buffered
+ * body bytes so POST/PATCH JSON survives silent refresh.
  */
 export function createAppClient(): ApiClient {
   const baseUrl = import.meta.env.VITE_API_URL ?? "";
@@ -28,6 +29,7 @@ export function createAppClient(): ApiClient {
   });
 
   let refreshInFlight: Promise<boolean> | null = null;
+  const retryBodies = new WeakMap<Request, ArrayBuffer>();
 
   async function refreshSession(): Promise<boolean> {
     if (refreshInFlight) {
@@ -57,6 +59,14 @@ export function createAppClient(): ApiClient {
   }
 
   client.use({
+    async onRequest({ request }) {
+      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
+      // POST/PATCH JSON after silent refresh.
+      if (request.body != null) {
+        retryBodies.set(request, await request.clone().arrayBuffer());
+      }
+      return request;
+    },
     async onResponse({ request, response }) {
       if (response.status !== 401 || isAuthURL(request.url)) {
         return response;
@@ -65,14 +75,12 @@ export function createAppClient(): ApiClient {
       if (!ok) {
         return response;
       }
-      const retry = new Request(request, {
-        headers: new Headers(request.headers),
-      });
+      const headers = new Headers(request.headers);
       const access = getAccessToken();
       if (access) {
-        retry.headers.set("Authorization", `Bearer ${access}`);
+        headers.set("Authorization", `Bearer ${access}`);
       }
-      return fetch(retry);
+      return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
     },
   });
   return client;
@@ -84,6 +92,18 @@ export function useApiClient(): ApiClient {
     throw new Error("useApiClient must be used within AppProviders");
   }
   return client;
+}
+
+function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/goldentest/testdata/golden/new-mui/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new-mui/frontend/src/api/client.ts
@@ -7,6 +7,7 @@ import {
   getRefreshToken,
 } from "../auth/session";
 import { createGombitClient, unwrap } from "./generated/client";
+import { bufferRetryBody, retryInit } from "./retry";
 
 export type ApiClient = ReturnType<typeof createGombitClient>;
 
@@ -60,11 +61,7 @@ export function createAppClient(): ApiClient {
 
   client.use({
     async onRequest({ request }) {
-      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
-      // POST/PATCH JSON after silent refresh.
-      if (request.body != null) {
-        retryBodies.set(request, await request.clone().arrayBuffer());
-      }
+      await bufferRetryBody(request, retryBodies);
       return request;
     },
     async onResponse({ request, response }) {
@@ -92,18 +89,6 @@ export function useApiClient(): ApiClient {
     throw new Error("useApiClient must be used within AppProviders");
   }
   return client;
-}
-
-function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
-  const init: RequestInit = {
-    method: request.method,
-    headers,
-    credentials: request.credentials,
-  };
-  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
-    init.body = body;
-  }
-  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/goldentest/testdata/golden/new-mui/frontend/src/api/retry.ts
+++ b/goldentest/testdata/golden/new-mui/frontend/src/api/retry.ts
@@ -1,0 +1,41 @@
+/**
+ * 401 retry helpers for createAppClient.
+ *
+ * Fetch consumes a Request's body stream. Firefox's Request.body getter is
+ * unimplemented (always undefined; MDN / Bugzilla 1387483), so buffering
+ * MUST be gated on method, not the Request.body getter. clone() and
+ * arrayBuffer() are implemented there and still yield the JSON bytes.
+ */
+
+export async function bufferRetryBody(
+  request: Request,
+  bodies: WeakMap<Request, ArrayBuffer>,
+): Promise<void> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    bodies.set(request, await request.clone().arrayBuffer());
+  }
+}
+
+export function retryInit(
+  request: Request,
+  headers: Headers,
+  body: ArrayBuffer | undefined,
+): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+    cache: request.cache,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    signal: request.signal,
+    mode: request.mode,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
+}

--- a/goldentest/testdata/golden/new/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new/frontend/src/api/client.ts
@@ -18,7 +18,8 @@ export const ApiClientContext = createContext<ApiClient | null>(null);
  *
  * On 401, rotate the in-memory refresh token once and retry. Concurrent
  * 401s share that refresh instead of returning stale failures. Tokens are
- * never written to web storage.
+ * never written to web storage. The retry rebuilds fetch() from buffered
+ * body bytes so POST/PATCH JSON survives silent refresh.
  */
 export function createAppClient(): ApiClient {
   const baseUrl = import.meta.env.VITE_API_URL ?? "";
@@ -28,6 +29,7 @@ export function createAppClient(): ApiClient {
   });
 
   let refreshInFlight: Promise<boolean> | null = null;
+  const retryBodies = new WeakMap<Request, ArrayBuffer>();
 
   async function refreshSession(): Promise<boolean> {
     if (refreshInFlight) {
@@ -57,6 +59,14 @@ export function createAppClient(): ApiClient {
   }
 
   client.use({
+    async onRequest({ request }) {
+      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
+      // POST/PATCH JSON after silent refresh.
+      if (request.body != null) {
+        retryBodies.set(request, await request.clone().arrayBuffer());
+      }
+      return request;
+    },
     async onResponse({ request, response }) {
       if (response.status !== 401 || isAuthURL(request.url)) {
         return response;
@@ -65,14 +75,12 @@ export function createAppClient(): ApiClient {
       if (!ok) {
         return response;
       }
-      const retry = new Request(request, {
-        headers: new Headers(request.headers),
-      });
+      const headers = new Headers(request.headers);
       const access = getAccessToken();
       if (access) {
-        retry.headers.set("Authorization", `Bearer ${access}`);
+        headers.set("Authorization", `Bearer ${access}`);
       }
-      return fetch(retry);
+      return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
     },
   });
   return client;
@@ -84,6 +92,18 @@ export function useApiClient(): ApiClient {
     throw new Error("useApiClient must be used within AppProviders");
   }
   return client;
+}
+
+function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/goldentest/testdata/golden/new/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new/frontend/src/api/client.ts
@@ -7,6 +7,7 @@ import {
   getRefreshToken,
 } from "../auth/session";
 import { createGombitClient, unwrap } from "./generated/client";
+import { bufferRetryBody, retryInit } from "./retry";
 
 export type ApiClient = ReturnType<typeof createGombitClient>;
 
@@ -60,11 +61,7 @@ export function createAppClient(): ApiClient {
 
   client.use({
     async onRequest({ request }) {
-      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
-      // POST/PATCH JSON after silent refresh.
-      if (request.body != null) {
-        retryBodies.set(request, await request.clone().arrayBuffer());
-      }
+      await bufferRetryBody(request, retryBodies);
       return request;
     },
     async onResponse({ request, response }) {
@@ -92,18 +89,6 @@ export function useApiClient(): ApiClient {
     throw new Error("useApiClient must be used within AppProviders");
   }
   return client;
-}
-
-function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
-  const init: RequestInit = {
-    method: request.method,
-    headers,
-    credentials: request.credentials,
-  };
-  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
-    init.body = body;
-  }
-  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/goldentest/testdata/golden/new/frontend/src/api/retry.ts
+++ b/goldentest/testdata/golden/new/frontend/src/api/retry.ts
@@ -1,0 +1,41 @@
+/**
+ * 401 retry helpers for createAppClient.
+ *
+ * Fetch consumes a Request's body stream. Firefox's Request.body getter is
+ * unimplemented (always undefined; MDN / Bugzilla 1387483), so buffering
+ * MUST be gated on method, not the Request.body getter. clone() and
+ * arrayBuffer() are implemented there and still yield the JSON bytes.
+ */
+
+export async function bufferRetryBody(
+  request: Request,
+  bodies: WeakMap<Request, ArrayBuffer>,
+): Promise<void> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    bodies.set(request, await request.clone().arrayBuffer());
+  }
+}
+
+export function retryInit(
+  request: Request,
+  headers: Headers,
+  body: ArrayBuffer | undefined,
+): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+    cache: request.cache,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    signal: request.signal,
+    mode: request.mode,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
+}

--- a/goldentest/tree_test.go
+++ b/goldentest/tree_test.go
@@ -89,7 +89,11 @@ func assertFrontendInvariants(t *testing.T, files fileMap) {
 	if !strings.Contains(client, "refreshInFlight") {
 		t.Error("client.ts missing shared refresh promise")
 	}
-	assert401RetryReusesBufferedBody(t, client, []string{`headers.set("Authorization", ` + "`Bearer ${access}`" + `)`})
+	retry := string(files["frontend/src/api/retry.ts"])
+	if retry == "" {
+		t.Fatal("missing frontend/src/api/retry.ts")
+	}
+	assert401RetryReusesBufferedBody(t, client, retry, []string{`headers.set("Authorization", ` + "`Bearer ${access}`" + `)`})
 }
 
 // assertCookieFrontendInvariants is assertFrontendInvariants' counterpart for
@@ -142,7 +146,11 @@ func assertCookieFrontendInvariants(t *testing.T, files fileMap) {
 	if !strings.Contains(client, "X-CSRF-Token") {
 		t.Error("cookie-mode client.ts missing X-CSRF-Token double-submit")
 	}
-	assert401RetryReusesBufferedBody(t, client, []string{`headers.set("X-CSRF-Token", token)`})
+	retry := string(files["frontend/src/api/retry.ts"])
+	if retry == "" {
+		t.Fatal("missing frontend/src/api/retry.ts")
+	}
+	assert401RetryReusesBufferedBody(t, client, retry, []string{`headers.set("X-CSRF-Token", token)`})
 }
 
 func assertMUIFrontendInvariants(t *testing.T, files fileMap) {
@@ -179,22 +187,45 @@ func assertMUIFrontendInvariants(t *testing.T, files fileMap) {
 }
 
 // assert401RetryReusesBufferedBody is the #106 contract: 401 retries must
-// not clone a consumed Request, and must resend the buffered body.
-func assert401RetryReusesBufferedBody(t *testing.T, src string, extra []string) {
+// not clone a consumed Request, must not gate on Request.body (Firefox),
+// and must resend the buffered body.
+func assert401RetryReusesBufferedBody(t *testing.T, client, retry string, extra []string) {
 	t.Helper()
-	if strings.Contains(src, "new Request(request") {
+	if strings.Contains(client, "new Request(request") {
 		t.Error("client.ts 401 retry clones a consumed Request; rebuild from buffered body bytes instead")
+	}
+	for _, src := range []string{client, retry} {
+		if strings.Contains(src, "request.body !=") || strings.Contains(src, "request.body !==") {
+			t.Error("401 retry must not gate on Request.body (undefined in Firefox); gate on method")
+		}
 	}
 	for _, want := range append([]string{
 		"refreshInFlight",
 		"isAuthURL",
-		"WeakMap<Request, ArrayBuffer>",
-		"request.clone().arrayBuffer()",
+		`from "./retry"`,
+		"bufferRetryBody",
 		"fetch(request.url",
-		"init.body = body",
+		"retryInit(",
 	}, extra...) {
-		if !strings.Contains(src, want) {
+		if !strings.Contains(client, want) {
 			t.Errorf("client.ts missing %q", want)
+		}
+	}
+	for _, want := range []string{
+		`request.method !== "GET" && request.method !== "HEAD"`,
+		"request.clone().arrayBuffer()",
+		"init.body = body",
+		"signal: request.signal",
+		"mode: request.mode",
+		"cache: request.cache",
+		"redirect: request.redirect",
+		"referrer: request.referrer",
+		"referrerPolicy: request.referrerPolicy",
+		"integrity: request.integrity",
+		"keepalive: request.keepalive",
+	} {
+		if !strings.Contains(retry, want) {
+			t.Errorf("retry.ts missing %q", want)
 		}
 	}
 }

--- a/goldentest/tree_test.go
+++ b/goldentest/tree_test.go
@@ -89,6 +89,7 @@ func assertFrontendInvariants(t *testing.T, files fileMap) {
 	if !strings.Contains(client, "refreshInFlight") {
 		t.Error("client.ts missing shared refresh promise")
 	}
+	assert401RetryReusesBufferedBody(t, client, []string{`headers.set("Authorization", ` + "`Bearer ${access}`" + `)`})
 }
 
 // assertCookieFrontendInvariants is assertFrontendInvariants' counterpart for
@@ -141,6 +142,7 @@ func assertCookieFrontendInvariants(t *testing.T, files fileMap) {
 	if !strings.Contains(client, "X-CSRF-Token") {
 		t.Error("cookie-mode client.ts missing X-CSRF-Token double-submit")
 	}
+	assert401RetryReusesBufferedBody(t, client, []string{`headers.set("X-CSRF-Token", token)`})
 }
 
 func assertMUIFrontendInvariants(t *testing.T, files fileMap) {
@@ -173,6 +175,27 @@ func assertMUIFrontendInvariants(t *testing.T, files fileMap) {
 	}
 	if !strings.Contains(login, "TextField") && !strings.Contains(login, "Paper") {
 		t.Error("MUI LoginPage.tsx missing Paper/TextField")
+	}
+}
+
+// assert401RetryReusesBufferedBody is the #106 contract: 401 retries must
+// not clone a consumed Request, and must resend the buffered body.
+func assert401RetryReusesBufferedBody(t *testing.T, src string, extra []string) {
+	t.Helper()
+	if strings.Contains(src, "new Request(request") {
+		t.Error("client.ts 401 retry clones a consumed Request; rebuild from buffered body bytes instead")
+	}
+	for _, want := range append([]string{
+		"refreshInFlight",
+		"isAuthURL",
+		"WeakMap<Request, ArrayBuffer>",
+		"request.clone().arrayBuffer()",
+		"fetch(request.url",
+		"init.body = body",
+	}, extra...) {
+		if !strings.Contains(src, want) {
+			t.Errorf("client.ts missing %q", want)
+		}
 	}
 }
 

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -49,6 +51,7 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 		"frontend/src/app/providers.tsx",
 		"frontend/src/app/router.tsx",
 		"frontend/src/api/client.ts",
+		"frontend/src/api/retry.ts",
 		"frontend/src/api/formErrors.ts",
 		"frontend/src/api/generated/client.ts",
 		"frontend/src/api/generated/error.ts",
@@ -500,30 +503,86 @@ func TestGenerate401RetryReusesBufferedBody(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Generate() error = %v", err)
 			}
-			src := readFile(t, filepath.Join(workDir, "demo", "frontend", "src", "api", "client.ts"))
-			assert401RetryReusesBufferedBody(t, src, tt.want)
+			apiDir := filepath.Join(workDir, "demo", "frontend", "src", "api")
+			assert401RetryReusesBufferedBody(t, readFile(t, filepath.Join(apiDir, "client.ts")), readFile(t, filepath.Join(apiDir, "retry.ts")), tt.want)
 		})
 	}
 }
 
-func assert401RetryReusesBufferedBody(t *testing.T, src string, extra []string) {
+func TestRetryBodyResentWhenRequestBodyUndefined(t *testing.T) {
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not available")
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	harness := filepath.Join(filepath.Dir(thisFile), "testdata", "retry_body_harness.mjs")
+	for _, auth := range []string{"jwt", "cookie"} {
+		t.Run(auth, func(t *testing.T) {
+			workDir := t.TempDir()
+			err := Generate(context.Background(), Options{
+				Name:     "demo",
+				Database: "sqlite",
+				Auth:     auth,
+				WorkDir:  workDir,
+			})
+			if err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+			retryPath := filepath.Join(workDir, "demo", "frontend", "src", "api", "retry.ts")
+			cmd := exec.Command("node", "--experimental-strip-types", "--no-warnings", harness, retryPath) //nolint:gosec // fixed harness argv
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("retry body harness: %v\n%s", err, out)
+			}
+			if !strings.Contains(string(out), "ok") {
+				t.Fatalf("retry body harness stdout = %q, want ok", out)
+			}
+		})
+	}
+}
+
+func assert401RetryReusesBufferedBody(t *testing.T, client, retry string, extra []string) {
 	t.Helper()
-	if strings.Contains(src, "new Request(request") {
+	if strings.Contains(client, "new Request(request") {
 		t.Error("api/client.ts 401 retry clones a consumed Request; rebuild from buffered body bytes instead")
+	}
+	for _, src := range []string{client, retry} {
+		if strings.Contains(src, "request.body !=") || strings.Contains(src, "request.body !==") {
+			t.Error("401 retry must not gate on Request.body (undefined in Firefox); gate on method")
+		}
 	}
 	for _, want := range append([]string{
 		"refreshInFlight",
 		"isAuthURL",
-		"WeakMap<Request, ArrayBuffer>",
-		"request.clone().arrayBuffer()",
+		`from "./retry"`,
+		"bufferRetryBody",
 		"fetch(request.url",
-		"init.body = body",
+		"retryInit(",
 	}, extra...) {
-		if !strings.Contains(src, want) {
+		if !strings.Contains(client, want) {
 			t.Errorf("api/client.ts missing %q", want)
 		}
 	}
-	lower := strings.ToLower(src)
+	for _, want := range []string{
+		`request.method !== "GET" && request.method !== "HEAD"`,
+		"request.clone().arrayBuffer()",
+		"init.body = body",
+		"signal: request.signal",
+		"mode: request.mode",
+		"cache: request.cache",
+		"redirect: request.redirect",
+		"referrer: request.referrer",
+		"referrerPolicy: request.referrerPolicy",
+		"integrity: request.integrity",
+		"keepalive: request.keepalive",
+	} {
+		if !strings.Contains(retry, want) {
+			t.Errorf("api/retry.ts missing %q", want)
+		}
+	}
+	lower := strings.ToLower(client + retry)
 	if strings.Contains(lower, "localstorage") || strings.Contains(lower, "sessionstorage") {
 		t.Error("api/client.ts uses web storage")
 	}

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -468,6 +468,67 @@ func TestGenerateRecordsAuthAndUIChoices(t *testing.T) {
 	}
 }
 
+// TestGenerate401RetryReusesBufferedBody is the #106 contract: after fetch
+// consumes request.body, `new Request(request, ...)` throws in the browser
+// (or retries POST/PATCH with an empty body). Both auth branches must buffer
+// the body in onRequest and rebuild the retry from those bytes.
+func TestGenerate401RetryReusesBufferedBody(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		auth string
+		want []string
+	}{
+		{
+			name: "jwt",
+			auth: "jwt",
+			want: []string{`headers.set("Authorization", ` + "`Bearer ${access}`" + `)`},
+		},
+		{
+			name: "cookie",
+			auth: "cookie",
+			want: []string{`headers.set("X-CSRF-Token", token)`},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := t.TempDir()
+			err := Generate(context.Background(), Options{
+				Name:     "demo",
+				Database: "sqlite",
+				Auth:     tt.auth,
+				WorkDir:  workDir,
+			})
+			if err != nil {
+				t.Fatalf("Generate() error = %v", err)
+			}
+			src := readFile(t, filepath.Join(workDir, "demo", "frontend", "src", "api", "client.ts"))
+			assert401RetryReusesBufferedBody(t, src, tt.want)
+		})
+	}
+}
+
+func assert401RetryReusesBufferedBody(t *testing.T, src string, extra []string) {
+	t.Helper()
+	if strings.Contains(src, "new Request(request") {
+		t.Error("api/client.ts 401 retry clones a consumed Request; rebuild from buffered body bytes instead")
+	}
+	for _, want := range append([]string{
+		"refreshInFlight",
+		"isAuthURL",
+		"WeakMap<Request, ArrayBuffer>",
+		"request.clone().arrayBuffer()",
+		"fetch(request.url",
+		"init.body = body",
+	}, extra...) {
+		if !strings.Contains(src, want) {
+			t.Errorf("api/client.ts missing %q", want)
+		}
+	}
+	lower := strings.ToLower(src)
+	if strings.Contains(lower, "localstorage") || strings.Contains(lower, "sessionstorage") {
+		t.Error("api/client.ts uses web storage")
+	}
+}
+
 func TestGenerateMUIPreset(t *testing.T) {
 	workDir := t.TempDir()
 	err := Generate(context.Background(), Options{

--- a/scaffold/templates/frontend/src/api/client.ts.tmpl
+++ b/scaffold/templates/frontend/src/api/client.ts.tmpl
@@ -7,6 +7,7 @@ import {
   setCSRFToken,
 } from "../auth/session";
 import { createGombitClient } from "./generated/client";
+import { bufferRetryBody, retryInit } from "./retry";
 
 export type ApiClient = ReturnType<typeof createGombitClient>;
 
@@ -74,11 +75,7 @@ export function createAppClient(): ApiClient {
 
   client.use({
     async onRequest({ request }) {
-      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
-      // POST/PATCH JSON after silent refresh.
-      if (request.body != null) {
-        retryBodies.set(request, await request.clone().arrayBuffer());
-      }
+      await bufferRetryBody(request, retryBodies);
       return request;
     },
     async onResponse({ request, response }) {
@@ -134,18 +131,6 @@ function isUnsafeMethod(method: string): boolean {
   return method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
 }
 
-function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
-  const init: RequestInit = {
-    method: request.method,
-    headers,
-    credentials: request.credentials,
-  };
-  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
-    init.body = body;
-  }
-  return init;
-}
-
 function isAuthURL(url: string): boolean {
   try {
     const path = new URL(url, "http://gombit.invalid").pathname;
@@ -169,6 +154,7 @@ import {
   getRefreshToken,
 } from "../auth/session";
 import { createGombitClient, unwrap } from "./generated/client";
+import { bufferRetryBody, retryInit } from "./retry";
 
 export type ApiClient = ReturnType<typeof createGombitClient>;
 
@@ -222,11 +208,7 @@ export function createAppClient(): ApiClient {
 
   client.use({
     async onRequest({ request }) {
-      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
-      // POST/PATCH JSON after silent refresh.
-      if (request.body != null) {
-        retryBodies.set(request, await request.clone().arrayBuffer());
-      }
+      await bufferRetryBody(request, retryBodies);
       return request;
     },
     async onResponse({ request, response }) {
@@ -254,18 +236,6 @@ export function useApiClient(): ApiClient {
     throw new Error("useApiClient must be used within AppProviders");
   }
   return client;
-}
-
-function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
-  const init: RequestInit = {
-    method: request.method,
-    headers,
-    credentials: request.credentials,
-  };
-  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
-    init.body = body;
-  }
-  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/scaffold/templates/frontend/src/api/client.ts.tmpl
+++ b/scaffold/templates/frontend/src/api/client.ts.tmpl
@@ -20,7 +20,8 @@ const REFRESH_PATH = "/api/v1/auth/refresh";
  * (M5-3). Session cookies (HttpOnly) and the CSRF cookie are managed by the
  * browser on same-origin requests; this wiring adds the X-CSRF-Token
  * double-submit header on state-changing requests and retries once after a
- * silent cookie refresh on 401. See docs/auth-cookie.md.
+ * silent cookie refresh on 401. The retry rebuilds fetch() from buffered
+ * body bytes so POST/PATCH JSON survives that refresh. See docs/auth-cookie.md.
  *
  * The CSRF bootstrap and refresh calls below use fetch directly instead of
  * the typed client: they are session infrastructure, not part of the
@@ -43,6 +44,7 @@ export function createAppClient(): ApiClient {
   });
 
   let refreshInFlight: Promise<boolean> | null = null;
+  const retryBodies = new WeakMap<Request, ArrayBuffer>();
 
   async function refreshSession(): Promise<boolean> {
     if (refreshInFlight) {
@@ -71,6 +73,14 @@ export function createAppClient(): ApiClient {
   }
 
   client.use({
+    async onRequest({ request }) {
+      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
+      // POST/PATCH JSON after silent refresh.
+      if (request.body != null) {
+        retryBodies.set(request, await request.clone().arrayBuffer());
+      }
+      return request;
+    },
     async onResponse({ request, response }) {
       if (response.status !== 401 || isAuthURL(request.url)) {
         return response;
@@ -79,12 +89,12 @@ export function createAppClient(): ApiClient {
       if (!ok) {
         return response;
       }
-      const retry = new Request(request, { headers: new Headers(request.headers) });
+      const headers = new Headers(request.headers);
       const token = getCSRFToken();
       if (token) {
-        retry.headers.set("X-CSRF-Token", token);
+        headers.set("X-CSRF-Token", token);
       }
-      return fetch(retry);
+      return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
     },
   });
   return client;
@@ -124,6 +134,18 @@ function isUnsafeMethod(method: string): boolean {
   return method !== "GET" && method !== "HEAD" && method !== "OPTIONS";
 }
 
+function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
+}
+
 function isAuthURL(url: string): boolean {
   try {
     const path = new URL(url, "http://gombit.invalid").pathname;
@@ -158,7 +180,8 @@ export const ApiClientContext = createContext<ApiClient | null>(null);
  *
  * On 401, rotate the in-memory refresh token once and retry. Concurrent
  * 401s share that refresh instead of returning stale failures. Tokens are
- * never written to web storage.
+ * never written to web storage. The retry rebuilds fetch() from buffered
+ * body bytes so POST/PATCH JSON survives silent refresh.
  */
 export function createAppClient(): ApiClient {
   const baseUrl = import.meta.env.VITE_API_URL ?? "";
@@ -168,6 +191,7 @@ export function createAppClient(): ApiClient {
   });
 
   let refreshInFlight: Promise<boolean> | null = null;
+  const retryBodies = new WeakMap<Request, ArrayBuffer>();
 
   async function refreshSession(): Promise<boolean> {
     if (refreshInFlight) {
@@ -197,6 +221,14 @@ export function createAppClient(): ApiClient {
   }
 
   client.use({
+    async onRequest({ request }) {
+      // Fetch consumes request.body; buffer bytes so a 401 retry can resend
+      // POST/PATCH JSON after silent refresh.
+      if (request.body != null) {
+        retryBodies.set(request, await request.clone().arrayBuffer());
+      }
+      return request;
+    },
     async onResponse({ request, response }) {
       if (response.status !== 401 || isAuthURL(request.url)) {
         return response;
@@ -205,14 +237,12 @@ export function createAppClient(): ApiClient {
       if (!ok) {
         return response;
       }
-      const retry = new Request(request, {
-        headers: new Headers(request.headers),
-      });
+      const headers = new Headers(request.headers);
       const access = getAccessToken();
       if (access) {
-        retry.headers.set("Authorization", `Bearer ${access}`);
+        headers.set("Authorization", `Bearer ${access}`);
       }
-      return fetch(retry);
+      return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
     },
   });
   return client;
@@ -224,6 +254,18 @@ export function useApiClient(): ApiClient {
     throw new Error("useApiClient must be used within AppProviders");
   }
   return client;
+}
+
+function retryInit(request: Request, headers: Headers, body: ArrayBuffer | undefined): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
 }
 
 function isAuthURL(url: string): boolean {

--- a/scaffold/templates/frontend/src/api/retry.ts.tmpl
+++ b/scaffold/templates/frontend/src/api/retry.ts.tmpl
@@ -1,0 +1,41 @@
+/**
+ * 401 retry helpers for createAppClient.
+ *
+ * Fetch consumes a Request's body stream. Firefox's Request.body getter is
+ * unimplemented (always undefined; MDN / Bugzilla 1387483), so buffering
+ * MUST be gated on method, not the Request.body getter. clone() and
+ * arrayBuffer() are implemented there and still yield the JSON bytes.
+ */
+
+export async function bufferRetryBody(
+  request: Request,
+  bodies: WeakMap<Request, ArrayBuffer>,
+): Promise<void> {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    bodies.set(request, await request.clone().arrayBuffer());
+  }
+}
+
+export function retryInit(
+  request: Request,
+  headers: Headers,
+  body: ArrayBuffer | undefined,
+): RequestInit {
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    credentials: request.credentials,
+    cache: request.cache,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    signal: request.signal,
+    mode: request.mode,
+  };
+  if (body !== undefined && request.method !== "GET" && request.method !== "HEAD") {
+    init.body = body;
+  }
+  return init;
+}

--- a/scaffold/testdata/retry_body_harness.mjs
+++ b/scaffold/testdata/retry_body_harness.mjs
@@ -1,0 +1,174 @@
+/**
+ * Runtime contract for #106: buffer a POST/PATCH JSON body, consume the
+ * original Request (as fetch does), then retry after a 401 + successful
+ * refresh. Request.body is forced to undefined to match Firefox, where the
+ * getter is unimplemented but clone()/arrayBuffer() still work.
+ *
+ * Usage: node --experimental-strip-types harness.mjs /path/to/retry.ts
+ */
+import { pathToFileURL } from "node:url";
+
+const retryPath = process.argv[2];
+if (!retryPath) {
+  throw new Error("usage: retry_body_harness.mjs <retry.ts>");
+}
+
+const { bufferRetryBody, retryInit } = await import(pathToFileURL(retryPath).href);
+if (typeof bufferRetryBody !== "function" || typeof retryInit !== "function") {
+  throw new Error("retry.ts must export bufferRetryBody and retryInit");
+}
+
+const bodyDesc = Object.getOwnPropertyDescriptor(Request.prototype, "body");
+Object.defineProperty(Request.prototype, "body", {
+  configurable: true,
+  enumerable: bodyDesc?.enumerable ?? false,
+  get() {
+    return undefined;
+  },
+});
+
+try {
+  await run();
+} finally {
+  if (bodyDesc) {
+    Object.defineProperty(Request.prototype, "body", bodyDesc);
+  }
+}
+
+async function run() {
+  const originalJSON = JSON.stringify({ name: "gadget", price: 12 });
+  const productURL = "http://gombit.test/api/v1/products";
+  const refreshURL = "http://gombit.test/api/v1/auth/refresh";
+
+  const request = new Request(productURL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: originalJSON,
+  });
+  if (request.body != null) {
+    throw new Error("Firefox simulation failed: request.body should be undefined");
+  }
+
+  const bodies = new WeakMap();
+  await bufferRetryBody(request, bodies);
+  if (!bodies.has(request)) {
+    throw new Error(
+      "bufferRetryBody skipped the POST (Request.body gate would do this in Firefox)",
+    );
+  }
+
+  const fetches = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const method =
+      init?.method ?? (input instanceof Request ? input.method : "GET");
+    let body = init?.body;
+    if (body === undefined && input instanceof Request && method !== "GET" && method !== "HEAD") {
+      try {
+        body = await input.arrayBuffer();
+      } catch {
+        body = undefined;
+      }
+    } else if (input instanceof Request) {
+      try {
+        await input.arrayBuffer();
+      } catch {
+        // already consumed
+      }
+    }
+    fetches.push({ url, method, body });
+    if (url === refreshURL) {
+      return new Response(JSON.stringify({ data: { ok: true } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    const dataCalls = fetches.filter((call) => call.url === productURL);
+    if (dataCalls.length === 1) {
+      return new Response(
+        JSON.stringify({ error: { code: "authentication", message: "expired" } }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(JSON.stringify({ data: { id: 1 } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+
+  try {
+    const first = await fetch(request);
+    if (first.status !== 401) {
+      throw new Error(`first fetch status = ${first.status}, want 401`);
+    }
+
+    const refresh = await fetch(refreshURL, { method: "POST" });
+    if (!refresh.ok) {
+      throw new Error(`refresh status = ${refresh.status}, want 2xx`);
+    }
+
+    const retry = await fetch(
+      request.url,
+      retryInit(request, new Headers(request.headers), bodies.get(request)),
+    );
+    if (!retry.ok) {
+      throw new Error(`retry status = ${retry.status}, want 2xx`);
+    }
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+
+  const productCalls = fetches.filter((call) => call.url === productURL);
+  if (productCalls.length !== 2) {
+    throw new Error(`product fetch count = ${productCalls.length}, want 2 (401 then retry)`);
+  }
+  const retryBody = productCalls[1].body;
+  const retryBytes = bodyBytes(retryBody);
+  if (retryBytes !== originalJSON) {
+    throw new Error(`retry body = ${JSON.stringify(retryBytes)}, want ${JSON.stringify(originalJSON)}`);
+  }
+
+  await assertPatchRetry();
+  process.stdout.write("ok\n");
+}
+
+async function assertPatchRetry() {
+  const originalJSON = JSON.stringify({ name: "renamed" });
+  const request = new Request("http://gombit.test/api/v1/products/1", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: originalJSON,
+  });
+  if (request.body != null) {
+    throw new Error("Firefox simulation failed on PATCH: request.body should be undefined");
+  }
+  const bodies = new WeakMap();
+  await bufferRetryBody(request, bodies);
+  await request.arrayBuffer();
+  const init = retryInit(request, new Headers(request.headers), bodies.get(request));
+  if (init.signal !== request.signal) {
+    throw new Error("retryInit dropped request.signal");
+  }
+  const got = bodyBytes(init.body);
+  if (got !== originalJSON) {
+    throw new Error(`PATCH retry body = ${JSON.stringify(got)}, want ${JSON.stringify(originalJSON)}`);
+  }
+}
+
+function bodyBytes(body) {
+  if (body == null) {
+    return "";
+  }
+  if (typeof body === "string") {
+    return body;
+  }
+  if (body instanceof ArrayBuffer) {
+    return Buffer.from(body).toString("utf8");
+  }
+  if (ArrayBuffer.isView(body)) {
+    return Buffer.from(body.buffer, body.byteOffset, body.byteLength).toString("utf8");
+  }
+  throw new Error(`unexpected retry body type ${Object.prototype.toString.call(body)}`);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The generated SPA 401 interceptor cloned the original `Request` after fetch had already consumed its body stream. In a browser that throws `TypeError: Failed to construct 'Request': Cannot construct a Request with a Request object that has already been used` (or retries POST/PATCH with an empty body) even though silent refresh succeeded.

Both jwt and cookie template branches now buffer the body in `onRequest` via `bufferRetryBody` (gated on method, not `Request.body` — Firefox's getter is unimplemented) and retry with `fetch(request.url, retryInit(...))` so the JSON body is resent after refresh.

Closes #106

## Acceptance criteria

- [x] After silent refresh, the original mutating request is retried with the same JSON body
- [x] JWT branch does not clone a consumed `Request`
- [x] Cookie branch does not clone a consumed `Request`
- [x] Bearer header re-attached on jwt retry
- [x] CSRF header re-attached on cookie retry
- [x] Shared `refreshInFlight`, auth-URL skip, in-memory tokens (never localStorage)
- [x] Goldens updated; regression test covers both auth branches
- [x] Buffering does not consult `Request.body` (Firefox)
- [x] Runtime harness asserts POST/PATCH retry bytes when `Request.body` is undefined

## Scope notes

Admin SPA (`internal/adminui`) already rebuilds from `init()` — not changed. Did not invent a new client architecture or touch M6 batteries. Shared `frontend/src/api/retry.ts` is only the 401 buffer/retry helpers extracted so the Node harness can import them.

## Validation

- [x] `go test ./scaffold -run 'TestGenerate401|TestRetryBody'`
- [x] `go test ./scaffold -run 'TestGenerateWritesFeaturePackageLayout|TestGenerateRecordsAuthAndUIChoices'`
- [x] `go test ./goldentest -run 'TestNewGolden$|TestNewGoldenCookieAuth|TestNewGoldenMUI|TestMakeResourceGolden|TestMakeCommandGolden'`
- [x] `gofmt` on changed Go
- [ ] `go test ./...` (CI)
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (CI)
- [x] Project `code-review` skill: first pass REQUEST CHANGES (Firefox `Request.body` gate + string-only tests); addressed in follow-up commit. Awaiting re-review after CI.

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes N/A (frontend template only)
- [x] Docs updated (`docs/frontend.md`, `docs/auth.md`, `docs/auth-cookie.md`, CHANGELOG)
- [x] Extraction N/A — not an extraction
- [x] Generators are idempotent/additive; this is a TS template, not a Go AST edit; goldens updated
- [ ] API changes regenerate OpenAPI + TS client — N/A (no API/OpenAPI change)
- [x] No secrets in generated frontend source; `VITE_*` still public; tokens stay in memory
- [x] Scope stays inside this issue — no M6 battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

