### PR TITLE
fix: drop hardcoded Products home link on make-resource lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ version.
 
 ### Fixed
 
+- `gombit make resource` no longer hardcodes a **Products** home link on
+  generated list pages. AppLayout already exposes that nav; Books (and any
+  other resource) keep a New link only
+  ([#112](https://github.com/gombit-dev/gombit/issues/112)).
 - Generated get/create handlers map GORM errors to D10 categories instead of
   collapsing every load failure to `not_found` and every persist failure to
   `internal`. Missing rows are 404 `not_found`; unique/duplicate keys are 409

--- a/goldentest/testdata/golden/make-resource/frontend/src/book/list.tsx
+++ b/goldentest/testdata/golden/make-resource/frontend/src/book/list.tsx
@@ -51,8 +51,6 @@ export function BookListPage() {
     <section>
       <h1>Books</h1>
       <p>
-        <Link to="/">Products</Link>
-        {" · "}
         <Link to="/books/new">New Book</Link>
       </p>
       <table>

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -371,8 +371,6 @@ func renderMinimalListTSX(ctx renderContext) string {
 	b.WriteString("    <section>\n")
 	b.WriteString("      <h1>" + ctx.Resource.Tag + "</h1>\n")
 	b.WriteString("      <p>\n")
-	b.WriteString("        <Link to=\"/\">Products</Link>\n")
-	b.WriteString("        {\" · \"}\n")
 	b.WriteString("        <Link to=\"/" + ctx.Resource.Kebab + "/new\">New " + ctx.Resource.TypeName + "</Link>\n")
 	b.WriteString("      </p>\n")
 	b.WriteString("      <table>\n")

--- a/resourcegen/generate_test.go
+++ b/resourcegen/generate_test.go
@@ -127,6 +127,15 @@ func TestGenerateBookFeaturePackage(t *testing.T) {
 	if strings.Contains(listTS, "@mui/material") {
 		t.Fatal("default make resource must stay headless")
 	}
+	if strings.Contains(listTS, `to="/">Products</Link>`) {
+		t.Fatal("generated Book list.tsx hardcodes a Products home link; AppLayout already exposes that nav")
+	}
+	if strings.Contains(listTS, "Products") {
+		t.Fatalf("generated Book list.tsx still mentions Products:\n%s", listTS)
+	}
+	if !strings.Contains(listTS, `to="/books/new">New Book</Link>`) {
+		t.Fatal("generated Book list.tsx missing New Book link")
+	}
 	formTS := readFile(t, filepath.Join(appDir, "frontend", "src", "book", "form.tsx"))
 	if !strings.Contains(formTS, "applyContractErrors") || !strings.Contains(formTS, "setError") {
 		t.Fatal("form.tsx does not map D10 field errors through applyContractErrors")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`gombit make resource` minimal list pages always rendered `<Link to="/">Products</Link>` regardless of the resource. Books (and every other model) advertised a product-specific home label. AppLayout already exposes Products in the header; the MUI list template never had this extra link.

The leftover home link is omitted. Generated lists keep the New resource link only.

Closes #112

## Acceptance criteria

- [x] Non-product resources no longer render a “Products” home link
- [x] New resource link remains
- [x] Goldens and resourcegen tests updated

## Scope notes

Omitted the extra link rather than relabeling it Home, matching MUI lists and AppLayout nav.

## Validation

- [x] `go test ./resourcegen`
- [x] `go test ./goldentest -run 'TestMakeResourceGolden$'`
- [ ] Full CI
- [ ] Project `code-review` skill (reviewer after CI)

## Working agreement checklist

- [x] New behavior has tests (resourcegen + goldentest)
- [x] CHANGELOG if applicable
- [x] Extraction N/A
- [x] Generators updated; goldens updated
- [ ] OpenAPI N/A
- [x] No secrets
- [x] Scope stays inside this issue
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

