### PR TITLE
fix: reject gombit new --auth none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ version.
 
 ### Fixed
 
+- `gombit new --auth none` is rejected. v0.1 auth is `jwt` or `cookie` (C3);
+  `none` was accepted and silently scaffolded a JWT app
+  ([#120](https://github.com/gombit-dev/gombit/issues/120)).
 - Cookie-mode generated SPAs bootstrap CSRF in `AppProviders` (not only
   on the login page) and await it before unsafe requests, so a reload on
   a gated route does not POST without `X-CSRF-Token`. `clearSession` drops

--- a/cli/new.go
+++ b/cli/new.go
@@ -80,7 +80,7 @@ at your framework checkout. Override with --framework-version.`,
 	})
 	cmd.Flags().StringVar(&database, "database", scaffold.DefaultDatabase, "database driver: sqlite, postgres, or mysql")
 	cmd.Flags().StringVar(&cache, "cache", scaffold.DefaultCache, "cache driver: memory, redis, or noop")
-	cmd.Flags().StringVar(&auth, "auth", scaffold.DefaultAuth, "auth mode: jwt (Bearer default), cookie (HttpOnly session + CSRF), or none")
+	cmd.Flags().StringVar(&auth, "auth", scaffold.DefaultAuth, "auth mode: jwt (Bearer default) or cookie (HttpOnly session + CSRF)")
 	cmd.Flags().StringVar(&ui, "ui", scaffold.DefaultUI, "UI preset: minimal (headless default) or mui (MUI CRUD screens)")
 	cmd.Flags().StringVar(&module, "module", "", "Go module path (default github.com/example/<name>)")
 	cmd.Flags().StringVar(&frameworkVersion, "framework-version", "",

--- a/cmd/gombit/new_test.go
+++ b/cmd/gombit/new_test.go
@@ -90,6 +90,7 @@ func TestRunNewFlagValidation(t *testing.T) {
 		{name: "unknown database", args: []string{"new", "demo", "--database", "oracle"}, want: "database"},
 		{name: "unknown cache", args: []string{"new", "demo", "--cache", "memcached"}, want: "cache"},
 		{name: "unknown auth", args: []string{"new", "demo", "--auth", "oauth"}, want: "auth"},
+		{name: "auth none", args: []string{"new", "demo", "--auth", "none"}, want: "auth"},
 		{name: "unknown ui", args: []string{"new", "demo", "--ui", "bootstrap"}, want: "ui"},
 		{name: "invalid name", args: []string{"new", "../evil", "--database", "sqlite"}, want: "project name"},
 	}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -109,7 +109,7 @@ go mod tidy
 | --- | --- | --- |
 | `--database` | `sqlite`, `postgres`, `mysql` | `sqlite` |
 | `--cache` | `memory`, `redis`, `noop` | `memory` |
-| `--auth` | `jwt`, `cookie`, `none` | `jwt` |
+| `--auth` | `jwt`, `cookie` | `jwt` |
 | `--ui` | `minimal`, `mui` | `minimal` |
 | `--module` | Go module path | `github.com/example/<name>` |
 | `--framework-version` | gombit version the generated `go.mod` requires | this binary's version |

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -385,6 +385,11 @@ func TestGenerateFlagValidation(t *testing.T) {
 			want: "auth",
 		},
 		{
+			name: "auth none not implemented",
+			opts: Options{Name: "demo", Auth: "none"},
+			want: "auth",
+		},
+		{
 			name: "unknown ui",
 			opts: Options{Name: "demo", UI: "bootstrap"},
 			want: "ui",

--- a/scaffold/options.go
+++ b/scaffold/options.go
@@ -30,7 +30,7 @@ const (
 var (
 	validDatabases = []string{"sqlite", "postgres", "mysql"}
 	validCaches    = []string{"memory", "redis", "noop"}
-	validAuths     = []string{"jwt", "cookie", "none"}
+	validAuths     = []string{"jwt", "cookie"}
 	validUIs       = []string{"minimal", "mui"}
 )
 

--- a/scaffold/prompt.go
+++ b/scaffold/prompt.go
@@ -42,7 +42,7 @@ func (opts *Options) resolveInteractive() error {
 	}
 	opts.Cache = cache
 
-	auth, err := promptLine(opts.Stdout, in, "Auth (jwt, cookie, none)", opts.Auth)
+	auth, err := promptLine(opts.Stdout, in, "Auth (jwt, cookie)", opts.Auth)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`gombit new --auth none` was accepted and wrote a JWT app (Bearer client, LoginPage, `GOMBIT_JWT_SECRET`). Templates only branch cookie vs else. v0.1 auth is `jwt` or `cookie` (C3). `--auth none` is now rejected the same as any unknown mode.

Closes #120

## Acceptance criteria

- [x] `--auth none` fails validation (does not scaffold JWT)
- [x] Valid modes remain `jwt` and `cookie`
- [x] Help, interactive prompt, and docs no longer advertise `none`
- [x] Tests for scaffold + `gombit new`

## Scope notes

Did not add a third unauthenticated scaffold (no JWT secret, public product routes). That would be a new product surface, not the C3 default. Reject matches the issue's first option.

## Validation

- [x] `go test ./scaffold/ ./cli/ ./cmd/gombit/`
- [ ] `go test ./...` — CI matrix
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — CI
- [ ] Project `code-review` skill run against this diff (after CI is green)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (no DB change)
- [x] Stable features ship docs and appear in an example app (`docs/cli.md`, CHANGELOG)
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests (N/A)
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) (validation only)
- [x] API changes regenerate the OpenAPI doc + TS client in this PR (N/A)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

