### PR TITLE
fix: refuse make resource names that share an HTTP path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ version.
 
 ### Fixed
 
+- `gombit make resource` refuses a second name whose plural HTTP path
+  collides with an existing feature-package (`Bus` and `Buse` both become
+  `/buses`) instead of registering two resources on one URL
+  ([#122](https://github.com/gombit-dev/gombit/issues/122)).
 - `gombit dev` Vite proxy now forwards `/admin` to the Go origin, and
   cookie-mode apps print an Admin row in the service table, so
   `http://127.0.0.1:5173/admin/` reaches the framework admin SPA instead of

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -311,7 +311,9 @@ and `--repo` are C6 opt-in and are not used by the generated handler.
 Route registration is appended in `cmd/server/main.go` via `go/ast` +
 `go/parser` + `go/format` (never regex), next to `product.Register(app)`.
 `internal/platform` AutoMigrate is updated the same way. Re-running does not
-duplicate the `Register` call.
+duplicate the `Register` call. A second resource whose plural HTTP path
+collides with an existing feature-package (`Bus` and `Buse` both become
+`/buses`) is refused.
 
 Frontend pages are React + TypeScript (list/table + React Hook Form create)
 under `frontend/src/<feature>/`. They import types from

--- a/resourcegen/fields_test.go
+++ b/resourcegen/fields_test.go
@@ -121,6 +121,33 @@ func TestParseResourceName(t *testing.T) {
 		t.Fatalf("widget = %+v", widget)
 	}
 
+	bus, err := parseResourceName("Bus")
+	if err != nil {
+		t.Fatalf("Bus: %v", err)
+	}
+	buse, err := parseResourceName("Buse")
+	if err != nil {
+		t.Fatalf("Buse: %v", err)
+	}
+	if bus.HTTPPath != "/buses" || buse.HTTPPath != "/buses" {
+		t.Fatalf("Bus HTTPPath = %q, Buse HTTPPath = %q, want both /buses", bus.HTTPPath, buse.HTTPPath)
+	}
+	if bus.Package == buse.Package {
+		t.Fatalf("Bus and Buse must stay distinct packages, got %q", bus.Package)
+	}
+
+	box, err := parseResourceName("Box")
+	if err != nil {
+		t.Fatalf("Box: %v", err)
+	}
+	boxe, err := parseResourceName("Boxe")
+	if err != nil {
+		t.Fatalf("Boxe: %v", err)
+	}
+	if box.HTTPPath != "/boxes" || boxe.HTTPPath != "/boxes" {
+		t.Fatalf("Box HTTPPath = %q, Boxe HTTPPath = %q, want both /boxes", box.HTTPPath, boxe.HTTPPath)
+	}
+
 	_, err = parseResourceName("platform")
 	if err == nil || !strings.Contains(err.Error(), "reserved") {
 		t.Fatalf("platform error = %v, want reserved", err)

--- a/resourcegen/generate.go
+++ b/resourcegen/generate.go
@@ -34,6 +34,9 @@ func Generate(ctx context.Context, opts Options) error {
 	if err != nil {
 		return err
 	}
+	if err := checkHTTPPathConflict(opts.WorkDir, name); err != nil {
+		return err
+	}
 	fields, err := parseFields(opts.Fields)
 	if err != nil {
 		return err
@@ -233,6 +236,53 @@ func readUI(workDir string) string {
 		return defaultUI
 	}
 	return defaultUI
+}
+
+func checkHTTPPathConflict(workDir string, name ResourceName) error {
+	dirs := []struct {
+		root   string
+		accept func(root, pkg string) bool
+	}{
+		{
+			root: filepath.Join(workDir, "internal"),
+			accept: func(root, pkg string) bool {
+				_, err := os.Stat(filepath.Join(root, pkg, "routes.go"))
+				return err == nil
+			},
+		},
+		{
+			root:   filepath.Join(workDir, "frontend", "src"),
+			accept: hasGeneratedListPage,
+		},
+	}
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir.root)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("resourcegen: read %s: %w", dir.root, err)
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			if !dir.accept(dir.root, entry.Name()) {
+				continue
+			}
+			other, err := parseResourceName(entry.Name())
+			if err != nil {
+				continue
+			}
+			if other.Package == name.Package {
+				continue
+			}
+			if other.HTTPPath == name.HTTPPath {
+				return fmt.Errorf("resourcegen: resource name %q maps to HTTP path %q already used by %q", name.Input, name.HTTPPath, other.Package)
+			}
+		}
+	}
+	return nil
 }
 
 func collectFrontendResources(workDir string, current ResourceName) []ResourceName {

--- a/resourcegen/generate_test.go
+++ b/resourcegen/generate_test.go
@@ -539,6 +539,73 @@ func TestGenerateFrontendKeepsTypedDefaultPrefix(t *testing.T) {
 	}
 }
 
+func TestGenerateRefusesCollidingHTTPPath(t *testing.T) {
+	workDir := t.TempDir()
+	if err := scaffold.Generate(context.Background(), scaffold.Options{
+		Name:     "demo",
+		Database: "sqlite",
+		WorkDir:  workDir,
+		Stdout:   ioDiscard{},
+	}); err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	appDir := filepath.Join(workDir, "demo")
+
+	previousLook := lookPath
+	lookPath = func(string) (string, error) { return "", errors.New("atlas missing") }
+	t.Cleanup(func() { lookPath = previousLook })
+
+	err := Generate(context.Background(), Options{
+		WorkDir:   appDir,
+		Name:      "Bus",
+		Fields:    []string{"name:string"},
+		Stdout:    ioDiscard{},
+		skipAtlas: true,
+	})
+	if err != nil {
+		t.Fatalf("Generate(Bus) error = %v", err)
+	}
+
+	err = Generate(context.Background(), Options{
+		WorkDir:   appDir,
+		Name:      "Buse",
+		Fields:    []string{"name:string"},
+		Stdout:    ioDiscard{},
+		skipAtlas: true,
+	})
+	if err == nil {
+		t.Fatal("Generate(Buse) error = nil, want HTTP path collision")
+	}
+	if !strings.Contains(err.Error(), "/buses") || !strings.Contains(err.Error(), "bus") {
+		t.Fatalf("Generate(Buse) error = %q, want /buses already used by bus", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(appDir, "internal", "buse")); !os.IsNotExist(statErr) {
+		t.Fatal("Generate(Buse) wrote internal/buse after colliding with /buses")
+	}
+
+	err = Generate(context.Background(), Options{
+		WorkDir:   appDir,
+		Name:      "Bus",
+		Fields:    []string{"name:string"},
+		Stdout:    ioDiscard{},
+		skipAtlas: true,
+	})
+	if err != nil {
+		t.Fatalf("idempotent Generate(Bus) error = %v", err)
+	}
+
+	err = Generate(context.Background(), Options{
+		WorkDir:   appDir,
+		Name:      "Widget",
+		Fields:    []string{"name:string"},
+		Stdout:    ioDiscard{},
+		skipAtlas: true,
+	})
+	if err != nil {
+		t.Fatalf("Generate(Widget) error = %v, want distinct HTTP path to succeed", err)
+	}
+}
+
 func TestGenerateNumberFieldEmptyIsZero(t *testing.T) {
 	workDir := t.TempDir()
 	if err := scaffold.Generate(context.Background(), scaffold.Options{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`pluralizeSnake` turns `Bus` and `Buse` into the same HTTP path `/buses` (and `Box`/`Boxe` into `/boxes`). The second `gombit make resource` still wrote a second feature-package, so both `huma.Register` calls and both `resources.tsx` routes landed on one URL.

This PR refuses the second name when an existing feature-package (`internal/*/routes.go` or a generated frontend list page) already owns that path. Idempotent re-runs of the same package still succeed. Distinct paths (`Bus` then `Widget`) still succeed.

Closes #122

## Acceptance criteria

Issue #122 has no formal checklist. This PR satisfies the stated expected behavior:

- [x] Refuse a second resource whose plural HTTP path collides with an existing feature-package (`Bus` / `Buse` → `/buses`)
- [x] Do not write the colliding package
- [x] Same-name re-runs remain idempotent
- [x] Distinct paths still generate

## Scope notes

- Does not invent a smarter inflector or pick an alternate path (`/buses-2`). The issue allowed refuse-or-distinct; refuse is the smaller contract.
- Does not reserve the scaffold `product` package ([#125](https://github.com/gombit-dev/gombit/issues/125)).
- Does not reserve `version` / `createsuperuser` ([#124](https://github.com/gombit-dev/gombit/issues/124)).

## Validation

- [x] `go test ./resourcegen -count=1 -run 'TestGenerateRefusesCollidingHTTPPath|TestParseResourceName'`
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (CI)
- [ ] Project `code-review` skill run against this diff (after CI)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (N/A — generator-only)
- [x] Stable features ship docs and appear in an example app (`docs/cli.md`; goldens unchanged because no new default resource)
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests (N/A)
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR (N/A — no API contract change)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

