### PR TITLE
fix: do not truncate JSON strings like a<b in XSS sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ version.
 
 ### Fixed
 
+- XSS request sanitizer no longer truncates JSON/query strings that contain
+  `<` without a complete HTML tag (e.g. `a<b` stayed `a`). Complete tags
+  are still stripped ([#118](https://github.com/gombit-dev/gombit/issues/118)).
 - Cookie-mode session 401s omit `WWW-Authenticate: Bearer`. The D10 body
   stays `authentication`; Bearer mode still sends `Bearer realm="api"`
   ([#117](https://github.com/gombit-dev/gombit/issues/117)).

--- a/docs/router.md
+++ b/docs/router.md
@@ -88,6 +88,11 @@ Other behavior notes:
   Callers that hash the raw body must hash the bytes handlers actually see.
 - Unclosed dangerous elements (for example a truncated `<script>...`) discard
   the remainder of the string (fail-closed).
+- Incomplete angle brackets that are not a complete HTML tag (no closing
+  `>`, e.g. a product name `a<b`) are left unchanged. The HTML tokenizer
+  would otherwise treat `"<"+letter` as a start tag and silently shorten
+  the string. Complete tags (`<b>hi</b>`, `<script>…</script>`) are still
+  stripped.
 - JSON sanitizer buffering is capped at 8MiB. Larger JSON bodies abort with
   HTTP 413 and a D10 error envelope (`payload_too_large`) and never reach
   handlers. `http.Server.ReadTimeout` matches `GOMBIT_HTTP_REQUEST_TIMEOUT`

--- a/framework/xss.go
+++ b/framework/xss.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -35,6 +36,12 @@ var xssSkipElementContent = map[string]struct{}{
 	"embed":    {},
 	"textarea": {},
 }
+
+// completeHTMLTag matches a real tag with a closing ">". The HTML tokenizer
+// treats "<" + letter as a start tag even without ">", which silently
+// truncates comparison text like "a<b". Incomplete angle brackets are left
+// unchanged; complete tags still go through stripHTML.
+var completeHTMLTag = regexp.MustCompile(`(?i)<\s*/?[a-z][a-z0-9:-]*(?:\s[^>]*)?\s*/?>`)
 
 // xssMiddleware sanitizes HTML tags from request input before handlers run.
 // JSON string values (POST/PUT/PATCH) and GET query values are stripped to
@@ -179,13 +186,18 @@ func sanitizeJSONValue(value any, fieldName string) {
 }
 
 // stripHTML removes HTML tags and discards content inside dangerous elements.
-// Plain strings without "<" or ">" are returned unchanged.
+// Plain strings without "<" or ">" are returned unchanged. Strings that
+// contain "<" / ">" but no complete tag (no closing ">", e.g. "a<b") are
+// also returned unchanged so comparison text is not truncated.
 //
 // An unclosed skip element (for example `<script src=x>...`) discards the
 // remainder of the string — fail-closed for truncated markup. Self-closing
 // skip tags do not enter skip mode.
 func stripHTML(s string) string {
 	if !strings.ContainsAny(s, "<>") {
+		return s
+	}
+	if !completeHTMLTag.MatchString(s) {
 		return s
 	}
 

--- a/framework/xss_test.go
+++ b/framework/xss_test.go
@@ -29,6 +29,13 @@ func TestStripHTML(t *testing.T) {
 		{name: "img stripped", in: `x<img src=x onerror=alert(0)>y`, want: "xy"},
 		{name: "unclosed script fail-closed", in: `<script src=x>alert(1)`, want: ""},
 		{name: "nested markup", in: `<div><b>a</b><i>b</i></div>`, want: "ab"},
+		// Incomplete "<"+letter is not a tag (golang.org/x/net/html would
+		// otherwise eat the rest of the string: "a<b" → "a").
+		{name: "comparison a<b", in: "a<b", want: "a<b"},
+		{name: "comparison a<b>c without real tag name", in: "a < b", want: "a < b"},
+		{name: "less-than number", in: "score < 10", want: "score < 10"},
+		{name: "greater-than only", in: "a>b", want: "a>b"},
+		{name: "complete tag still stripped", in: "foo <bar> baz", want: "foo  baz"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -236,5 +243,29 @@ func TestSanitizeJSONBodyUpdatesContentLengthHeader(t *testing.T) {
 	}
 	if gotHeader := c.Request.Header.Get("Content-Length"); gotHeader != strconv.Itoa(len(got)) {
 		t.Fatalf("Content-Length header = %q, want %d", gotHeader, len(got))
+	}
+}
+
+func TestSanitizeJSONBodyPreservesComparisonText(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"name":"a<b","price":1}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	sanitizeJSONBody(c)
+
+	got, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(got, &payload); err != nil {
+		t.Fatalf("unmarshal sanitized body: %v (%s)", err, got)
+	}
+	if payload["name"] != "a<b" {
+		t.Fatalf("name = %#v, want a<b (not truncated)", payload["name"])
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`stripHTML` ran `golang.org/x/net/html` on any string containing `<` or `>`. The tokenizer treats `"<"+letter` as a start tag even without `>`, so `"a<b"` became `"a"` with no error.

The sanitizer now requires a complete HTML tag (closing `>`) before tokenizing. Comparison text is unchanged. Complete tags (`<b>hi</b>`, `<script>…</script>`, `foo <bar> baz`) are still stripped per M1-8.

Closes #118

## Acceptance criteria

- [x] JSON name `a<b` is stored as `a<b`, not truncated to `a`
- [x] `a < b` and `score < 10` unchanged
- [x] Actual HTML (`<script>`, `<b>hi</b>`, `img`) still sanitized
- [x] Tests + docs/CHANGELOG

## Scope notes

`foo <bar> baz` still becomes `foo  baz` because `<bar>` is a complete tag. M1-8 still strips markup before handlers. The silent truncation bug is incomplete tags (`a<b`). Rejecting complete tags with 422 instead of stripping is not this issue.

## Validation

- [x] `go test ./framework/`
- [ ] `go test ./...` — CI matrix
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — CI
- [ ] Project `code-review` skill run against this diff (after CI is green)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (no DB change)
- [x] Stable features ship docs and appear in an example app (`docs/router.md`, CHANGELOG)
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests (keeps first-party html tokenizer; does not pull Bluemonday)
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) (N/A)
- [x] API changes regenerate the OpenAPI doc + TS client in this PR (N/A)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

