### PR TITLE
fix: omit Bearer WWW-Authenticate on cookie-mode 401s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ version.
 
 ### Fixed
 
+- Cookie-mode session 401s omit `WWW-Authenticate: Bearer`. The D10 body
+  stays `authentication`; Bearer mode still sends `Bearer realm="api"`
+  ([#117](https://github.com/gombit-dev/gombit/issues/117)).
 - Minimal generated number inputs use RHF `setValueAs` so a cleared field
   submits `0` instead of JSON `null` (`valueAsNumber` → `NaN`)
   ([#116](https://github.com/gombit-dev/gombit/issues/116)).

--- a/auth/cookie_handlers.go
+++ b/auth/cookie_handlers.go
@@ -111,12 +111,12 @@ func (s *Service) requireCookieSession() func(ctx huma.Context, next func(huma.C
 	return func(ctx huma.Context, next func(huma.Context)) {
 		cookie, err := huma.ReadCookie(ctx, AccessCookieName)
 		if err != nil || cookie.Value == "" {
-			writeAuthError(ctx, contract.WithContext(ctx.Context(), contract.Authentication("missing session cookie")))
+			writeCookieAuthError(ctx, contract.WithContext(ctx.Context(), contract.Authentication("missing session cookie")))
 			return
 		}
 		user, err := s.ParseAccess(ctx.Context(), cookie.Value)
 		if err != nil {
-			writeAuthError(ctx, contract.WithContext(ctx.Context(), contract.Authentication("invalid session cookie")))
+			writeCookieAuthError(ctx, contract.WithContext(ctx.Context(), contract.Authentication("invalid session cookie")))
 			return
 		}
 		next(huma.WithValue(ctx, userContextKey{}, user))

--- a/auth/cookie_handlers_test.go
+++ b/auth/cookie_handlers_test.go
@@ -364,7 +364,7 @@ func TestCookieMe401OmitsBearerChallenge(t *testing.T) {
 	t.Run("invalid session cookie", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
-		req.AddCookie(&http.Cookie{Name: auth.AccessCookieName, Value: "not-a-jwt"})
+		req.AddCookie(&http.Cookie{Name: auth.AccessCookieName, Value: "not-a-jwt"}) //nolint:gosec // G124: request Cookie header only carries name/value.
 		app.Router().ServeHTTP(rec, req)
 		if rec.Code != http.StatusUnauthorized {
 			t.Fatalf("status = %d, want 401; body: %s", rec.Code, rec.Body.String())

--- a/auth/cookie_handlers_test.go
+++ b/auth/cookie_handlers_test.go
@@ -337,6 +337,45 @@ func TestCSRFSafeMethodsAreExempt(t *testing.T) {
 	if rec.Result().Header.Get("Set-Cookie") == "" {
 		t.Fatal("safe GET request did not bootstrap a csrf cookie")
 	}
+	if got := rec.Result().Header.Get("WWW-Authenticate"); got != "" {
+		t.Fatalf("cookie-mode 401 WWW-Authenticate = %q, want omit (not Bearer)", got)
+	}
+}
+
+func TestCookieMe401OmitsBearerChallenge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieAuthApp(t)
+
+	t.Run("missing session cookie", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
+		app.Router().ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401; body: %s", rec.Code, rec.Body.String())
+		}
+		if got := rec.Result().Header.Get("WWW-Authenticate"); got != "" {
+			t.Fatalf("WWW-Authenticate = %q, want omit", got)
+		}
+		if !strings.Contains(rec.Body.String(), "missing session cookie") {
+			t.Fatalf("body = %s, want missing session cookie", rec.Body.String())
+		}
+	})
+
+	t.Run("invalid session cookie", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
+		req.AddCookie(&http.Cookie{Name: auth.AccessCookieName, Value: "not-a-jwt"})
+		app.Router().ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401; body: %s", rec.Code, rec.Body.String())
+		}
+		if got := rec.Result().Header.Get("WWW-Authenticate"); got != "" {
+			t.Fatalf("WWW-Authenticate = %q, want omit", got)
+		}
+		if !strings.Contains(rec.Body.String(), "invalid session cookie") {
+			t.Fatalf("body = %s, want invalid session cookie", rec.Body.String())
+		}
+	})
 }
 
 func assertCSRFRejected(t *testing.T, rec *httptest.ResponseRecorder) {

--- a/auth/handlers.go
+++ b/auth/handlers.go
@@ -133,11 +133,24 @@ func bearerToken(header string) (string, bool) {
 }
 
 func writeAuthError(ctx huma.Context, env *contract.ErrorEnvelope) {
+	writeAuthChallenge(ctx, env, `Bearer realm="api"`)
+}
+
+// writeCookieAuthError is the cookie-mode counterpart: RFC 7235 says a 401
+// challenge must name the scheme the resource uses. Cookie apps register
+// cookieAuth (apiKey in gombit_access), not HTTP Bearer.
+func writeCookieAuthError(ctx huma.Context, env *contract.ErrorEnvelope) {
+	writeAuthChallenge(ctx, env, "")
+}
+
+func writeAuthChallenge(ctx huma.Context, env *contract.ErrorEnvelope, challenge string) {
 	if env == nil {
 		return
 	}
 	ctx.SetHeader("Content-Type", "application/json")
-	ctx.SetHeader("WWW-Authenticate", `Bearer realm="api"`)
+	if challenge != "" {
+		ctx.SetHeader("WWW-Authenticate", challenge)
+	}
 	ctx.SetStatus(env.GetStatus())
 	_ = json.NewEncoder(ctx.BodyWriter()).Encode(env)
 }

--- a/auth/handlers_test.go
+++ b/auth/handlers_test.go
@@ -57,6 +57,9 @@ func TestHandlerTable(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
 		app.Router().ServeHTTP(rec, req)
 		assertError(t, rec, http.StatusUnauthorized, "authentication")
+		if got := rec.Result().Header.Get("WWW-Authenticate"); got != `Bearer realm="api"` {
+			t.Fatalf("WWW-Authenticate = %q, want Bearer realm=%q", got, "api")
+		}
 	})
 
 	t.Run("invalid bearer", func(t *testing.T) {

--- a/docs/auth-cookie.md
+++ b/docs/auth-cookie.md
@@ -96,7 +96,7 @@ differs: tokens travel in cookies, not JSON.
 | `POST` | `/auth/login` | Public, CSRF-protected | Body `{email, password}`. On success, sets `gombit_access` + `gombit_refresh` cookies; body is the public user, not tokens. |
 | `POST` | `/auth/refresh` | Cookie (`gombit_refresh`), CSRF-protected | No request body; reads the refresh cookie. Rotates both session cookies. |
 | `POST` | `/auth/logout` | Cookie (`gombit_refresh`), CSRF-protected | No request body; revokes the current refresh token and clears both session cookies. Idempotent. |
-| `GET` | `/me` | Cookie (`gombit_access`), safe | Same response shape as Bearer mode's `/me`. |
+| `GET` | `/me` | Cookie (`gombit_access`), safe | Same response shape as Bearer mode's `/me`. Missing or invalid session cookies are 401 D10 `authentication` and **omit** `WWW-Authenticate: Bearer` (RFC 7235: the challenge must name the scheme the resource uses). |
 
 ## Config
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -34,7 +34,7 @@ All paths use `config.API.Prefix` (default `/api/v1`). D10 envelopes.
 | `POST` | `/auth/login` | Public. Returns `access_token`, `refresh_token`, `token_type`, `expires_in`. |
 | `POST` | `/auth/refresh` | Public. Body `{ "refresh_token" }`. Issues a new pair; the old refresh token is invalid. |
 | `POST` | `/auth/logout` | Public. Body `{ "refresh_token" }`. Revokes that refresh token. Bound access JWTs then fail. |
-| `GET` | `/me` | Bearer access JWT. Example protected route for E2E. |
+| `GET` | `/me` | Bearer access JWT. Example protected route for E2E. Missing/invalid Bearer is 401 with `WWW-Authenticate: Bearer realm="api"`. |
 
 Passwords are hashed with bcrypt. Access JWTs are HS256, bound to the refresh
 row so logout (and reuse of a rotated refresh token) 401s `/me`. Reusing a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cookie-mode `requireCookieSession` shared `writeAuthError` with Bearer mode, so every 401 for a missing/invalid `gombit_access` cookie advertised `WWW-Authenticate: Bearer realm="api"`. RFC 7235 says a 401 challenge must name the scheme the resource uses; cookie OpenAPI registers `cookieAuth`, not HTTP Bearer.

Cookie 401s now omit `WWW-Authenticate`. Bearer mode still sends `Bearer realm="api"`.

Closes #117

## Acceptance criteria

- [x] Cookie-mode 401s omit `WWW-Authenticate: Bearer`
- [x] Bearer-mode 401s still send `WWW-Authenticate: Bearer realm="api"`
- [x] D10 body remains `authentication` (`missing session cookie` / `invalid session cookie`)
- [x] Tests + docs/CHANGELOG

## Scope notes

No OpenAPI/TS client change: this is a response header on an existing 401, not a new path or body shape.

## Validation

- [x] `go test ./auth/`
- [ ] `go test ./...` — CI matrix
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — CI
- [ ] Project `code-review` skill run against this diff (after CI is green)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (auth tests use SQLite; no schema change)
- [x] Stable features ship docs and appear in an example app (`docs/auth-cookie.md`, `docs/auth.md`, CHANGELOG)
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests (N/A — not an extraction)
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) (N/A)
- [x] API changes regenerate the OpenAPI doc + TS client in this PR (N/A — header-only; no OpenAPI path/schema change)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

