### PR TITLE
fix: initialize auth timing dummy hash with sync.Once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ version.
 
 ### Fixed
 
+- Unknown-email login timing pad no longer races on `Service.dummyHash`.
+  `compareDummy` initializes the dummy bcrypt hash once via `sync.Once` so
+  concurrent `Authenticate` misses are race-free
+  ([#113](https://github.com/gombit-dev/gombit/issues/113)).
 - `gombit make resource` no longer hardcodes a **Products** home link on
   generated list pages. AppLayout already exposes that nav; Books (and any
   other resource) keep a New link only

--- a/auth/service.go
+++ b/auth/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gombit-dev/gombit/config"
@@ -19,6 +20,7 @@ type Service struct {
 	secret    []byte
 	hasher    Hasher
 	clock     Clock
+	dummyOnce sync.Once
 	dummyHash string
 }
 
@@ -244,12 +246,15 @@ func revokeAllTx(tx *gorm.DB, userID uint, now time.Time) error {
 }
 
 func (s *Service) compareDummy(password string) {
-	if s.dummyHash == "" {
+	s.dummyOnce.Do(func() {
 		hash, err := s.hasher.Hash("timing-dummy-password")
 		if err != nil {
 			return
 		}
 		s.dummyHash = hash
+	})
+	if s.dummyHash == "" {
+		return
 	}
 	_ = s.hasher.Compare(s.dummyHash, password)
 }

--- a/auth/service_test.go
+++ b/auth/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -161,6 +162,30 @@ func TestRegisterDoesNotGrantSuperuser(t *testing.T) {
 	}
 	if _, err := svc.Register(ctx, "user@example.com", "correct-horse-2"); !errors.Is(err, ErrEmailTaken) {
 		t.Fatalf("duplicate Register error = %v, want ErrEmailTaken", err)
+	}
+}
+
+// TestAuthenticateUnknownEmailParallel is the #113 regression: unknown-email
+// logins lazily initialize Service.dummyHash. Concurrent Authenticate calls
+// on one *Service must not race on that write (go test -race).
+func TestAuthenticateUnknownEmailParallel(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	const n = 32
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = svc.Authenticate(ctx, "nobody@example.com", "x")
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if !errors.Is(err, errInvalidCredentials) {
+			t.Fatalf("Authenticate()[%d] error = %v, want errInvalidCredentials", i, err)
+		}
 	}
 }
 

--- a/dev/run_test.go
+++ b/dev/run_test.go
@@ -207,6 +207,39 @@ func waitStarts(t *testing.T, startedCh <-chan struct{}, n int) {
 	}
 }
 
+// waitChildEnvAssigned waits until n captured cmds have a non-empty Env.
+// opts.Command signals startedCh before runOne/runProcesses assigns cmd.Env,
+// so reading Env immediately after waitStarts can observe a nil overlay.
+func waitChildEnvAssigned(t *testing.T, mu *sync.Mutex, cmds *[]*exec.Cmd, n int) []*exec.Cmd {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	var captured []*exec.Cmd
+	for {
+		mu.Lock()
+		captured = append([]*exec.Cmd(nil), *cmds...)
+		ready := len(captured) >= n
+		if ready {
+			for _, cmd := range captured {
+				if len(cmd.Env) == 0 {
+					ready = false
+					break
+				}
+			}
+		}
+		mu.Unlock()
+		if ready {
+			return captured
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for child Env overlay (got %d cmds)", len(captured))
+		case <-ticker.C:
+		}
+	}
+}
+
 func TestPlanBackendPrefersAir(t *testing.T) {
 	t.Parallel()
 	plan, err := planBackend(t.TempDir(), func(file string) (string, error) {
@@ -500,12 +533,7 @@ func TestRunChildEnvReplacesParentHTTPAddr(t *testing.T) {
 	}()
 
 	waitStarts(t, startedCh, 2)
-	mu.Lock()
-	captured := append([]*exec.Cmd(nil), cmds...)
-	mu.Unlock()
-	if len(captured) < 2 {
-		t.Fatalf("started %d commands, want 2", len(captured))
-	}
+	captured := waitChildEnvAssigned(t, &mu, &cmds, 2)
 	for _, cmd := range captured {
 		if values := envKeyValues(cmd.Env, "GOMBIT_HTTP_ADDR"); len(values) != 1 || values[0] != ":9090" {
 			t.Fatalf("child Env GOMBIT_HTTP_ADDR = %v, want single :9090", values)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unknown-email logins take a bcrypt timing-dummy path. `dummyHash` was lazily written from request goroutines with no synchronization, so concurrent failed logins raced (`go test -race`).

`compareDummy` now initializes the dummy hash with `sync.Once`. A 32-goroutine `-race` test covers parallel unknown-email `Authenticate` on one `*Service`.

Also unblocks CI: `TestRunChildEnvReplacesParentHTTPAddr` raced on `cmd.Env` assignment (read before supervisor overlay). The test now waits until Env is set. Unrelated to #113; it was failing this PR's Test job.

Closes #113

## Acceptance criteria

- [x] Dummy hash initialized once (race-free)
- [x] Timing pad still runs Compare on unknown-email logins
- [x] `go test -race` regression with concurrent unknown-email Authenticate

## Scope notes

Did not start #127 (token family revoke). If Hash fails, dummyHash stays empty and Compare is skipped (same as before); Once will not retry.

`dev/run_test.go` poll-until-Env is only to stop a flake that failed CI on this PR (`child Env GOMBIT_HTTP_ADDR = []`).

## Validation

- [x] Reproduced: `go test -race ./auth -run TestAuthenticateUnknownEmailParallel` failed before
- [x] `go test -race ./auth -count=1` pass after
- [x] `go test ./dev -count=20 -run TestRunChildEnvReplacesParentHTTPAddr`
- [ ] Full CI (must be 13/13 green before merge)
- [ ] Project `code-review` skill (reviewer after CI)

## Working agreement checklist

- [x] New behavior has tests; DB-touching N/A beyond existing auth sqlite test harness
- [x] CHANGELOG
- [x] Extraction N/A
- [x] Generators N/A
- [ ] OpenAPI N/A
- [x] No secrets
- [x] Scope stays inside this issue (plus CI flake unblocker)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

