### PR TITLE
fix: serialize cookie CSRF bootstrap under StrictMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ version.
   silent refresh. POST/PATCH retries buffer via `clone().arrayBuffer()` gated
   on method (Firefox's `Request.body` getter is undefined) and resend those
   bytes ([#106](https://github.com/gombit-dev/gombit/issues/106)).
+- Cookie-mode generated SPAs serialize CSRF bootstrap (`csrfInFlight` plus
+  skip-if-token-exists) and `await bootstrapCSRF()` before login/register,
+  so React StrictMode remounts no longer mint a second pair that 403s login
+  ([#107](https://github.com/gombit-dev/gombit/issues/107)).
 - XSS JSON sanitization no longer `io.ReadAll`s request bodies without a
   bound: JSON sanitizer buffering is capped at 8MiB (HTTP 413, D10
   `payload_too_large`), and `http.Server.ReadTimeout` follows

--- a/docs/auth-cookie.md
+++ b/docs/auth-cookie.md
@@ -75,9 +75,12 @@ app — including feature routes added later via `app.Router()` — not just
   {"error": {"code": "authorization", "message": "csrf token missing or invalid", "request_id": "..."}}
   ```
 
-`GET /auth/csrf` is the bootstrap endpoint: an SPA calls it once (e.g. on
-app load, or on the login page before the first `POST /auth/login`) to get
-a token, mirrored in both the `Set-Cookie` header and the JSON body
+`GET /auth/csrf` is the bootstrap endpoint: it **always mints a new** signed
+cookie+body pair (it does not reuse an existing `gombit_csrf` cookie). The
+SPA must not overlap these calls — overlapping responses desync the HttpOnly
+cookie from the in-memory `X-CSRF-Token` and login then 403s. The generated
+client serializes that (see [Generated frontend](#generated-frontend)). The
+token is mirrored in both the `Set-Cookie` header and the JSON body
 (`{"data": {"csrf_token": "..."}}`) so the SPA does not need to parse
 `document.cookie` itself.
 
@@ -88,7 +91,7 @@ differs: tokens travel in cookies, not JSON.
 
 | Method | Path | Auth | Notes |
 | --- | --- | --- | --- |
-| `GET` | `/auth/csrf` | Public, safe (CSRF-exempt) | Issues/refreshes the CSRF cookie; body mirrors it as `csrf_token`. |
+| `GET` | `/auth/csrf` | Public, safe (CSRF-exempt) | Always issues a **new** CSRF cookie+body pair; body mirrors it as `csrf_token`. |
 | `POST` | `/auth/register` | Public, CSRF-protected | Same as Bearer mode: creates a user, never sets `IsSuperuser`. |
 | `POST` | `/auth/login` | Public, CSRF-protected | Body `{email, password}`. On success, sets `gombit_access` + `gombit_refresh` cookies; body is the public user, not tokens. |
 | `POST` | `/auth/refresh` | Cookie (`gombit_refresh`), CSRF-protected | No request body; reads the refresh cookie. Rotates both session cookies. |
@@ -123,8 +126,11 @@ rebuilds the request from buffered body bytes so POST/PATCH JSON survives
 that refresh (buffering is gated on method; Firefox does not implement
 the Request.body getter). `RequireAuth` confirms a session by calling
 `GET /me` (it cannot check an in-memory token, unlike Bearer mode).
-`LoginPage` calls `bootstrapCSRF()` on mount so the login `POST` itself
-has a token to double-submit. See the templates under
+`LoginPage` warms the token with `bootstrapCSRF()` on mount and **awaits**
+it before `POST /auth/login` and `POST /auth/register`. Concurrent callers
+share one in-flight promise (`csrfInFlight`); if a token is already in
+memory the call is a no-op so React StrictMode remounts do not mint a
+second pair. See the templates under
 [`scaffold/templates/frontend/src`](../scaffold/templates/frontend/src) for
 the exact `{{if eq .Auth "cookie"}}` branches.
 

--- a/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
@@ -97,21 +97,41 @@ export function createAppClient(): ApiClient {
   return client;
 }
 
+let csrfInFlight: Promise<void> | null = null;
+
 /**
- * Fetches a fresh CSRF cookie/token pair. Call once on app load (or right
- * before the first mutating request, e.g. on the login page) so
- * POST /auth/login and friends have a token to double-submit.
+ * Fetches a CSRF cookie/token pair. Concurrent callers share one in-flight
+ * promise (GET /auth/csrf always mints a new pair; overlapping responses
+ * desync the cookie from the in-memory X-CSRF-Token). If a token is already
+ * in memory, this is a no-op so React StrictMode remounts do not mint a
+ * second pair. After clearSession the token is gone and the next call
+ * bootstraps again. Login must await this before POST.
  */
-export async function bootstrapCSRF(): Promise<void> {
-  const baseUrl = import.meta.env.VITE_API_URL ?? "";
-  const response = await fetch(baseUrl + CSRF_PATH, { credentials: "same-origin" });
-  if (!response.ok) {
-    return;
+export function bootstrapCSRF(): Promise<void> {
+  if (getCSRFToken()) {
+    return Promise.resolve();
   }
-  const body = (await response.json()) as { data?: { csrf_token?: string } };
-  if (body.data?.csrf_token) {
-    setCSRFToken(body.data.csrf_token);
+  if (csrfInFlight) {
+    return csrfInFlight;
   }
+  csrfInFlight = (async () => {
+    try {
+      const baseUrl = import.meta.env.VITE_API_URL ?? "";
+      const response = await fetch(baseUrl + CSRF_PATH, {
+        credentials: "same-origin",
+      });
+      if (!response.ok) {
+        return;
+      }
+      const body = (await response.json()) as { data?: { csrf_token?: string } };
+      if (body.data?.csrf_token) {
+        setCSRFToken(body.data.csrf_token);
+      }
+    } finally {
+      csrfInFlight = null;
+    }
+  })();
+  return csrfInFlight;
 }
 
 function csrfRequestHeaders(): HeadersInit {

--- a/goldentest/testdata/golden/new-cookie/frontend/src/pages/LoginPage.tsx
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/pages/LoginPage.tsx
@@ -34,6 +34,9 @@ export function LoginPage() {
   async function onLogin(values: LoginValues) {
     setStatus("");
     try {
+      // Mount effect starts CSRF; wait for that in-flight pair (or mint one
+      // after clearSession) before POST /auth/login.
+      await bootstrapCSRF();
       await unwrap(
         await client.POST("/api/v1/auth/login", {
           body: { email: values.email, password: values.password },
@@ -51,6 +54,7 @@ export function LoginPage() {
   async function onRegister(values: LoginValues) {
     setStatus("");
     try {
+      await bootstrapCSRF();
       await unwrap(
         await client.POST("/api/v1/auth/register", {
           body: { email: values.email, password: values.password },

--- a/goldentest/tree_test.go
+++ b/goldentest/tree_test.go
@@ -82,6 +82,9 @@ func assertFrontendInvariants(t *testing.T, files fileMap) {
 	if !strings.Contains(login, "/api/v1/auth/login") {
 		t.Error("LoginPage.tsx missing login path")
 	}
+	if strings.Contains(login, "bootstrapCSRF") {
+		t.Error("jwt LoginPage.tsx must not import bootstrapCSRF")
+	}
 	client := string(files["frontend/src/api/client.ts"])
 	if client == "" {
 		t.Fatal("missing frontend/src/api/client.ts")
@@ -94,6 +97,9 @@ func assertFrontendInvariants(t *testing.T, files fileMap) {
 		t.Fatal("missing frontend/src/api/retry.ts")
 	}
 	assert401RetryReusesBufferedBody(t, client, retry, []string{`headers.set("Authorization", ` + "`Bearer ${access}`" + `)`})
+	if strings.Contains(client, "csrfInFlight") || strings.Contains(client, "bootstrapCSRF") {
+		t.Error("jwt client.ts must not include cookie CSRF bootstrap")
+	}
 }
 
 // assertCookieFrontendInvariants is assertFrontendInvariants' counterpart for
@@ -136,8 +142,11 @@ func assertCookieFrontendInvariants(t *testing.T, files fileMap) {
 	if login == "" {
 		t.Fatal("missing frontend/src/pages/LoginPage.tsx")
 	}
-	if !strings.Contains(login, "bootstrapCSRF") {
-		t.Error("cookie-mode LoginPage.tsx missing bootstrapCSRF call")
+	if strings.Count(login, "await bootstrapCSRF()") < 2 {
+		t.Error("cookie-mode LoginPage.tsx must await bootstrapCSRF() on both login and register")
+	}
+	if !strings.Contains(login, "void bootstrapCSRF()") {
+		t.Error("cookie-mode LoginPage.tsx missing eager CSRF bootstrap on mount")
 	}
 	client := string(files["frontend/src/api/client.ts"])
 	if client == "" {
@@ -151,6 +160,12 @@ func assertCookieFrontendInvariants(t *testing.T, files fileMap) {
 		t.Fatal("missing frontend/src/api/retry.ts")
 	}
 	assert401RetryReusesBufferedBody(t, client, retry, []string{`headers.set("X-CSRF-Token", token)`})
+	if !strings.Contains(client, "csrfInFlight") {
+		t.Error("cookie-mode client.ts missing csrfInFlight lock")
+	}
+	if !strings.Contains(client, "if (getCSRFToken())") {
+		t.Error("cookie-mode client.ts missing skip-if-token-exists no-op")
+	}
 }
 
 func assertMUIFrontendInvariants(t *testing.T, files fileMap) {

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -237,6 +237,9 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	if !strings.Contains(loginPage, "/api/v1/auth/login") {
 		t.Fatal("LoginPage.tsx missing login path")
 	}
+	if strings.Contains(loginPage, "bootstrapCSRF") {
+		t.Fatal("jwt LoginPage.tsx must not import bootstrapCSRF")
+	}
 	if strings.Contains(strings.ToLower(loginPage), "localstorage") {
 		t.Fatal("LoginPage.tsx uses localStorage")
 	}
@@ -256,6 +259,9 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	appClient := readFile(t, filepath.Join(dest, "frontend", "src", "api", "client.ts"))
 	if !strings.Contains(appClient, "refreshInFlight") {
 		t.Fatal("api/client.ts missing shared refresh promise")
+	}
+	if strings.Contains(appClient, "csrfInFlight") || strings.Contains(appClient, "bootstrapCSRF") {
+		t.Fatal("jwt api/client.ts must not include cookie CSRF bootstrap")
 	}
 	router := readFile(t, filepath.Join(dest, "frontend", "src", "app", "router.tsx"))
 	if !strings.Contains(router, "RequireAuth") || !strings.Contains(router, "LoginPage") {
@@ -585,6 +591,42 @@ func assert401RetryReusesBufferedBody(t *testing.T, client, retry string, extra 
 	lower := strings.ToLower(client + retry)
 	if strings.Contains(lower, "localstorage") || strings.Contains(lower, "sessionstorage") {
 		t.Error("api/client.ts uses web storage")
+	}
+}
+
+// TestGenerateCookieCSRFBootstrapIsSerialized is the #107 regression: GET
+// /auth/csrf always mints a new cookie+body pair, so overlapping bootstrap
+// calls (React StrictMode remounts, or login before the mount effect
+// finishes) desync the HttpOnly cookie from the in-memory X-CSRF-Token.
+func TestGenerateCookieCSRFBootstrapIsSerialized(t *testing.T) {
+	workDir := t.TempDir()
+	err := Generate(context.Background(), Options{
+		Name:     "shop",
+		Database: "sqlite",
+		Auth:     "cookie",
+		WorkDir:  workDir,
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	client := readFile(t, filepath.Join(workDir, "shop", "frontend", "src", "api", "client.ts"))
+	if !strings.Contains(client, "csrfInFlight") {
+		t.Fatal("cookie client.ts missing csrfInFlight lock")
+	}
+	if !strings.Contains(client, "if (getCSRFToken())") {
+		t.Fatal("cookie client.ts missing skip-if-token-exists no-op")
+	}
+	if !strings.Contains(client, "if (csrfInFlight)") {
+		t.Fatal("cookie client.ts missing in-flight promise reuse")
+	}
+
+	login := readFile(t, filepath.Join(workDir, "shop", "frontend", "src", "pages", "LoginPage.tsx"))
+	if strings.Count(login, "await bootstrapCSRF()") < 2 {
+		t.Fatal("cookie LoginPage.tsx must await bootstrapCSRF() on both login and register")
+	}
+	if !strings.Contains(login, "void bootstrapCSRF()") {
+		t.Fatal("cookie LoginPage.tsx missing eager CSRF bootstrap on mount")
 	}
 }
 

--- a/scaffold/templates/frontend/src/api/client.ts.tmpl
+++ b/scaffold/templates/frontend/src/api/client.ts.tmpl
@@ -97,21 +97,41 @@ export function createAppClient(): ApiClient {
   return client;
 }
 
+let csrfInFlight: Promise<void> | null = null;
+
 /**
- * Fetches a fresh CSRF cookie/token pair. Call once on app load (or right
- * before the first mutating request, e.g. on the login page) so
- * POST /auth/login and friends have a token to double-submit.
+ * Fetches a CSRF cookie/token pair. Concurrent callers share one in-flight
+ * promise (GET /auth/csrf always mints a new pair; overlapping responses
+ * desync the cookie from the in-memory X-CSRF-Token). If a token is already
+ * in memory, this is a no-op so React StrictMode remounts do not mint a
+ * second pair. After clearSession the token is gone and the next call
+ * bootstraps again. Login must await this before POST.
  */
-export async function bootstrapCSRF(): Promise<void> {
-  const baseUrl = import.meta.env.VITE_API_URL ?? "";
-  const response = await fetch(baseUrl + CSRF_PATH, { credentials: "same-origin" });
-  if (!response.ok) {
-    return;
+export function bootstrapCSRF(): Promise<void> {
+  if (getCSRFToken()) {
+    return Promise.resolve();
   }
-  const body = (await response.json()) as { data?: { csrf_token?: string } };
-  if (body.data?.csrf_token) {
-    setCSRFToken(body.data.csrf_token);
+  if (csrfInFlight) {
+    return csrfInFlight;
   }
+  csrfInFlight = (async () => {
+    try {
+      const baseUrl = import.meta.env.VITE_API_URL ?? "";
+      const response = await fetch(baseUrl + CSRF_PATH, {
+        credentials: "same-origin",
+      });
+      if (!response.ok) {
+        return;
+      }
+      const body = (await response.json()) as { data?: { csrf_token?: string } };
+      if (body.data?.csrf_token) {
+        setCSRFToken(body.data.csrf_token);
+      }
+    } finally {
+      csrfInFlight = null;
+    }
+  })();
+  return csrfInFlight;
 }
 
 function csrfRequestHeaders(): HeadersInit {

--- a/scaffold/templates/frontend/src/pages/LoginPage.tsx.tmpl
+++ b/scaffold/templates/frontend/src/pages/LoginPage.tsx.tmpl
@@ -47,7 +47,10 @@ export function LoginPage() {
 {{end}}  async function onLogin(values: LoginValues) {
     setStatus("");
     try {
-{{if eq .Auth "cookie"}}      await unwrap(
+{{if eq .Auth "cookie"}}      // Mount effect starts CSRF; wait for that in-flight pair (or mint one
+      // after clearSession) before POST /auth/login.
+      await bootstrapCSRF();
+      await unwrap(
         await client.POST("/api/v1/auth/login", {
           body: { email: values.email, password: values.password },
         }),
@@ -71,7 +74,8 @@ export function LoginPage() {
   async function onRegister(values: LoginValues) {
     setStatus("");
     try {
-      await unwrap(
+{{if eq .Auth "cookie"}}      await bootstrapCSRF();
+{{end}}      await unwrap(
         await client.POST("/api/v1/auth/register", {
           body: { email: values.email, password: values.password },
         }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cookie-mode generated apps mint a new CSRF cookie+body pair on every `GET /auth/csrf`. The scaffolded `bootstrapCSRF()` had no in-flight lock and no skip-if-token-exists no-op, and `LoginPage` fired it with `void bootstrapCSRF()` in a StrictMode `useEffect` without awaiting before `POST /auth/login` (or register). Overlapping responses desync the HttpOnly cookie from the in-memory `X-CSRF-Token`, so login 403s.

Port the admin SPA contract: share one `csrfInFlight` promise, no-op when a token is already in memory, and `await bootstrapCSRF()` on login and register.

Rebased onto `main` after #145 merged (cookie `client.ts` now has both 401 body retry helpers and CSRF bootstrap serialization).

Closes #107

## Acceptance criteria

- [x] One CSRF pair per session bootstrap (in-flight lock)
- [x] Skip-if-token-exists so StrictMode remounts do not mint a second pair
- [x] Login awaits `bootstrapCSRF()` before POST
- [x] Register awaits `bootstrapCSRF()` before POST
- [x] Eager mount `useEffect` kept; lock + skip-if-present makes remounts safe
- [x] JWT templates still do not import CSRF bootstrap
- [x] Cookie goldens and generate regression updated

## Scope notes

Did not start #119 (CSRF only on the login page / reload). Admin SPA already had this guard — not rewritten.

## Validation

- [x] `go test ./scaffold -run 'TestGenerateCookieCSRFBootstrapIsSerialized|TestGenerate401RetryReusesBufferedBody|TestRetryBodyResentWhenRequestBodyUndefined|TestGenerateRecordsAuthAndUIChoices'`
- [x] `go test ./goldentest -run 'TestNewGoldenCookieAuth|TestNewGolden$'`
- [x] `gofmt` on changed Go
- [ ] `go test ./...` (CI)
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (CI)
- [x] Project `code-review` skill: APPROVE (no must-fix / should-fix) pending post after CI

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes N/A (frontend template only)
- [x] Docs updated (`docs/auth-cookie.md`, CHANGELOG)
- [x] Extraction N/A — not an extraction
- [x] Generators are idempotent/additive; TS template, not a Go AST edit; goldens updated
- [ ] API changes regenerate OpenAPI + TS client — N/A (no API/OpenAPI change)
- [x] No secrets in generated frontend source; tokens stay in memory
- [x] Scope stays inside this issue — no M6 battery creep; #119 deferred
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

