### PR TITLE
fix: coerce cleared number inputs to 0 in generated forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ version.
 
 ### Fixed
 
+- Minimal generated number inputs use RHF `setValueAs` so a cleared field
+  submits `0` instead of JSON `null` (`valueAsNumber` → `NaN`)
+  ([#116](https://github.com/gombit-dev/gombit/issues/116)).
 - Admin silent `POST /auth/refresh` on 401 awaits CSRF bootstrap, so a
   reload with an expired access cookie does not 403 CSRF and drop a valid
   refresh session ([#115](https://github.com/gombit-dev/gombit/issues/115)).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -309,7 +309,8 @@ duplicate the `Register` call.
 Frontend pages are React + TypeScript (list/table + React Hook Form create)
 under `frontend/src/<feature>/`. They import types from
 `frontend/src/api/generated` — no hand-written API DTOs — and map D10
-`error.fields` through `frontend/src/api/formErrors.ts`. A generated
+`error.fields` through `frontend/src/api/formErrors.ts`. Integer fields
+coerce a cleared number input to `0` (`setValueAs`), not JSON `null`. A generated
 `frontend/src/resources.tsx` registry is the React Router registration
 point (not regex-patched `main.tsx`). When `gombit.yaml` has `ui: mui`,
 list/form pages use MUI Table and TextField instead of raw HTML. Generated

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -141,6 +141,11 @@ A body like `{"error":{"code":"validation_error","message":"...","fields":{"name
 calls `setError("name", { type: "server", message: "required" })`. Do not
 invent another error shape.
 
+Minimal `type="number"` inputs use React Hook Form `setValueAs` so a
+cleared field becomes `0`, not `NaN` (`JSON.stringify` would emit
+`null` and Huma would 422 a non-pointer Go int). The MUI preset does
+the same with `raw === "" ? 0 : Number(raw)`.
+
 ## Generated client placeholder
 
 `frontend/src/api/generated` ships a placeholder product contract so

--- a/goldentest/testdata/golden/make-command/frontend/src/pages/ProductFormPage.tsx
+++ b/goldentest/testdata/golden/make-command/frontend/src/pages/ProductFormPage.tsx
@@ -54,7 +54,7 @@ export function ProductFormPage() {
         {errors.name?.message ? <p>{errors.name.message}</p> : null}
         <label>
           Price
-          <input type="number" {...register("price", { valueAsNumber: true })} />
+          <input type="number" {...register("price", { setValueAs: (value) => (value === "" ? 0 : Number(value)) })} />
         </label>
         {errors.price?.message ? <p>{errors.price.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>

--- a/goldentest/testdata/golden/make-resource/frontend/src/pages/ProductFormPage.tsx
+++ b/goldentest/testdata/golden/make-resource/frontend/src/pages/ProductFormPage.tsx
@@ -54,7 +54,7 @@ export function ProductFormPage() {
         {errors.name?.message ? <p>{errors.name.message}</p> : null}
         <label>
           Price
-          <input type="number" {...register("price", { valueAsNumber: true })} />
+          <input type="number" {...register("price", { setValueAs: (value) => (value === "" ? 0 : Number(value)) })} />
         </label>
         {errors.price?.message ? <p>{errors.price.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>

--- a/goldentest/testdata/golden/new-cookie/frontend/src/pages/ProductFormPage.tsx
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/pages/ProductFormPage.tsx
@@ -54,7 +54,7 @@ export function ProductFormPage() {
         {errors.name?.message ? <p>{errors.name.message}</p> : null}
         <label>
           Price
-          <input type="number" {...register("price", { valueAsNumber: true })} />
+          <input type="number" {...register("price", { setValueAs: (value) => (value === "" ? 0 : Number(value)) })} />
         </label>
         {errors.price?.message ? <p>{errors.price.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>

--- a/goldentest/testdata/golden/new/frontend/src/pages/ProductFormPage.tsx
+++ b/goldentest/testdata/golden/new/frontend/src/pages/ProductFormPage.tsx
@@ -54,7 +54,7 @@ export function ProductFormPage() {
         {errors.name?.message ? <p>{errors.name.message}</p> : null}
         <label>
           Price
-          <input type="number" {...register("price", { valueAsNumber: true })} />
+          <input type="number" {...register("price", { setValueAs: (value) => (value === "" ? 0 : Number(value)) })} />
         </label>
         {errors.price?.message ? <p>{errors.price.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>

--- a/goldentest/tree_test.go
+++ b/goldentest/tree_test.go
@@ -75,6 +75,7 @@ func assertFrontendInvariants(t *testing.T, files fileMap) {
 	if !strings.Contains(session, "getAccessToken") || !strings.Contains(session, "clearSession") {
 		t.Error("session.ts missing in-memory token helpers")
 	}
+	assertNumberInputEmptyIsZero(t, string(files["frontend/src/pages/ProductFormPage.tsx"]))
 	login := string(files["frontend/src/pages/LoginPage.tsx"])
 	if login == "" {
 		t.Fatal("missing frontend/src/pages/LoginPage.tsx")
@@ -167,6 +168,7 @@ func assertCookieFrontendInvariants(t *testing.T, files fileMap) {
 	if !strings.Contains(client, "if (getCSRFToken())") {
 		t.Error("cookie-mode client.ts missing skip-if-token-exists no-op")
 	}
+	assertNumberInputEmptyIsZero(t, string(files["frontend/src/pages/ProductFormPage.tsx"]))
 	assertRuntimeAPIPrefix(t, files, "cookie")
 }
 
@@ -201,6 +203,7 @@ func assertMUIFrontendInvariants(t *testing.T, files fileMap) {
 	if !strings.Contains(login, "TextField") && !strings.Contains(login, "Paper") {
 		t.Error("MUI LoginPage.tsx missing Paper/TextField")
 	}
+	assertNumberInputEmptyIsZero(t, string(files["frontend/src/pages/ProductFormPage.tsx"]))
 	assertRuntimeAPIPrefix(t, files, "jwt")
 }
 
@@ -361,6 +364,19 @@ func assertNoReplace(t *testing.T, files fileMap) {
 				t.Errorf("%s contains a replace directive; goldens must not bake machine-specific paths", rel)
 			}
 		}
+	}
+}
+
+func assertNumberInputEmptyIsZero(t *testing.T, form string) {
+	t.Helper()
+	if form == "" {
+		t.Fatal("missing frontend/src/pages/ProductFormPage.tsx")
+	}
+	if strings.Contains(form, "valueAsNumber") {
+		t.Error("ProductFormPage.tsx uses valueAsNumber; empty number inputs become NaN and JSON.stringify emits null")
+	}
+	if !strings.Contains(form, `=== "" ? 0`) {
+		t.Error("ProductFormPage.tsx number input does not coerce empty to 0")
 	}
 }
 

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -528,7 +528,7 @@ func renderFormField(field Field) string {
 	case FieldBool:
 		b.WriteString("          <input type=\"checkbox\" {...register(\"" + field.JSONName + "\")} />\n")
 	case FieldInt, FieldInt64, FieldUint:
-		b.WriteString("          <input type=\"number\" {...register(\"" + field.JSONName + "\", { valueAsNumber: true })} />\n")
+		b.WriteString("          <input type=\"number\" {...register(\"" + field.JSONName + "\", { setValueAs: (value) => (value === \"\" ? 0 : Number(value)) })} />\n")
 	default:
 		b.WriteString("          <input type=\"text\" {...register(\"" + field.JSONName + "\"")
 		if field.Required {

--- a/resourcegen/generate_test.go
+++ b/resourcegen/generate_test.go
@@ -538,3 +538,38 @@ func TestGenerateFrontendKeepsTypedDefaultPrefix(t *testing.T) {
 		t.Fatal("form.tsx baked live api_prefix /svc/v2")
 	}
 }
+
+func TestGenerateNumberFieldEmptyIsZero(t *testing.T) {
+	workDir := t.TempDir()
+	if err := scaffold.Generate(context.Background(), scaffold.Options{
+		Name:     "demo",
+		Database: "sqlite",
+		WorkDir:  workDir,
+		Stdout:   ioDiscard{},
+	}); err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	appDir := filepath.Join(workDir, "demo")
+
+	previousLook := lookPath
+	lookPath = func(string) (string, error) { return "", errors.New("atlas missing") }
+	t.Cleanup(func() { lookPath = previousLook })
+
+	err := Generate(context.Background(), Options{
+		WorkDir:   appDir,
+		Name:      "Widget",
+		Fields:    []string{"qty:int"},
+		Stdout:    ioDiscard{},
+		skipAtlas: true,
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	formTS := readFile(t, filepath.Join(appDir, "frontend", "src", "widget", "form.tsx"))
+	if strings.Contains(formTS, "valueAsNumber") {
+		t.Fatal("form.tsx uses valueAsNumber; empty number inputs become NaN and JSON.stringify emits null")
+	}
+	if !strings.Contains(formTS, `setValueAs: (value) => (value === "" ? 0 : Number(value))`) {
+		t.Fatalf("form.tsx missing setValueAs empty→0 for qty:\n%s", formTS)
+	}
+}

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -261,6 +261,7 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	if !strings.Contains(productFormPage, `required: "Name is required"`) {
 		t.Fatalf("ProductFormPage.tsx missing required-field error message:\n%s", productFormPage)
 	}
+	assertNumberInputEmptyIsZero(t, productFormPage, "ProductFormPage.tsx")
 	appClient := readFile(t, filepath.Join(dest, "frontend", "src", "api", "client.ts"))
 	if !strings.Contains(appClient, "refreshInFlight") {
 		t.Fatal("api/client.ts missing shared refresh promise")
@@ -938,6 +939,16 @@ func readFile(t *testing.T, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(data)
+}
+
+func assertNumberInputEmptyIsZero(t *testing.T, src, name string) {
+	t.Helper()
+	if strings.Contains(src, "valueAsNumber") {
+		t.Fatalf("%s uses valueAsNumber; empty number inputs become NaN and JSON.stringify emits null", name)
+	}
+	if !strings.Contains(src, `setValueAs: (value) => (value === "" ? 0 : Number(value))`) {
+		t.Fatalf("%s missing setValueAs empty→0 for number inputs:\n%s", name, src)
+	}
 }
 
 func TestGeneratePinsResolvableFrameworkVersion(t *testing.T) {

--- a/scaffold/templates/frontend/src/pages/ProductFormPage.tsx.tmpl
+++ b/scaffold/templates/frontend/src/pages/ProductFormPage.tsx.tmpl
@@ -113,7 +113,7 @@ export function ProductFormPage() {
         {errors.name?.message ? <p>{errors.name.message}</p> : null}
         <label>
           Price
-          <input type="number" {...register("price", { valueAsNumber: true })} />
+          <input type="number" {...register("price", { setValueAs: (value) => (value === "" ? 0 : Number(value)) })} />
         </label>
         {errors.price?.message ? <p>{errors.price.message}</p> : null}
         <button type="submit" disabled={isSubmitting}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Minimal generated number inputs used React Hook Form `valueAsNumber: true`. Clearing the field stores `NaN`; `JSON.stringify` emits `null`; Huma cannot bind a non-pointer Go int and returns 422 `validation_error`.

Empty values now coerce to `0` via `setValueAs`, matching the MUI `raw === "" ? 0 : Number(raw)` path. Same change in `gombit new` ProductForm and `gombit make resource` int/int64/uint fields.

Closes #116

## Acceptance criteria

- [x] Cleared minimal number input does not serialize as JSON `null`
- [x] Empty number field submits `0` (same as MUI)
- [x] Tests: scaffold ProductForm, `make resource Widget qty:int`, golden invariants reject `valueAsNumber`
- [x] Docs/CHANGELOG

## Scope notes

Admin SPA number widgets are not this issue. MUI generated forms already coerced empty to `0` and are unchanged.

## Validation

- [x] `go test ./scaffold/ ./resourcegen/`
- [x] `go test ./goldentest -run 'TestNewGolden$|TestNewGoldenCookieAuth|TestMakeResourceGolden|TestMakeCommandGolden'`
- [ ] `go test ./...` — CI matrix
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — CI
- [ ] Project `code-review` skill run against this diff (after CI is green)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (no DB change)
- [x] Stable features ship docs and appear in an example app (`docs/frontend.md`, `docs/cli.md`, CHANGELOG, goldens)
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests (N/A — not an extraction)
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) (templates/string builders only; no AST overwrite of user files)
- [x] API changes regenerate the OpenAPI doc + TS client in this PR (N/A — no API change)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

