### PR TITLE
fix: honor page/per_page on generated list handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ version.
 
 ### Fixed
 
+- Generated list handlers honor `page` / `per_page` instead of returning every
+  row while advertising `meta.per_page=20`. Scaffolded product handlers,
+  `gombit make resource`, and the tutorial Task list clamp like the admin data
+  plane (default page 1, per_page 20, max 100), `COUNT` `meta.total`
+  separately, and `LIMIT`/`OFFSET` the payload
+  ([#110](https://github.com/gombit-dev/gombit/issues/110)).
 - Generated application SPA honors `GOMBIT_API_PREFIX` / `config.API.Prefix`
   at runtime (HTML `__GOMBIT_API_PREFIX__` injection + `rewriteAPIRequest`)
   for `gombit dev` and `gombit build --embed`. `gombit client generate`

--- a/admin/resources.go
+++ b/admin/resources.go
@@ -10,12 +10,6 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-const (
-	defaultPage    = 1
-	defaultPerPage = 20
-	maxPerPage     = 100
-)
-
 type listInput struct {
 	Slug     string `path:"slug" doc:"Registered model slug"`
 	Page     int    `query:"page" doc:"1-based page"`
@@ -81,17 +75,7 @@ func (h *handlers) listResources(ctx context.Context, input *listInput) (*listOu
 		return nil, contract.WithContext(ctx, contract.Internal("admin database is not attached"))
 	}
 
-	page := input.Page
-	if page < 1 {
-		page = defaultPage
-	}
-	perPage := input.PerPage
-	if perPage < 1 {
-		perPage = defaultPerPage
-	}
-	if perPage > maxPerPage {
-		perPage = maxPerPage
-	}
+	page, perPage := contract.ClampPage(input.Page, input.PerPage)
 
 	q := db.WithContext(ctx).Model(m.newInstance())
 	q, err = applySearch(q, m, input.Search)
@@ -118,7 +102,7 @@ func (h *handlers) listResources(ctx context.Context, input *listInput) (*listOu
 	}
 
 	slice := m.newSlice()
-	if err := q.Offset((page - 1) * perPage).Limit(perPage).Find(slice).Error; err != nil {
+	if err := q.Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(slice).Error; err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("list resources"))
 	}
 

--- a/contract/doc.go
+++ b/contract/doc.go
@@ -10,7 +10,8 @@
 //	{"data": ..., "meta": {"page": 1, "per_page": 20, "total": 125}}
 //
 // Use contract.DataMeta[T, PageMeta] (or another concrete meta type) so OpenAPI
-// emits a real meta schema.
+// emits a real meta schema. Generated list handlers honor page/per_page via
+// ClampPage (default page 1, per_page 20, max 100).
 // Validation failures (Huma Install path):
 //
 //	{"error":{"code":"validation_error","message":"...","fields":{...},"request_id":"..."}}

--- a/contract/envelope.go
+++ b/contract/envelope.go
@@ -22,8 +22,43 @@ type DataMeta[T any, M any] struct {
 // PageMeta is the conventional pagination meta object for collection responses.
 // It is the v0.1 typed default for list endpoints; other meta shapes can use the
 // second type parameter on DataMeta when needed.
+//
+// Generated list handlers and the admin data plane honor page/per_page with
+// ClampPage defaults: page 1, per_page 20, max 100. Meta.Total is the matching
+// row count, not len(data).
 type PageMeta struct {
 	Page    int   `json:"page"`
 	PerPage int   `json:"per_page"`
 	Total   int64 `json:"total"`
+}
+
+const (
+	// DefaultPage is the 1-based page used when page is missing or < 1.
+	DefaultPage = 1
+	// DefaultPerPage is the page size used when per_page is missing or < 1.
+	DefaultPerPage = 20
+	// MaxPerPage is the upper clamp for per_page (admin and generated lists).
+	MaxPerPage = 100
+)
+
+// ClampPage returns a 1-based page and a per-page size using the v0.1 defaults.
+// Values less than 1 become DefaultPage / DefaultPerPage; per_page above
+// MaxPerPage is clamped to MaxPerPage.
+func ClampPage(page, perPage int) (int, int) {
+	if page < 1 {
+		page = DefaultPage
+	}
+	if perPage < 1 {
+		perPage = DefaultPerPage
+	}
+	if perPage > MaxPerPage {
+		perPage = MaxPerPage
+	}
+	return page, perPage
+}
+
+// PageOffset returns the 0-based OFFSET for a 1-based page and per-page size.
+// Callers should pass values already returned by ClampPage.
+func PageOffset(page, perPage int) int {
+	return (page - 1) * perPage
 }

--- a/contract/envelope_test.go
+++ b/contract/envelope_test.go
@@ -2,6 +2,7 @@ package contract
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -101,11 +102,14 @@ func TestClampPage(t *testing.T) {
 		{0, 1000, DefaultPage, MaxPerPage},
 	}
 	for _, tt := range tests {
-		gotPage, gotPer := ClampPage(tt.page, tt.perPage)
-		if gotPage != tt.wantPage || gotPer != tt.wantPer {
-			t.Fatalf("ClampPage(%d, %d) = (%d, %d), want (%d, %d)",
-				tt.page, tt.perPage, gotPage, gotPer, tt.wantPage, tt.wantPer)
-		}
+		t.Run(fmt.Sprintf("page=%d,per_page=%d", tt.page, tt.perPage), func(t *testing.T) {
+			t.Parallel()
+			gotPage, gotPer := ClampPage(tt.page, tt.perPage)
+			if gotPage != tt.wantPage || gotPer != tt.wantPer {
+				t.Fatalf("ClampPage(%d, %d) = (%d, %d), want (%d, %d)",
+					tt.page, tt.perPage, gotPage, gotPer, tt.wantPage, tt.wantPer)
+			}
+		})
 	}
 }
 
@@ -120,8 +124,11 @@ func TestPageOffset(t *testing.T) {
 		{3, 10, 20},
 	}
 	for _, tt := range tests {
-		if got := PageOffset(tt.page, tt.perPage); got != tt.want {
-			t.Fatalf("PageOffset(%d, %d) = %d, want %d", tt.page, tt.perPage, got, tt.want)
-		}
+		t.Run(fmt.Sprintf("page=%d,per_page=%d", tt.page, tt.perPage), func(t *testing.T) {
+			t.Parallel()
+			if got := PageOffset(tt.page, tt.perPage); got != tt.want {
+				t.Fatalf("PageOffset(%d, %d) = %d, want %d", tt.page, tt.perPage, got, tt.want)
+			}
+		})
 	}
 }

--- a/contract/envelope_test.go
+++ b/contract/envelope_test.go
@@ -84,3 +84,44 @@ func TestDataMetaZeroPageMetaStillSerializes(t *testing.T) {
 		t.Fatalf("non-nil zero PageMeta should serialize; got %s", raw)
 	}
 }
+
+func TestClampPage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		page, perPage     int
+		wantPage, wantPer int
+	}{
+		{0, 0, DefaultPage, DefaultPerPage},
+		{1, 20, 1, 20},
+		{2, 50, 2, 50},
+		{3, 100, 3, 100},
+		{1, 101, 1, MaxPerPage},
+		{-5, -10, DefaultPage, DefaultPerPage},
+		{0, 1000, DefaultPage, MaxPerPage},
+	}
+	for _, tt := range tests {
+		gotPage, gotPer := ClampPage(tt.page, tt.perPage)
+		if gotPage != tt.wantPage || gotPer != tt.wantPer {
+			t.Fatalf("ClampPage(%d, %d) = (%d, %d), want (%d, %d)",
+				tt.page, tt.perPage, gotPage, gotPer, tt.wantPage, tt.wantPer)
+		}
+	}
+}
+
+func TestPageOffset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		page, perPage, want int
+	}{
+		{1, 20, 0},
+		{2, 20, 20},
+		{3, 10, 20},
+	}
+	for _, tt := range tests {
+		if got := PageOffset(tt.page, tt.perPage); got != tt.want {
+			t.Fatalf("PageOffset(%d, %d) = %d, want %d", tt.page, tt.perPage, got, tt.want)
+		}
+	}
+}

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -208,7 +208,8 @@ appear in OpenAPI.
 
 List query parameters:
 
-- `page`, `per_page` (default page 1, per_page 20, max 100)
+- `page`, `per_page` (default page 1, per_page 20, max 100; same
+  `contract.ClampPage` as generated list handlers)
 - `search` (OR `LIKE` across `Options.Search`)
 - `ordering` (a field from `Options.Ordering`; prefix `-` for DESC)
 - one query key per `Options.Filter` field

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -293,7 +293,7 @@ This writes a feature-package under `internal/<snake>/`:
 | File | When |
 | --- | --- |
 | `<snake>.go` | GORM model (`gorm.Model` + fields) |
-| `handler.go` | Thin Huma list/get/create over GORM (D10 envelope) |
+| `handler.go` | Thin Huma list/get/create over GORM (D10 envelope; list honors `page`/`per_page`) |
 | `routes.go` | `Register(app *framework.App)` |
 | `service.go` | Only with `--service` (pass-through) |
 | `repo.go` | Only with `--repo` (pass-through) |

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -51,10 +51,16 @@ type listWidgetsOutput struct {
 Pass a non-nil pointer when meta should appear; a nil `Meta` is omitted.
 A non-nil zero `PageMeta` still serializes (JSON `omitempty` does not drop empty structs).
 
+Generated list handlers (`gombit new` product, `gombit make resource`, and
+`examples/tutorial`) honor `page` / `per_page` query parameters the same way
+the admin data plane does: default page 1, per_page 20, max 100
+(`contract.ClampPage`). `meta.total` is a separate `COUNT`; `data` is the
+`LIMIT`/`OFFSET` slice, so `len(data)` never exceeds `meta.per_page`.
+
 ```go
 Body: contract.DataMeta[[]Widget, contract.PageMeta]{
     Data: items,
-    Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: 125},
+    Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
 },
 ```
 

--- a/examples/tutorial/internal/task/handler.go
+++ b/examples/tutorial/internal/task/handler.go
@@ -24,6 +24,11 @@ type listTasksOutput struct {
 	Body contract.DataMeta[[]taskData, contract.PageMeta]
 }
 
+type listTasksInput struct {
+	Page    int `query:"page" doc:"1-based page"`
+	PerPage int `query:"per_page" doc:"Page size"`
+}
+
 type getTaskInput struct {
 	ID string `path:"id" doc:"Task identifier"`
 }
@@ -43,9 +48,15 @@ type createTaskOutput struct {
 	Body contract.Data[taskData]
 }
 
-func (h *Handler) list(ctx context.Context, _ *struct{}) (*listTasksOutput, error) {
+func (h *Handler) list(ctx context.Context, input *listTasksInput) (*listTasksOutput, error) {
+	page, perPage := contract.ClampPage(input.Page, input.PerPage)
+	q := h.DB.WithContext(ctx).Model(&Task{})
+	var total int64
+	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("list tasks"))
+	}
 	var rows []Task
-	if err := h.DB.WithContext(ctx).Order("id").Find(&rows).Error; err != nil {
+	if err := q.Order("id").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("list tasks"))
 	}
 	items := make([]taskData, 0, len(rows))
@@ -55,7 +66,7 @@ func (h *Handler) list(ctx context.Context, _ *struct{}) (*listTasksOutput, erro
 	return &listTasksOutput{
 		Body: contract.DataMeta[[]taskData, contract.PageMeta]{
 			Data: items,
-			Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: int64(len(items))},
+			Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
 		},
 	}, nil
 }

--- a/examples/tutorial/internal/task/handler_test.go
+++ b/examples/tutorial/internal/task/handler_test.go
@@ -1,0 +1,148 @@
+package task_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gombit-dev/gombit/config"
+	"github.com/gombit-dev/gombit/contract"
+	"github.com/gombit-dev/gombit/database"
+	"github.com/gombit-dev/gombit/examples/tutorial/internal/task"
+	"github.com/gombit-dev/gombit/framework"
+	"go.uber.org/zap"
+)
+
+type listEnvelope struct {
+	Data []map[string]any   `json:"data"`
+	Meta *contract.PageMeta `json:"meta"`
+}
+
+func TestListHonorsPageAndPerPage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newTaskApp(t)
+	const total = 25
+	for i := 0; i < total; i++ {
+		createTask(t, app, fmt.Sprintf("task-%02d", i+1))
+	}
+
+	first := getList(t, app, "/api/v1/tasks")
+	if first.Meta == nil {
+		t.Fatal("default list missing meta")
+	}
+	if first.Meta.Page != 1 || first.Meta.PerPage != contract.DefaultPerPage || first.Meta.Total != total {
+		t.Fatalf("default meta = %+v, want page=1 per_page=%d total=%d", first.Meta, contract.DefaultPerPage, total)
+	}
+	if len(first.Data) != contract.DefaultPerPage {
+		t.Fatalf("default data len = %d, want %d (got more rows than advertised per_page)", len(first.Data), contract.DefaultPerPage)
+	}
+
+	page2 := getList(t, app, "/api/v1/tasks?page=2")
+	if page2.Meta == nil || page2.Meta.Page != 2 || page2.Meta.PerPage != contract.DefaultPerPage || page2.Meta.Total != total {
+		t.Fatalf("page=2 meta = %+v", page2.Meta)
+	}
+	if got, want := len(page2.Data), total-contract.DefaultPerPage; got != want {
+		t.Fatalf("page=2 data len = %d, want %d", got, want)
+	}
+	seen := map[any]struct{}{}
+	for _, row := range append(append([]map[string]any{}, first.Data...), page2.Data...) {
+		id := row["id"]
+		if _, ok := seen[id]; ok {
+			t.Fatalf("pages overlap on id %#v", id)
+		}
+		seen[id] = struct{}{}
+	}
+	if len(seen) != total {
+		t.Fatalf("page1+page2 unique ids = %d, want %d", len(seen), total)
+	}
+
+	small := getList(t, app, "/api/v1/tasks?page=1&per_page=5")
+	if small.Meta == nil || small.Meta.Page != 1 || small.Meta.PerPage != 5 || small.Meta.Total != total {
+		t.Fatalf("per_page=5 meta = %+v", small.Meta)
+	}
+	if len(small.Data) != 5 {
+		t.Fatalf("per_page=5 data len = %d, want 5", len(small.Data))
+	}
+
+	clamped := getList(t, app, "/api/v1/tasks?page=0&per_page=1000")
+	if clamped.Meta == nil || clamped.Meta.Page != contract.DefaultPage || clamped.Meta.PerPage != contract.MaxPerPage || clamped.Meta.Total != total {
+		t.Fatalf("clamped meta = %+v, want page=%d per_page=%d total=%d", clamped.Meta, contract.DefaultPage, contract.MaxPerPage, total)
+	}
+	if len(clamped.Data) != total {
+		t.Fatalf("clamped data len = %d, want %d (all rows fit under max per_page)", len(clamped.Data), total)
+	}
+}
+
+func TestListOpenAPIExposesPageQueryParams(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newTaskApp(t)
+
+	rec := httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/openapi.json", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("openapi status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	spec := rec.Body.String()
+	if !strings.Contains(spec, `"name":"page"`) || !strings.Contains(spec, `"name":"per_page"`) {
+		t.Fatalf("OpenAPI missing page/per_page query params; body: %s", spec)
+	}
+}
+
+func newTaskApp(t *testing.T) *framework.App {
+	t.Helper()
+	db, err := database.Open(config.DatabaseConfig{
+		Driver: config.DatabaseDriverSQLite,
+		DSN:    "file:" + filepath.Join(t.TempDir(), "task.db") + "?cache=shared&_fk=1",
+	})
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.AutoMigrate(&task.Task{}); err != nil {
+		t.Fatalf("AutoMigrate(Task) error = %v", err)
+	}
+
+	cfg := config.DefaultFor(config.EnvironmentTest)
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	app, err := framework.New(
+		framework.WithConfig(cfg),
+		framework.WithDatabase(db),
+		framework.WithLogger(zap.NewNop()),
+	)
+	if err != nil {
+		t.Fatalf("framework.New() error = %v", err)
+	}
+	task.Register(app)
+	return app
+}
+
+func createTask(t *testing.T, app *framework.App, title string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"title":%q,"done":false}`, title)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tasks", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	app.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create %q status = %d; body: %s", title, rec.Code, rec.Body.String())
+	}
+}
+
+func getList(t *testing.T, app *framework.App, path string) listEnvelope {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s status = %d; body: %s", path, rec.Code, rec.Body.String())
+	}
+	var env listEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode GET %s: %v; body: %s", path, err, rec.Body.String())
+	}
+	return env
+}

--- a/goldentest/testdata/golden/make-command/frontend/src/api/generated/schema.ts
+++ b/goldentest/testdata/golden/make-command/frontend/src/api/generated/schema.ts
@@ -346,7 +346,10 @@ export interface operations {
   };
   "list-products": {
     parameters: {
-      query?: never;
+      query?: {
+        page?: number;
+        per_page?: number;
+      };
       header?: never;
       path?: never;
       cookie?: never;

--- a/goldentest/testdata/golden/make-command/internal/product/handler.go
+++ b/goldentest/testdata/golden/make-command/internal/product/handler.go
@@ -23,6 +23,11 @@ type listProductsOutput struct {
 	Body contract.DataMeta[[]productData, contract.PageMeta]
 }
 
+type listProductsInput struct {
+	Page    int `query:"page" doc:"1-based page"`
+	PerPage int `query:"per_page" doc:"Page size"`
+}
+
 type getProductInput struct {
 	ID string `path:"id" doc:"Product identifier"`
 }
@@ -42,9 +47,15 @@ type createProductOutput struct {
 	Body contract.Data[productData]
 }
 
-func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, error) {
+func (h *Handler) list(ctx context.Context, input *listProductsInput) (*listProductsOutput, error) {
+	page, perPage := contract.ClampPage(input.Page, input.PerPage)
+	q := h.DB.WithContext(ctx).Model(&Product{})
+	var total int64
+	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("list products"))
+	}
 	var rows []Product
-	if err := h.DB.WithContext(ctx).Order("id").Find(&rows).Error; err != nil {
+	if err := q.Order("id").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("list products"))
 	}
 	items := make([]productData, 0, len(rows))
@@ -54,7 +65,7 @@ func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, e
 	return &listProductsOutput{
 		Body: contract.DataMeta[[]productData, contract.PageMeta]{
 			Data: items,
-			Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: int64(len(items))},
+			Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
 		},
 	}, nil
 }

--- a/goldentest/testdata/golden/make-resource/frontend/src/api/generated/schema.ts
+++ b/goldentest/testdata/golden/make-resource/frontend/src/api/generated/schema.ts
@@ -346,7 +346,10 @@ export interface operations {
   };
   "list-products": {
     parameters: {
-      query?: never;
+      query?: {
+        page?: number;
+        per_page?: number;
+      };
       header?: never;
       path?: never;
       cookie?: never;

--- a/goldentest/testdata/golden/make-resource/internal/book/handler.go
+++ b/goldentest/testdata/golden/make-resource/internal/book/handler.go
@@ -23,6 +23,11 @@ type listBooksOutput struct {
 	Body contract.DataMeta[[]bookData, contract.PageMeta]
 }
 
+type listBooksInput struct {
+	Page    int `query:"page" doc:"1-based page"`
+	PerPage int `query:"per_page" doc:"Page size"`
+}
+
 type getBookInput struct {
 	ID string `path:"id" doc:"Book identifier"`
 }
@@ -41,9 +46,15 @@ type createBookOutput struct {
 	Body contract.Data[bookData]
 }
 
-func (h *Handler) list(ctx context.Context, _ *struct{}) (*listBooksOutput, error) {
+func (h *Handler) list(ctx context.Context, input *listBooksInput) (*listBooksOutput, error) {
+	page, perPage := contract.ClampPage(input.Page, input.PerPage)
+	q := h.DB.WithContext(ctx).Model(&Book{})
+	var total int64
+	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("list books"))
+	}
 	var rows []Book
-	if err := h.DB.WithContext(ctx).Order("id").Find(&rows).Error; err != nil {
+	if err := q.Order("id").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("list books"))
 	}
 	items := make([]bookData, 0, len(rows))
@@ -53,7 +64,7 @@ func (h *Handler) list(ctx context.Context, _ *struct{}) (*listBooksOutput, erro
 	return &listBooksOutput{
 		Body: contract.DataMeta[[]bookData, contract.PageMeta]{
 			Data: items,
-			Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: int64(len(items))},
+			Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
 		},
 	}, nil
 }

--- a/goldentest/testdata/golden/make-resource/internal/product/handler.go
+++ b/goldentest/testdata/golden/make-resource/internal/product/handler.go
@@ -23,6 +23,11 @@ type listProductsOutput struct {
 	Body contract.DataMeta[[]productData, contract.PageMeta]
 }
 
+type listProductsInput struct {
+	Page    int `query:"page" doc:"1-based page"`
+	PerPage int `query:"per_page" doc:"Page size"`
+}
+
 type getProductInput struct {
 	ID string `path:"id" doc:"Product identifier"`
 }
@@ -42,9 +47,15 @@ type createProductOutput struct {
 	Body contract.Data[productData]
 }
 
-func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, error) {
+func (h *Handler) list(ctx context.Context, input *listProductsInput) (*listProductsOutput, error) {
+	page, perPage := contract.ClampPage(input.Page, input.PerPage)
+	q := h.DB.WithContext(ctx).Model(&Product{})
+	var total int64
+	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("list products"))
+	}
 	var rows []Product
-	if err := h.DB.WithContext(ctx).Order("id").Find(&rows).Error; err != nil {
+	if err := q.Order("id").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("list products"))
 	}
 	items := make([]productData, 0, len(rows))
@@ -54,7 +65,7 @@ func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, e
 	return &listProductsOutput{
 		Body: contract.DataMeta[[]productData, contract.PageMeta]{
 			Data: items,
-			Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: int64(len(items))},
+			Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
 		},
 	}, nil
 }

--- a/goldentest/testdata/golden/new-cookie/frontend/src/api/generated/schema.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/api/generated/schema.ts
@@ -391,7 +391,10 @@ export interface operations {
   };
   "list-products": {
     parameters: {
-      query?: never;
+      query?: {
+        page?: number;
+        per_page?: number;
+      };
       header?: never;
       path?: never;
       cookie?: never;

--- a/goldentest/testdata/golden/new-cookie/internal/product/handler.go
+++ b/goldentest/testdata/golden/new-cookie/internal/product/handler.go
@@ -23,6 +23,11 @@ type listProductsOutput struct {
 	Body contract.DataMeta[[]productData, contract.PageMeta]
 }
 
+type listProductsInput struct {
+	Page    int `query:"page" doc:"1-based page"`
+	PerPage int `query:"per_page" doc:"Page size"`
+}
+
 type getProductInput struct {
 	ID string `path:"id" doc:"Product identifier"`
 }
@@ -42,9 +47,15 @@ type createProductOutput struct {
 	Body contract.Data[productData]
 }
 
-func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, error) {
+func (h *Handler) list(ctx context.Context, input *listProductsInput) (*listProductsOutput, error) {
+	page, perPage := contract.ClampPage(input.Page, input.PerPage)
+	q := h.DB.WithContext(ctx).Model(&Product{})
+	var total int64
+	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("list products"))
+	}
 	var rows []Product
-	if err := h.DB.WithContext(ctx).Order("id").Find(&rows).Error; err != nil {
+	if err := q.Order("id").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("list products"))
 	}
 	items := make([]productData, 0, len(rows))
@@ -54,7 +65,7 @@ func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, e
 	return &listProductsOutput{
 		Body: contract.DataMeta[[]productData, contract.PageMeta]{
 			Data: items,
-			Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: int64(len(items))},
+			Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
 		},
 	}, nil
 }

--- a/goldentest/testdata/golden/new-mui/frontend/src/api/generated/schema.ts
+++ b/goldentest/testdata/golden/new-mui/frontend/src/api/generated/schema.ts
@@ -346,7 +346,10 @@ export interface operations {
   };
   "list-products": {
     parameters: {
-      query?: never;
+      query?: {
+        page?: number;
+        per_page?: number;
+      };
       header?: never;
       path?: never;
       cookie?: never;

--- a/goldentest/testdata/golden/new-mui/internal/product/handler.go
+++ b/goldentest/testdata/golden/new-mui/internal/product/handler.go
@@ -23,6 +23,11 @@ type listProductsOutput struct {
 	Body contract.DataMeta[[]productData, contract.PageMeta]
 }
 
+type listProductsInput struct {
+	Page    int `query:"page" doc:"1-based page"`
+	PerPage int `query:"per_page" doc:"Page size"`
+}
+
 type getProductInput struct {
 	ID string `path:"id" doc:"Product identifier"`
 }
@@ -42,9 +47,15 @@ type createProductOutput struct {
 	Body contract.Data[productData]
 }
 
-func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, error) {
+func (h *Handler) list(ctx context.Context, input *listProductsInput) (*listProductsOutput, error) {
+	page, perPage := contract.ClampPage(input.Page, input.PerPage)
+	q := h.DB.WithContext(ctx).Model(&Product{})
+	var total int64
+	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("list products"))
+	}
 	var rows []Product
-	if err := h.DB.WithContext(ctx).Order("id").Find(&rows).Error; err != nil {
+	if err := q.Order("id").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("list products"))
 	}
 	items := make([]productData, 0, len(rows))
@@ -54,7 +65,7 @@ func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, e
 	return &listProductsOutput{
 		Body: contract.DataMeta[[]productData, contract.PageMeta]{
 			Data: items,
-			Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: int64(len(items))},
+			Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
 		},
 	}, nil
 }

--- a/goldentest/testdata/golden/new/frontend/src/api/generated/schema.ts
+++ b/goldentest/testdata/golden/new/frontend/src/api/generated/schema.ts
@@ -346,7 +346,10 @@ export interface operations {
   };
   "list-products": {
     parameters: {
-      query?: never;
+      query?: {
+        page?: number;
+        per_page?: number;
+      };
       header?: never;
       path?: never;
       cookie?: never;

--- a/goldentest/testdata/golden/new/internal/product/handler.go
+++ b/goldentest/testdata/golden/new/internal/product/handler.go
@@ -23,6 +23,11 @@ type listProductsOutput struct {
 	Body contract.DataMeta[[]productData, contract.PageMeta]
 }
 
+type listProductsInput struct {
+	Page    int `query:"page" doc:"1-based page"`
+	PerPage int `query:"per_page" doc:"Page size"`
+}
+
 type getProductInput struct {
 	ID string `path:"id" doc:"Product identifier"`
 }
@@ -42,9 +47,15 @@ type createProductOutput struct {
 	Body contract.Data[productData]
 }
 
-func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, error) {
+func (h *Handler) list(ctx context.Context, input *listProductsInput) (*listProductsOutput, error) {
+	page, perPage := contract.ClampPage(input.Page, input.PerPage)
+	q := h.DB.WithContext(ctx).Model(&Product{})
+	var total int64
+	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("list products"))
+	}
 	var rows []Product
-	if err := h.DB.WithContext(ctx).Order("id").Find(&rows).Error; err != nil {
+	if err := q.Order("id").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("list products"))
 	}
 	items := make([]productData, 0, len(rows))
@@ -54,7 +65,7 @@ func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, e
 	return &listProductsOutput{
 		Body: contract.DataMeta[[]productData, contract.PageMeta]{
 			Data: items,
-			Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: int64(len(items))},
+			Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
 		},
 	}, nil
 }

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -143,8 +143,12 @@ func renderHandler(ctx renderContext) string {
 	}
 	b.WriteString("}\n\n")
 	listOut := "list" + ctx.Resource.Tag + "Output"
+	listIn := "list" + ctx.Resource.Tag + "Input"
 	b.WriteString("type " + listOut + " struct {\n")
 	b.WriteString("\tBody contract.DataMeta[[]" + data + ", contract.PageMeta]\n}\n\n")
+	b.WriteString("type " + listIn + " struct {\n")
+	b.WriteString("\tPage    int `query:\"page\" doc:\"1-based page\"`\n")
+	b.WriteString("\tPerPage int `query:\"per_page\" doc:\"Page size\"`\n}\n\n")
 	b.WriteString("type get" + typ + "Input struct {\n")
 	b.WriteString("\tID string `path:\"id\" doc:\"" + typ + " identifier\"`\n}\n\n")
 	b.WriteString("type get" + typ + "Output struct {\n")
@@ -157,9 +161,15 @@ func renderHandler(ctx renderContext) string {
 	b.WriteString("type create" + typ + "Output struct {\n")
 	b.WriteString("\tBody contract.Data[" + data + "]\n}\n\n")
 
-	b.WriteString("func (h *Handler) list(ctx context.Context, _ *struct{}) (*" + listOut + ", error) {\n")
+	b.WriteString("func (h *Handler) list(ctx context.Context, input *" + listIn + ") (*" + listOut + ", error) {\n")
+	b.WriteString("\tpage, perPage := contract.ClampPage(input.Page, input.PerPage)\n")
+	b.WriteString("\tq := h.DB.WithContext(ctx).Model(&" + typ + "{})\n")
+	b.WriteString("\tvar total int64\n")
+	b.WriteString("\tif err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {\n")
+	b.WriteString("\t\treturn nil, contract.WithContext(ctx, contract.Internal(\"list " + ctx.Resource.PluralSnake + "\"))\n")
+	b.WriteString("\t}\n")
 	b.WriteString("\tvar rows []" + typ + "\n")
-	b.WriteString("\tif err := h.DB.WithContext(ctx).Order(\"id\").Find(&rows).Error; err != nil {\n")
+	b.WriteString("\tif err := q.Order(\"id\").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {\n")
 	b.WriteString("\t\treturn nil, contract.WithContext(ctx, contract.Internal(\"list " + ctx.Resource.PluralSnake + "\"))\n")
 	b.WriteString("\t}\n")
 	b.WriteString("\titems := make([]" + data + ", 0, len(rows))\n")
@@ -167,7 +177,7 @@ func renderHandler(ctx renderContext) string {
 	b.WriteString("\treturn &" + listOut + "{\n")
 	b.WriteString("\t\tBody: contract.DataMeta[[]" + data + ", contract.PageMeta]{\n")
 	b.WriteString("\t\t\tData: items,\n")
-	b.WriteString("\t\t\tMeta: &contract.PageMeta{Page: 1, PerPage: 20, Total: int64(len(items))},\n")
+	b.WriteString("\t\t\tMeta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},\n")
 	b.WriteString("\t\t},\n")
 	b.WriteString("\t}, nil\n}\n\n")
 

--- a/resourcegen/generate_test.go
+++ b/resourcegen/generate_test.go
@@ -86,6 +86,18 @@ func TestGenerateBookFeaturePackage(t *testing.T) {
 	if !strings.Contains(handlerSrc, `contract.Internal("list books")`) {
 		t.Fatalf("handler Internal message = %q, want list books", handlerSrc)
 	}
+	if !strings.Contains(handlerSrc, `query:"page"`) || !strings.Contains(handlerSrc, `query:"per_page"`) {
+		t.Fatal("generated list handler missing page/per_page query params")
+	}
+	if !strings.Contains(handlerSrc, "contract.ClampPage") || !strings.Contains(handlerSrc, "contract.PageOffset") {
+		t.Fatal("generated list handler does not clamp page/per_page")
+	}
+	if !strings.Contains(handlerSrc, ".Limit(") || !strings.Contains(handlerSrc, "Count(&total)") {
+		t.Fatal("generated list handler does not LIMIT/OFFSET or count total separately")
+	}
+	if strings.Contains(handlerSrc, "PerPage: 20, Total: int64(len(items))") {
+		t.Fatal("generated list handler still advertises hardcoded per_page=20 from len(items)")
+	}
 	if _, err := os.Stat(filepath.Join(appDir, "internal", "book", "service.go")); !os.IsNotExist(err) {
 		t.Fatal("default generate wrote service.go")
 	}

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -283,6 +283,13 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	if !strings.Contains(schema, `"/api/v1/auth/login"`) || !strings.Contains(schema, `"/api/v1/me"`) {
 		t.Fatal("placeholder schema.ts missing auth paths")
 	}
+	if !strings.Contains(schema, "per_page?: number") {
+		t.Fatal("placeholder schema.ts missing list-products per_page query param")
+	}
+	handler := readFile(t, filepath.Join(dest, "internal", "product", "handler.go"))
+	if !strings.Contains(handler, "contract.ClampPage") || !strings.Contains(handler, `query:"per_page"`) {
+		t.Fatal("product handler missing page/per_page list pagination")
+	}
 }
 
 func TestGenerateDryRunWritesNothing(t *testing.T) {

--- a/scaffold/templates/frontend/src/api/generated/schema.ts.tmpl
+++ b/scaffold/templates/frontend/src/api/generated/schema.ts.tmpl
@@ -484,7 +484,10 @@ export interface operations {
   };
   "list-products": {
     parameters: {
-      query?: never;
+      query?: {
+        page?: number;
+        per_page?: number;
+      };
       header?: never;
       path?: never;
       cookie?: never;

--- a/scaffold/templates/internal/product/handler.go.tmpl
+++ b/scaffold/templates/internal/product/handler.go.tmpl
@@ -23,6 +23,11 @@ type listProductsOutput struct {
 	Body contract.DataMeta[[]productData, contract.PageMeta]
 }
 
+type listProductsInput struct {
+	Page    int `query:"page" doc:"1-based page"`
+	PerPage int `query:"per_page" doc:"Page size"`
+}
+
 type getProductInput struct {
 	ID string `path:"id" doc:"Product identifier"`
 }
@@ -42,9 +47,15 @@ type createProductOutput struct {
 	Body contract.Data[productData]
 }
 
-func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, error) {
+func (h *Handler) list(ctx context.Context, input *listProductsInput) (*listProductsOutput, error) {
+	page, perPage := contract.ClampPage(input.Page, input.PerPage)
+	q := h.DB.WithContext(ctx).Model(&Product{})
+	var total int64
+	if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("list products"))
+	}
 	var rows []Product
-	if err := h.DB.WithContext(ctx).Order("id").Find(&rows).Error; err != nil {
+	if err := q.Order("id").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("list products"))
 	}
 	items := make([]productData, 0, len(rows))
@@ -54,7 +65,7 @@ func (h *Handler) list(ctx context.Context, _ *struct{}) (*listProductsOutput, e
 	return &listProductsOutput{
 		Body: contract.DataMeta[[]productData, contract.PageMeta]{
 			Data: items,
-			Meta: &contract.PageMeta{Page: 1, PerPage: 20, Total: int64(len(items))},
+			Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},
 		},
 	}, nil
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Generated list handlers `Find`ed the entire table and advertised `meta.per_page=20` regardless of payload size. `?page=2` was ignored. `len(data)` could exceed `meta.per_page`.

List handlers now honor `page` / `per_page` with the same clamps as admin (`contract.ClampPage` / `PageOffset`: default 1/20, max 100). `meta.total` is a separate `COUNT`. `data` is `LIMIT`/`OFFSET` ordered by id.

Closes #110

## Acceptance criteria

- [x] `page` / `per_page` query params on generated list
- [x] Default page=1, per_page=20; per_page clamped to 100
- [x] `len(data)` never exceeds `meta.per_page`
- [x] `meta.total` is table count, not `len(data)`
- [x] `?page=2` returns the next slice
- [x] Admin uses the same clamp helpers
- [x] Scaffold, resourcegen, tutorial example, goldens, placeholder schema updated

## Scope notes

Did not start #111. Generated SPA list pages still GET without query params, so they now show the first page of 20 (honest D10) rather than every row.

## Validation

- [x] Tutorial `TestListHonorsPageAndPerPage` (failed before, passes after)
- [x] `TestClampPage` / `TestPageOffset`
- [x] resourcegen/scaffold generator assertions
- [x] `go test ./goldentest`
- [x] `gofmt` + golangci-lint on touched packages
- [ ] `go test ./...` (CI)
- [ ] Project `code-review` skill (reviewer after CI)

## Working agreement checklist

- [x] New behavior has tests; tutorial list test uses SQLite in-process (CI matrix for admin still applies)
- [x] Docs updated (`docs/contract.md`, `docs/cli.md`, `docs/admin.md`, CHANGELOG)
- [x] Extraction N/A
- [x] Generators updated (templates + resourcegen); goldens updated
- [ ] API OpenAPI regenerate — placeholder schema.ts.tmpl updated; `examples/client` SampleApp list-widgets is a 1-row stub without list query params (unchanged)
- [x] No secrets in generated frontend
- [x] Scope stays inside this issue
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

