### PR TITLE
fix: bootstrap CSRF on cookie SPA reload, not only login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ version.
 
 ### Fixed
 
+- Cookie-mode generated SPAs bootstrap CSRF in `AppProviders` (not only
+  on the login page) and await it before unsafe requests, so a reload on
+  a gated route does not POST without `X-CSRF-Token`. `clearSession` drops
+  the in-memory CSRF token
+  ([#119](https://github.com/gombit-dev/gombit/issues/119)).
 - XSS request sanitizer no longer truncates JSON/query strings that contain
   `<` without a complete HTML tag (e.g. `a<b` stayed `a`). Complete tags
   are still stripped ([#118](https://github.com/gombit-dev/gombit/issues/118)).

--- a/docs/auth-cookie.md
+++ b/docs/auth-cookie.md
@@ -130,10 +130,13 @@ that refresh (buffering is gated on method; Firefox does not implement
 the Request.body getter). `RequireAuth` confirms a session by calling
 `GET /me` (it cannot check an in-memory token, unlike Bearer mode).
 `LoginPage` warms the token with `bootstrapCSRF()` on mount and **awaits**
-it before `POST /auth/login` and `POST /auth/register`. Concurrent callers
+it before `POST /auth/login` and `POST /auth/register`. `AppProviders` also
+fires `bootstrapCSRF()` so a hard reload on a gated route still has an
+in-memory `X-CSRF-Token` before POST/PATCH/DELETE. Unsafe client requests
+and silent refresh await that in-flight pair. Concurrent callers
 share one in-flight promise (`csrfInFlight`); if a token is already in
 memory the call is a no-op so React StrictMode remounts do not mint a
-second pair. See the templates under
+second pair. `clearSession` drops the in-memory CSRF token. See the templates under
 [`scaffold/templates/frontend/src`](../scaffold/templates/frontend/src) for
 the exact `{{if eq .Auth "cookie"}}` branches.
 

--- a/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
@@ -37,9 +37,10 @@ export function createAppClient(): ApiClient {
   const client = createGombitClient({ baseUrl });
 
   client.use({
-    onRequest({ request }) {
+    async onRequest({ request }) {
       request = rewriteAPIRequest(request);
       if (isUnsafeMethod(request.method)) {
+        await bootstrapCSRF();
         const token = getCSRFToken();
         if (token) {
           request.headers.set("X-CSRF-Token", token);
@@ -58,6 +59,7 @@ export function createAppClient(): ApiClient {
     }
     refreshInFlight = (async () => {
       try {
+        await bootstrapCSRF();
         const response = await fetch(baseUrl + apiPath("/auth/refresh"), {
           method: "POST",
           credentials: "same-origin",
@@ -110,7 +112,8 @@ let csrfInFlight: Promise<void> | null = null;
  * desync the cookie from the in-memory X-CSRF-Token). If a token is already
  * in memory, this is a no-op so React StrictMode remounts do not mint a
  * second pair. After clearSession the token is gone and the next call
- * bootstraps again. Login must await this before POST.
+ * bootstraps again. Unsafe requests and silent refresh await this
+ * before POST so a reload cannot race GET /auth/csrf.
  */
 export function bootstrapCSRF(): Promise<void> {
   if (getCSRFToken()) {

--- a/goldentest/testdata/golden/new-cookie/frontend/src/app/providers.tsx
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/app/providers.tsx
@@ -1,8 +1,11 @@
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 
-import { ApiClientContext, createAppClient } from "../api/client";
+import { bootstrapCSRF, ApiClientContext, createAppClient } from "../api/client";
 
 export function AppProviders({ children }: { children: ReactNode }) {
   const client = useMemo(() => createAppClient(), []);
+  useEffect(() => {
+    void bootstrapCSRF();
+  }, []);
   return <ApiClientContext.Provider value={client}>{children}</ApiClientContext.Provider>;
 }

--- a/goldentest/testdata/golden/new-cookie/frontend/src/auth/session.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/auth/session.ts
@@ -27,4 +27,5 @@ export function setCSRFToken(token: string | undefined): void {
 
 export function clearSession(): void {
   authenticated = false;
+  csrfToken = undefined;
 }

--- a/goldentest/tree_test.go
+++ b/goldentest/tree_test.go
@@ -140,6 +140,9 @@ func assertCookieFrontendInvariants(t *testing.T, files fileMap) {
 	if strings.Contains(session, "getAccessToken") {
 		t.Error("cookie-mode session.ts must not expose getAccessToken")
 	}
+	if !strings.Contains(session, "csrfToken = undefined") {
+		t.Error("cookie-mode clearSession must drop the in-memory CSRF token")
+	}
 	login := string(files["frontend/src/pages/LoginPage.tsx"])
 	if login == "" {
 		t.Fatal("missing frontend/src/pages/LoginPage.tsx")
@@ -167,6 +170,13 @@ func assertCookieFrontendInvariants(t *testing.T, files fileMap) {
 	}
 	if !strings.Contains(client, "if (getCSRFToken())") {
 		t.Error("cookie-mode client.ts missing skip-if-token-exists no-op")
+	}
+	providers := string(files["frontend/src/app/providers.tsx"])
+	if !strings.Contains(providers, "void bootstrapCSRF()") {
+		t.Error("cookie-mode AppProviders must bootstrap CSRF on mount")
+	}
+	if !strings.Contains(client, "await bootstrapCSRF()") {
+		t.Error("cookie-mode client.ts must await bootstrapCSRF before unsafe requests")
 	}
 	assertNumberInputEmptyIsZero(t, string(files["frontend/src/pages/ProductFormPage.tsx"]))
 	assertRuntimeAPIPrefix(t, files, "cookie")

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -269,6 +269,10 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	if strings.Contains(appClient, "csrfInFlight") || strings.Contains(appClient, "bootstrapCSRF") {
 		t.Fatal("jwt api/client.ts must not include cookie CSRF bootstrap")
 	}
+	providers := readFile(t, filepath.Join(dest, "frontend", "src", "app", "providers.tsx"))
+	if strings.Contains(providers, "bootstrapCSRF") {
+		t.Fatal("jwt AppProviders must not import bootstrapCSRF")
+	}
 	assertSPAHonorsRuntimeAPIPrefix(t, dest, "jwt")
 	router := readFile(t, filepath.Join(dest, "frontend", "src", "app", "router.tsx"))
 	if !strings.Contains(router, "RequireAuth") || !strings.Contains(router, "LoginPage") {
@@ -760,6 +764,18 @@ func TestGenerateCookieCSRFBootstrapIsSerialized(t *testing.T) {
 	}
 	if !strings.Contains(login, "void bootstrapCSRF()") {
 		t.Fatal("cookie LoginPage.tsx missing eager CSRF bootstrap on mount")
+	}
+
+	providers := readFile(t, filepath.Join(workDir, "shop", "frontend", "src", "app", "providers.tsx"))
+	if !strings.Contains(providers, "void bootstrapCSRF()") {
+		t.Fatal("cookie AppProviders must bootstrap CSRF on mount so reload on a gated route still has X-CSRF-Token")
+	}
+	session := readFile(t, filepath.Join(workDir, "shop", "frontend", "src", "auth", "session.ts"))
+	if !strings.Contains(session, "csrfToken = undefined") {
+		t.Fatal("cookie clearSession must drop the in-memory CSRF token")
+	}
+	if !strings.Contains(client, "await bootstrapCSRF()") {
+		t.Fatal("cookie client.ts must await bootstrapCSRF before unsafe requests / refresh")
 	}
 }
 

--- a/scaffold/templates/frontend/src/api/client.ts.tmpl
+++ b/scaffold/templates/frontend/src/api/client.ts.tmpl
@@ -37,9 +37,10 @@ export function createAppClient(): ApiClient {
   const client = createGombitClient({ baseUrl });
 
   client.use({
-    onRequest({ request }) {
+    async onRequest({ request }) {
       request = rewriteAPIRequest(request);
       if (isUnsafeMethod(request.method)) {
+        await bootstrapCSRF();
         const token = getCSRFToken();
         if (token) {
           request.headers.set("X-CSRF-Token", token);
@@ -58,6 +59,7 @@ export function createAppClient(): ApiClient {
     }
     refreshInFlight = (async () => {
       try {
+        await bootstrapCSRF();
         const response = await fetch(baseUrl + apiPath("/auth/refresh"), {
           method: "POST",
           credentials: "same-origin",
@@ -110,7 +112,8 @@ let csrfInFlight: Promise<void> | null = null;
  * desync the cookie from the in-memory X-CSRF-Token). If a token is already
  * in memory, this is a no-op so React StrictMode remounts do not mint a
  * second pair. After clearSession the token is gone and the next call
- * bootstraps again. Login must await this before POST.
+ * bootstraps again. Unsafe requests and silent refresh await this
+ * before POST so a reload cannot race GET /auth/csrf.
  */
 export function bootstrapCSRF(): Promise<void> {
   if (getCSRFToken()) {

--- a/scaffold/templates/frontend/src/app/providers.tsx.tmpl
+++ b/scaffold/templates/frontend/src/app/providers.tsx.tmpl
@@ -1,11 +1,17 @@
-import { useMemo, type ReactNode } from "react";
-{{if eq .UI "mui"}}import { CssBaseline, ThemeProvider } from "@mui/material";
+{{if eq .Auth "cookie"}}import { useEffect, useMemo, type ReactNode } from "react";
+{{else}}import { useMemo, type ReactNode } from "react";
+{{end}}{{if eq .UI "mui"}}import { CssBaseline, ThemeProvider } from "@mui/material";
 {{end}}
-import { ApiClientContext, createAppClient } from "../api/client";
+import { {{if eq .Auth "cookie"}}bootstrapCSRF, {{end}}ApiClientContext, createAppClient } from "../api/client";
 {{if eq .UI "mui"}}import { theme } from "../theme";
 {{end}}
 export function AppProviders({ children }: { children: ReactNode }) {
   const client = useMemo(() => createAppClient(), []);
+{{- if eq .Auth "cookie"}}
+  useEffect(() => {
+    void bootstrapCSRF();
+  }, []);
+{{- end}}
 {{if eq .UI "mui"}}  return (
     <ThemeProvider theme={theme}>
       <CssBaseline />

--- a/scaffold/templates/frontend/src/auth/session.ts.tmpl
+++ b/scaffold/templates/frontend/src/auth/session.ts.tmpl
@@ -27,6 +27,7 @@ export function setCSRFToken(token: string | undefined): void {
 
 export function clearSession(): void {
   authenticated = false;
+  csrfToken = undefined;
 }
 {{else}}/**
  * In-memory access and refresh tokens. Never persist them in web storage.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cookie-mode `gombit new` apps called `bootstrapCSRF()` only from `LoginPage`. After a hard reload on `/` or `/products/new`, the in-memory CSRF token was gone (never stored). `GET /me` still succeeded; `POST /api/v1/products` and logout went out without `X-CSRF-Token` and 403d.

`AppProviders` now warms CSRF on mount (same as admin). Unsafe openapi-fetch requests and silent refresh `await bootstrapCSRF()`. `clearSession` drops the in-memory token.

Closes #119

## Acceptance criteria

- [x] CSRF bootstrap runs from `AppProviders`, not only the login page
- [x] Reload on a gated route still sends `X-CSRF-Token` on POST
- [x] Unsafe requests / refresh wait for the in-flight CSRF pair
- [x] `clearSession` clears `csrfToken`
- [x] JWT apps still do not import `bootstrapCSRF`
- [x] Tests, goldens, docs/CHANGELOG

## Scope notes

Admin already bootstrapped in providers (#115 covers admin 401-vs-CSRF race). This PR is the generated cookie SPA.

## Validation

- [x] `go test ./scaffold/`
- [x] `go test ./goldentest -run 'TestNewGolden$|TestNewGoldenCookieAuth|TestNewGoldenMUI'`
- [ ] `go test ./...` — CI matrix
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — CI
- [ ] Project `code-review` skill run against this diff (after CI is green)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (no DB change)
- [x] Stable features ship docs and appear in an example app (`docs/auth-cookie.md`, CHANGELOG, goldens)
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests (N/A)
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) (templates only; no AST overwrite)
- [x] API changes regenerate the OpenAPI doc + TS client in this PR (N/A)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

