### PR TITLE
fix: proxy /admin from Vite during gombit dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ version.
 
 ### Fixed
 
+- `gombit dev` Vite proxy now forwards `/admin` to the Go origin, and
+  cookie-mode apps print an Admin row in the service table, so
+  `http://127.0.0.1:5173/admin/` reaches the framework admin SPA instead of
+  the generated application catch-all
+  ([#121](https://github.com/gombit-dev/gombit/issues/121)).
 - `gombit new --auth none` is rejected. v0.1 auth is `jwt` or `cookie` (C3);
   `none` was accepted and silently scaffolded a JWT app
   ([#120](https://github.com/gombit-dev/gombit/issues/120)).

--- a/cli/dev.go
+++ b/cli/dev.go
@@ -26,13 +26,14 @@ Backend reload uses air when it is on PATH, then watchexec, then falls back
 to go run ./cmd/server (with a hint). The frontend uses pnpm when available
 (or when frontend/pnpm-lock.yaml exists), otherwise npm.
 
-Vite proxies /api, /openapi.json, and /docs to the Go origin. Prefixes that
-do not start with /api (for example /svc/v2) get an extra proxy entry from
-the live GOMBIT_API_PREFIX. When the live OpenAPI document changes, gombit
-regenerates frontend/src/api/generated (the same output as gombit client
-generate).
+Vite proxies /api, /openapi.json, /docs, and /admin to the Go origin.
+Prefixes that do not start with /api (for example /svc/v2) get an extra
+proxy entry from the live GOMBIT_API_PREFIX. When the live OpenAPI document
+changes, gombit regenerates frontend/src/api/generated (the same output as
+gombit client generate).
 
 A service table is printed at startup, including the API docs URL (/docs).
+Cookie-mode apps also print the Admin SPA URL (/admin/).
 
 SIGINT/SIGTERM stops the child processes. air and watchexec are optional
 (go run fallback). Node.js is required for Vite HMR; a missing
@@ -46,6 +47,7 @@ default; gombit build --embed is the optional single-binary SPA path.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			apiPrefix := "/api/v1"
+			adminURL := ""
 			cfg, cfgErr := LoadConfig()
 			if !cmd.Flags().Changed("http") {
 				if cfgErr != nil {
@@ -55,6 +57,7 @@ default; gombit build --embed is the optional single-binary SPA path.`,
 			}
 			if cfgErr == nil {
 				apiPrefix = dev.APIPrefixFromConfig(cfg)
+				adminURL = dev.AdminURLFromConfig(cfg, httpAddr)
 			}
 			if err := dev.ValidateFlags(httpAddr, frontendHost, frontendPort, poll, clientOut); err != nil {
 				return fmt.Errorf("gombit %w", err)
@@ -63,6 +66,7 @@ default; gombit build --embed is the optional single-binary SPA path.`,
 				WorkDir:      ".",
 				HTTPAddr:     httpAddr,
 				APIPrefix:    apiPrefix,
+				AdminURL:     adminURL,
 				FrontendHost: frontendHost,
 				FrontendPort: frontendPort,
 				ClientOut:    clientOut,

--- a/cmd/gombit/dev_test.go
+++ b/cmd/gombit/dev_test.go
@@ -33,7 +33,7 @@ func TestRunDevHelp(t *testing.T) {
 		t.Fatalf("run(dev --help) error = %v", err)
 	}
 	got := stdout.String()
-	for _, want := range []string{"--http", "--frontend-port", "--frontend-host", "--poll", "--client-out", "/docs"} {
+	for _, want := range []string{"--http", "--frontend-port", "--frontend-host", "--poll", "--client-out", "/docs", "/admin"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("dev help missing %q:\n%s", want, got)
 		}
@@ -126,6 +126,34 @@ func TestRunDevHTTPFlagOverridesConfig(t *testing.T) {
 	}
 	if got.PollInterval != time.Second {
 		t.Fatalf("PollInterval = %s, want 1s", got.PollInterval)
+	}
+	if got.AdminURL != "" {
+		t.Fatalf("AdminURL = %q, want empty for JWT default", got.AdminURL)
+	}
+}
+
+func TestRunDevCookieConfigPrintsAdminURL(t *testing.T) {
+	cfg := config.Default()
+	cfg.Auth.Mode = config.AuthModeCookie
+	cfg.Auth.JWTSecret = "dev-secret-at-least-thirty-two-chars"
+	cfg.HTTP.Addr = "127.0.0.1:19090"
+	stubConfig(t, cfg)
+
+	var got dev.Options
+	previous := cli.RunDev
+	cli.RunDev = func(ctx context.Context, opts dev.Options) error {
+		got = opts
+		return errors.New("stopped")
+	}
+	t.Cleanup(func() { cli.RunDev = previous })
+
+	chdir(t, t.TempDir())
+	err := run(context.Background(), []string{"dev"}, ioDiscard{}, ioDiscard{})
+	if err == nil || !strings.Contains(err.Error(), "stopped") {
+		t.Fatalf("run() error = %v, want stopped", err)
+	}
+	if got.AdminURL != "http://127.0.0.1:19090/admin/" {
+		t.Fatalf("AdminURL = %q, want cookie admin SPA URL", got.AdminURL)
 	}
 }
 

--- a/dev/options.go
+++ b/dev/options.go
@@ -57,6 +57,9 @@ type Options struct {
 	HTTPGet      HTTPGetFunc
 	Generate     GenerateFunc
 	ShutdownWait time.Duration
+	// AdminURL is printed in the service table when non-empty (cookie-mode
+	// apps that mount the framework admin SPA). JWT apps leave this empty.
+	AdminURL string
 }
 
 func (opts *Options) normalize() error {
@@ -148,6 +151,15 @@ func APIPrefixFromConfig(cfg config.Config) string {
 		return "/api/v1"
 	}
 	return prefix
+}
+
+// AdminURLFromConfig returns the admin SPA URL for cookie-mode apps with
+// auth enabled. JWT apps and auth-disabled configs return "".
+func AdminURLFromConfig(cfg config.Config, httpAddr string) string {
+	if !cfg.Auth.Enabled() || cfg.Auth.EffectiveMode() != config.AuthModeCookie {
+		return ""
+	}
+	return originFromAddr(httpAddr) + "/admin/"
 }
 
 func parseListenAddr(addr string) (hostPort string, err error) {

--- a/dev/run.go
+++ b/dev/run.go
@@ -58,6 +58,7 @@ func Run(ctx context.Context, opts Options) error {
 	services := Services{
 		Backend:  originFromAddr(opts.HTTPAddr),
 		Frontend: frontendOrigin(opts.FrontendHost, opts.FrontendPort),
+		Admin:    opts.AdminURL,
 	}
 	if _, err := fmt.Fprint(opts.Stdout, FormatServiceTable(services)); err != nil {
 		return err

--- a/dev/run_test.go
+++ b/dev/run_test.go
@@ -107,6 +107,9 @@ func TestRunPrintsServiceTableAndShutsDown(t *testing.T) {
 	if !strings.Contains(got, "http://127.0.0.1:15173") {
 		t.Fatalf("stdout missing frontend URL:\n%s", got)
 	}
+	if strings.Contains(got, "Admin") {
+		t.Fatalf("stdout included Admin without AdminURL:\n%s", got)
+	}
 	if !strings.Contains(stderr.String(), "without reload") {
 		t.Fatalf("stderr = %q, want reload hint", stderr.String())
 	}

--- a/dev/table.go
+++ b/dev/table.go
@@ -9,15 +9,22 @@ import (
 type Services struct {
 	Backend  string
 	Frontend string
+	// Admin is the cookie-mode admin SPA URL. Empty omits the row (JWT apps
+	// do not mount /admin/).
+	Admin string
 }
 
 // FormatServiceTable renders the Backend / Frontend / OpenAPI / API docs table.
+// Cookie-mode apps also get an Admin row when Admin is set.
 func FormatServiceTable(services Services) string {
 	rows := [][2]string{
 		{"Backend", services.Backend},
 		{"Frontend", services.Frontend},
 		{"OpenAPI", services.Backend + "/openapi.json"},
 		{"API docs", services.Backend + "/docs"},
+	}
+	if services.Admin != "" {
+		rows = append(rows, [2]string{"Admin", services.Admin})
 	}
 	width := 0
 	for _, row := range rows {

--- a/dev/table_test.go
+++ b/dev/table_test.go
@@ -3,6 +3,8 @@ package dev
 import (
 	"strings"
 	"testing"
+
+	"github.com/gombit-dev/gombit/config"
 )
 
 func TestFormatServiceTableIncludesDocsAndOpenAPI(t *testing.T) {
@@ -32,6 +34,80 @@ func TestFormatServiceTableIncludesDocsAndOpenAPI(t *testing.T) {
 	}
 	if !strings.Contains(got, "http://127.0.0.1:8080/openapi.json") {
 		t.Fatalf("service table missing OpenAPI URL:\n%s", got)
+	}
+	if strings.Contains(got, "Admin") {
+		t.Fatalf("service table included Admin without Admin URL:\n%s", got)
+	}
+}
+
+func TestFormatServiceTableIncludesAdminWhenSet(t *testing.T) {
+	t.Parallel()
+
+	got := FormatServiceTable(Services{
+		Backend:  "http://127.0.0.1:8080",
+		Frontend: "http://127.0.0.1:5173",
+		Admin:    "http://127.0.0.1:8080/admin/",
+	})
+	if !strings.Contains(got, "Admin") {
+		t.Fatalf("service table missing Admin row:\n%s", got)
+	}
+	if !strings.Contains(got, "http://127.0.0.1:8080/admin/") {
+		t.Fatalf("service table missing Admin URL:\n%s", got)
+	}
+}
+
+func TestAdminURLFromConfig(t *testing.T) {
+	t.Parallel()
+
+	cookie := config.Default()
+	cookie.Auth.Mode = config.AuthModeCookie
+	cookie.Auth.JWTSecret = "dev-secret-at-least-thirty-two-chars"
+
+	jwt := config.Default()
+	jwt.Auth.Mode = config.AuthModeJWT
+	jwt.Auth.JWTSecret = cookie.Auth.JWTSecret
+
+	disabled := config.Default()
+	disabled.Auth.Mode = config.AuthModeCookie
+
+	tests := []struct {
+		name string
+		cfg  config.Config
+		addr string
+		want string
+	}{
+		{
+			name: "cookie with secret",
+			cfg:  cookie,
+			addr: ":8080",
+			want: "http://127.0.0.1:8080/admin/",
+		},
+		{
+			name: "cookie honors --http",
+			cfg:  cookie,
+			addr: "127.0.0.1:9090",
+			want: "http://127.0.0.1:9090/admin/",
+		},
+		{
+			name: "jwt omits admin",
+			cfg:  jwt,
+			addr: ":8080",
+			want: "",
+		},
+		{
+			name: "cookie without secret omits admin",
+			cfg:  disabled,
+			addr: ":8080",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := AdminURLFromConfig(tt.cfg, tt.addr); got != tt.want {
+				t.Fatalf("AdminURLFromConfig() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -102,8 +102,9 @@ prefixes `/auth/*` and `/admin/*` with that value (default `/api/v1`).
 The SPA may use MUI internally. That is **not** a C4 violation: `--ui mui`
 remains the generated **application** preset. `gombit new` trees do not
 gain `@mui` from this package. `gombit make resource` does not grow
-`--admin`. Optional `gombit dev` Admin URL in the service table is out of
-scope (ADR-013).
+`--admin`. Cookie-mode `gombit dev` prints the Admin SPA URL and Vite
+proxies `/admin` to the Go origin so `http://127.0.0.1:5173/admin/` reaches
+the framework admin instead of the generated application SPA.
 
 Rebuild: see [`internal/adminui/README.md`](../internal/adminui/README.md).
 Commit `dist/` with source changes so consumers `go get` a working embed.
@@ -244,6 +245,5 @@ superuser with `auth.Service.CreateSuperuser` (the same path as
 - Full users/groups management screens in the admin SPA
 - `--admin` generator / golden template changes / copying the SPA into
   generated `frontend/`
-- `gombit dev` Admin URL in the service table
 - M6 batteries (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
 - `localStorage` tokens

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -186,8 +186,8 @@ One command starts:
 1. The Go API with reload when `air` or `watchexec` is on `PATH`. If neither
    is installed, Gombit runs `go run ./cmd/server` and prints a hint.
 2. The Vite frontend with HMR (`pnpm` when available, otherwise `npm`). Vite
-   proxies `/api`, `/openapi.json`, and `/docs` to the Go origin. Prefixes
-   that do not start with `/api` get an extra proxy entry from the live
+   proxies `/api`, `/openapi.json`, `/docs`, and `/admin` to the Go origin.
+   Prefixes that do not start with `/api` get an extra proxy entry from the live
    `GOMBIT_API_PREFIX`.
 3. An OpenAPI watcher that regenerates `frontend/src/api/generated` when the
    live `/openapi.json` document changes (`gombit client generate`).
@@ -199,6 +199,13 @@ Backend      http://127.0.0.1:8080
 Frontend     http://127.0.0.1:5173
 OpenAPI      http://127.0.0.1:8080/openapi.json
 API docs     http://127.0.0.1:8080/docs
+```
+
+Cookie-mode apps also print the admin SPA (the same origin the Vite `/admin`
+proxy forwards to):
+
+```text
+Admin        http://127.0.0.1:8080/admin/
 ```
 
 ### Flags

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -100,7 +100,9 @@ works. For a split deploy, set the API **origin only** (for example
 `rewriteAPIRequest` maps them to the prefix injected (or substituted) in
 `index.html`. Prefixes that still start with `/api` (such as `/api/v2`)
 hit the existing `/api` proxy during `gombit dev`; a prefix that does not
-(`/svc/v2`) gets an extra Vite proxy entry.
+(`/svc/v2`) gets an extra Vite proxy entry. Vite also proxies `/docs` and
+`/admin` so interactive docs and the cookie-mode admin SPA are reachable on
+the frontend origin.
 
 `VITE_*` values are baked into the browser bundle. Never put JWT secrets,
 database passwords, or other server credentials there. Do not put

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -99,7 +99,7 @@ gombit dev
 ```
 
 `gombit dev` runs the Go API and the Vite dev server together, proxies `/api`,
-`/openapi.json`, and `/docs` to the backend, and regenerates the TypeScript
+`/openapi.json`, `/docs`, and `/admin` to the backend, and regenerates the TypeScript
 client whenever the live spec changes. It prints a service table with the URLs.
 
 Open:
@@ -497,7 +497,8 @@ Registration is explicit and typed — `Options` is concrete data, resolved once
 at startup. Leave `Fields` empty and they're derived from the struct at
 registration time, still once, never per request.
 
-Now visit **<http://127.0.0.1:8080/admin/>** and log in as your superuser. The
+Now visit **<http://127.0.0.1:5173/admin/>** (Vite proxies `/admin` to the Go
+server) or **<http://127.0.0.1:8080/admin/>** and log in as your superuser. The
 SPA is framework-owned and served from the binary; you don't build or maintain
 it.
 

--- a/goldentest/testdata/golden/make-command/frontend/README.md
+++ b/goldentest/testdata/golden/make-command/frontend/README.md
@@ -14,7 +14,8 @@ gombit dev
 ```
 
 That starts the Go API, Vite HMR, and live `gombit client generate` into
-`src/api/generated`. Vite proxies `/api`, `/openapi.json`, and `/docs`.
+`src/api/generated`. Vite proxies `/api`, `/openapi.json`, `/docs`, and
+`/admin`.
 
 Optional single-binary production (split remains the default):
 

--- a/goldentest/testdata/golden/make-command/frontend/vite.config.ts
+++ b/goldentest/testdata/golden/make-command/frontend/vite.config.ts
@@ -46,6 +46,7 @@ const proxy: Record<string, { target: string; changeOrigin: boolean }> = {
   "/api": { target: backend, changeOrigin: true },
   "/openapi.json": { target: backend, changeOrigin: true },
   "/docs": { target: backend, changeOrigin: true },
+  "/admin": { target: backend, changeOrigin: true },
 };
 if (apiPrefix !== "/" && apiPrefix !== "/api" && !apiPrefix.startsWith("/api/")) {
   proxy[apiPrefix] = { target: backend, changeOrigin: true };

--- a/goldentest/testdata/golden/make-resource/frontend/README.md
+++ b/goldentest/testdata/golden/make-resource/frontend/README.md
@@ -14,7 +14,8 @@ gombit dev
 ```
 
 That starts the Go API, Vite HMR, and live `gombit client generate` into
-`src/api/generated`. Vite proxies `/api`, `/openapi.json`, and `/docs`.
+`src/api/generated`. Vite proxies `/api`, `/openapi.json`, `/docs`, and
+`/admin`.
 
 Optional single-binary production (split remains the default):
 

--- a/goldentest/testdata/golden/make-resource/frontend/vite.config.ts
+++ b/goldentest/testdata/golden/make-resource/frontend/vite.config.ts
@@ -46,6 +46,7 @@ const proxy: Record<string, { target: string; changeOrigin: boolean }> = {
   "/api": { target: backend, changeOrigin: true },
   "/openapi.json": { target: backend, changeOrigin: true },
   "/docs": { target: backend, changeOrigin: true },
+  "/admin": { target: backend, changeOrigin: true },
 };
 if (apiPrefix !== "/" && apiPrefix !== "/api" && !apiPrefix.startsWith("/api/")) {
   proxy[apiPrefix] = { target: backend, changeOrigin: true };

--- a/goldentest/testdata/golden/new-cookie/README.md
+++ b/goldentest/testdata/golden/new-cookie/README.md
@@ -33,7 +33,7 @@ TypeScript client regeneration:
 gombit dev
 ```
 
-`gombit dev` prints a service table (Backend, Frontend, OpenAPI, API docs).
+`gombit dev` prints a service table (Backend, Frontend, OpenAPI, API docs, Admin).
 Backend reload uses `air` or `watchexec` when installed; otherwise it falls
 back to `go run ./cmd/server`. The frontend uses `pnpm` when available,
 otherwise `npm`. Node.js is required for Vite HMR. The frontend is a Vite +

--- a/goldentest/testdata/golden/new-cookie/frontend/README.md
+++ b/goldentest/testdata/golden/new-cookie/frontend/README.md
@@ -14,7 +14,8 @@ gombit dev
 ```
 
 That starts the Go API, Vite HMR, and live `gombit client generate` into
-`src/api/generated`. Vite proxies `/api`, `/openapi.json`, and `/docs`.
+`src/api/generated`. Vite proxies `/api`, `/openapi.json`, `/docs`, and
+`/admin`.
 
 Optional single-binary production (split remains the default):
 

--- a/goldentest/testdata/golden/new-cookie/frontend/vite.config.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/vite.config.ts
@@ -46,6 +46,7 @@ const proxy: Record<string, { target: string; changeOrigin: boolean }> = {
   "/api": { target: backend, changeOrigin: true },
   "/openapi.json": { target: backend, changeOrigin: true },
   "/docs": { target: backend, changeOrigin: true },
+  "/admin": { target: backend, changeOrigin: true },
 };
 if (apiPrefix !== "/" && apiPrefix !== "/api" && !apiPrefix.startsWith("/api/")) {
   proxy[apiPrefix] = { target: backend, changeOrigin: true };

--- a/goldentest/testdata/golden/new-mui/frontend/README.md
+++ b/goldentest/testdata/golden/new-mui/frontend/README.md
@@ -14,7 +14,8 @@ gombit dev
 ```
 
 That starts the Go API, Vite HMR, and live `gombit client generate` into
-`src/api/generated`. Vite proxies `/api`, `/openapi.json`, and `/docs`.
+`src/api/generated`. Vite proxies `/api`, `/openapi.json`, `/docs`, and
+`/admin`.
 
 Optional single-binary production (split remains the default):
 

--- a/goldentest/testdata/golden/new-mui/frontend/vite.config.ts
+++ b/goldentest/testdata/golden/new-mui/frontend/vite.config.ts
@@ -46,6 +46,7 @@ const proxy: Record<string, { target: string; changeOrigin: boolean }> = {
   "/api": { target: backend, changeOrigin: true },
   "/openapi.json": { target: backend, changeOrigin: true },
   "/docs": { target: backend, changeOrigin: true },
+  "/admin": { target: backend, changeOrigin: true },
 };
 if (apiPrefix !== "/" && apiPrefix !== "/api" && !apiPrefix.startsWith("/api/")) {
   proxy[apiPrefix] = { target: backend, changeOrigin: true };

--- a/goldentest/testdata/golden/new/frontend/README.md
+++ b/goldentest/testdata/golden/new/frontend/README.md
@@ -14,7 +14,8 @@ gombit dev
 ```
 
 That starts the Go API, Vite HMR, and live `gombit client generate` into
-`src/api/generated`. Vite proxies `/api`, `/openapi.json`, and `/docs`.
+`src/api/generated`. Vite proxies `/api`, `/openapi.json`, `/docs`, and
+`/admin`.
 
 Optional single-binary production (split remains the default):
 

--- a/goldentest/testdata/golden/new/frontend/vite.config.ts
+++ b/goldentest/testdata/golden/new/frontend/vite.config.ts
@@ -46,6 +46,7 @@ const proxy: Record<string, { target: string; changeOrigin: boolean }> = {
   "/api": { target: backend, changeOrigin: true },
   "/openapi.json": { target: backend, changeOrigin: true },
   "/docs": { target: backend, changeOrigin: true },
+  "/admin": { target: backend, changeOrigin: true },
 };
 if (apiPrefix !== "/" && apiPrefix !== "/api" && !apiPrefix.startsWith("/api/")) {
   proxy[apiPrefix] = { target: backend, changeOrigin: true };

--- a/goldentest/tree_test.go
+++ b/goldentest/tree_test.go
@@ -292,9 +292,15 @@ func assertRuntimeAPIPrefix(t *testing.T, files fileMap, auth string) {
 	if !strings.Contains(vite, "GOMBIT_API_PREFIX") || !strings.Contains(vite, "injectAPIPrefix") {
 		t.Error("vite.config.ts must inject GOMBIT_API_PREFIX during vite dev")
 	}
+	if !strings.Contains(vite, `"/admin"`) {
+		t.Error("vite.config.ts must proxy /admin to the Go origin")
+	}
 	readme := string(files["frontend/README.md"])
 	if !strings.Contains(readme, "A CDN must replace `__GOMBIT_API_PREFIX__`") {
 		t.Error("frontend/README.md must document split-deploy placeholder substitution")
+	}
+	if !strings.Contains(readme, "`/admin`") {
+		t.Error("frontend/README.md must mention the Vite /admin proxy")
 	}
 	envExample := string(files[".env.example"])
 	if !strings.Contains(envExample, "A CDN must replace __GOMBIT_API_PREFIX__") {

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -186,10 +186,17 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	}
 
 	viteConfig := readFile(t, filepath.Join(dest, "frontend", "vite.config.ts"))
-	for _, want := range []string{"/api", "/openapi.json", "/docs", "GOMBIT_DEV_FRONTEND_HOST", "GOMBIT_API_PREFIX", "__GOMBIT_API_PREFIX__", "injectAPIPrefix"} {
+	for _, want := range []string{"/api", "/openapi.json", "/docs", "/admin", "GOMBIT_DEV_FRONTEND_HOST", "GOMBIT_API_PREFIX", "__GOMBIT_API_PREFIX__", "injectAPIPrefix"} {
 		if !strings.Contains(viteConfig, want) {
 			t.Fatalf("vite.config.ts missing %q:\n%s", want, viteConfig)
 		}
+	}
+	appReadme := readFile(t, filepath.Join(dest, "README.md"))
+	if !strings.Contains(appReadme, "Backend, Frontend, OpenAPI, API docs") {
+		t.Fatal("README.md missing gombit dev service table description")
+	}
+	if strings.Contains(appReadme, "API docs, Admin") {
+		t.Fatal("jwt README.md must not list Admin in the gombit dev service table")
 	}
 	indexHTML := readFile(t, filepath.Join(dest, "frontend", "index.html"))
 	if !strings.Contains(indexHTML, `content="__GOMBIT_API_PREFIX__"`) {
@@ -447,6 +454,10 @@ func TestGenerateRecordsAuthAndUIChoices(t *testing.T) {
 			t.Fatalf("gombit.yaml missing %q:\n%s", want, yaml)
 		}
 	}
+	appReadme := readFile(t, filepath.Join(workDir, "shop", "README.md"))
+	if !strings.Contains(appReadme, "API docs, Admin") {
+		t.Fatal("cookie README.md missing Admin in the gombit dev service table")
+	}
 	envExample := readFile(t, filepath.Join(workDir, "shop", ".env.example"))
 	if !strings.Contains(envExample, "GOMBIT_DATABASE_DRIVER=postgres") {
 		t.Fatalf(".env.example missing postgres driver:\n%s", envExample)
@@ -684,7 +695,7 @@ func assertSPAHonorsRuntimeAPIPrefix(t *testing.T, dest, auth string) {
 	}
 
 	viteConfig := readFile(t, filepath.Join(dest, "frontend", "vite.config.ts"))
-	for _, want := range []string{"GOMBIT_API_PREFIX", "transformIndexHtml", "injectAPIPrefix"} {
+	for _, want := range []string{"GOMBIT_API_PREFIX", "transformIndexHtml", "injectAPIPrefix", `"/admin"`} {
 		if !strings.Contains(viteConfig, want) {
 			t.Errorf("vite.config.ts missing %q", want)
 		}
@@ -729,6 +740,9 @@ func assertSPAHonorsRuntimeAPIPrefix(t *testing.T, dest, auth string) {
 	readme := readFile(t, filepath.Join(dest, "frontend", "README.md"))
 	if !strings.Contains(readme, "A CDN must replace `__GOMBIT_API_PREFIX__`") {
 		t.Error("frontend/README.md must document split-deploy placeholder substitution")
+	}
+	if !strings.Contains(readme, "`/admin`") {
+		t.Error("frontend/README.md must mention the Vite /admin proxy")
 	}
 	envExample := readFile(t, filepath.Join(dest, ".env.example"))
 	if !strings.Contains(envExample, "A CDN must replace __GOMBIT_API_PREFIX__") {

--- a/scaffold/templates/README.md.tmpl
+++ b/scaffold/templates/README.md.tmpl
@@ -33,7 +33,7 @@ TypeScript client regeneration:
 gombit dev
 ```
 
-`gombit dev` prints a service table (Backend, Frontend, OpenAPI, API docs).
+`gombit dev` prints a service table (Backend, Frontend, OpenAPI, API docs{{if eq .Auth "cookie"}}, Admin{{end}}).
 Backend reload uses `air` or `watchexec` when installed; otherwise it falls
 back to `go run ./cmd/server`. The frontend uses `pnpm` when available,
 otherwise `npm`. Node.js is required for Vite HMR. The frontend is a Vite +

--- a/scaffold/templates/frontend/README.md.tmpl
+++ b/scaffold/templates/frontend/README.md.tmpl
@@ -22,7 +22,8 @@ gombit dev
 ```
 
 That starts the Go API, Vite HMR, and live `gombit client generate` into
-`src/api/generated`. Vite proxies `/api`, `/openapi.json`, and `/docs`.
+`src/api/generated`. Vite proxies `/api`, `/openapi.json`, `/docs`, and
+`/admin`.
 
 Optional single-binary production (split remains the default):
 

--- a/scaffold/templates/frontend/vite.config.ts.tmpl
+++ b/scaffold/templates/frontend/vite.config.ts.tmpl
@@ -46,6 +46,7 @@ const proxy: Record<string, { target: string; changeOrigin: boolean }> = {
   "/api": { target: backend, changeOrigin: true },
   "/openapi.json": { target: backend, changeOrigin: true },
   "/docs": { target: backend, changeOrigin: true },
+  "/admin": { target: backend, changeOrigin: true },
 };
 if (apiPrefix !== "/" && apiPrefix !== "/api" && !apiPrefix.startsWith("/api/")) {
   proxy[apiPrefix] = { target: backend, changeOrigin: true };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cookie-mode admin is served by the Go process at `/admin/`. `gombit dev` printed the Vite origin as Frontend and only proxied `/api`, `/openapi.json`, and `/docs`, so `http://127.0.0.1:5173/admin` hit the generated SPA catch-all (`path="*"` → product list).

This change:

- Proxies `/admin` to the Go origin in the generated Vite config (same pattern as `/docs`).
- Prints an **Admin** row in the `gombit dev` service table for cookie-mode apps with auth enabled (`http://127.0.0.1:8080/admin/`). JWT apps omit the row.

Closes #121

## Acceptance criteria

Issue #121 has no formal checklist. This PR satisfies the stated expected behavior:

- [x] Vite proxies `/admin` to the backend (like `/docs`)
- [x] Cookie-mode `gombit dev` prints the admin URL in the service table
- [x] JWT / auth-disabled configs do not print an Admin row
- [x] Docs (`cli.md`, `admin.md`, `frontend.md`, `tutorial.md`) and generated READMEs describe the proxy

## Scope notes

- Existing generated apps keep their old `vite.config.ts` until they re-run `gombit new --force` or copy the proxy entry. New apps and goldens are updated.
- ADR-013 left a service-table Admin URL out of ADMIN-2; this bug issue requested it, so `docs/admin.md` no longer lists it as out of scope. The ADR text is left as historical ADMIN-2 scope.
- JWT apps also get the `/admin` proxy; the backend 404s because admin is cookie-only. That is preferable to the generated SPA pretending `/admin` is a product route.

## Validation

- [x] `go test ./dev ./cli ./cmd/gombit ./scaffold ./goldentest`
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (CI)
- [ ] Project `code-review` skill run against this diff (after CI)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (N/A — no DB changes)
- [x] Stable features ship docs and appear in an example app (docs + goldens; admin example already mounts `/admin/`)
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests (N/A — not an extraction)
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) (`vite.config.ts` is generated; `--force` still required to overwrite user-owned copies)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR (N/A — no API contract change)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

