### PR TITLE
fix: strip go.mod // comments from generator module paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ version.
 
 ### Fixed
 
+- `gombit make resource` and `gombit make command` strip trailing `//`
+  comments from the `go.mod` module line, so
+  `module example.com/demo // app` does not produce invalid imports
+  ([#123](https://github.com/gombit-dev/gombit/issues/123)).
 - `gombit make resource` refuses a second name whose plural HTTP path
   collides with an existing feature-package (`Bus` and `Buse` both become
   `/buses`) instead of registering two resources on one URL

--- a/commandgen/generate.go
+++ b/commandgen/generate.go
@@ -167,7 +167,7 @@ func readModulePath(workDir string) (string, error) {
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "module ") {
-			module := strings.TrimSpace(strings.TrimPrefix(line, "module "))
+			module := modulePathFromGoModLine(line)
 			if module == "" {
 				break
 			}
@@ -175,6 +175,24 @@ func readModulePath(workDir string) (string, error) {
 		}
 	}
 	return "", errors.New("commandgen: go.mod is missing a module path")
+}
+
+// modulePathFromGoModLine returns the module path from a `module …` line,
+// stripping a trailing // comment and optional quotes the way go list -m does.
+func modulePathFromGoModLine(line string) string {
+	rest := strings.TrimSpace(strings.TrimPrefix(line, "module "))
+	inQuote := false
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case '"':
+			inQuote = !inQuote
+		case '/':
+			if !inQuote && i+1 < len(rest) && rest[i+1] == '/' {
+				return strings.Trim(strings.TrimSpace(rest[:i]), `"`)
+			}
+		}
+	}
+	return strings.Trim(strings.TrimSpace(rest), `"`)
 }
 
 func displayPath(workDir, full string) (string, error) {

--- a/commandgen/generate_test.go
+++ b/commandgen/generate_test.go
@@ -396,6 +396,68 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
+func TestReadModulePathStripsLineComment(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module github.com/example/demo // app\n"), 0o600)
+	if err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	got, err := readModulePath(dir)
+	if err != nil {
+		t.Fatalf("readModulePath() error = %v", err)
+	}
+	if got != "github.com/example/demo" {
+		t.Fatalf("readModulePath() = %q, want github.com/example/demo", got)
+	}
+}
+
+func TestGenerateStripsGoModLineCommentFromImports(t *testing.T) {
+	appDir := scaffoldApp(t)
+	path := filepath.Join(appDir, "go.mod")
+	data := readFile(t, path)
+	lines := strings.Split(data, "\n")
+	found := false
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "module ") {
+			lines[i] = strings.TrimSpace(line) + " // app"
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("go.mod missing module line")
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+
+	err := Generate(context.Background(), Options{
+		WorkDir: appDir,
+		Name:    "greet",
+		Stdout:  ioDiscard{},
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	mod, err := readModulePath(appDir)
+	if err != nil {
+		t.Fatalf("readModulePath: %v", err)
+	}
+	if strings.Contains(mod, "//") {
+		t.Fatalf("readModulePath() = %q, want comment stripped", mod)
+	}
+	wantImport := `"` + mod + `/internal/commands"`
+	mainSrc := readFile(t, filepath.Join(appDir, "cmd", "gombit", "main.go"))
+	if !strings.Contains(mainSrc, wantImport) {
+		t.Fatalf("cmd/gombit/main.go missing import %s:\n%s", wantImport, mainSrc)
+	}
+	if strings.Contains(mainSrc, "// app/") {
+		t.Fatalf("cmd/gombit/main.go kept go.mod comment in an import:\n%s", mainSrc)
+	}
+}
+
 type ioDiscard struct{}
 
 func (ioDiscard) Write(p []byte) (int, error) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -313,7 +313,9 @@ Route registration is appended in `cmd/server/main.go` via `go/ast` +
 `internal/platform` AutoMigrate is updated the same way. Re-running does not
 duplicate the `Register` call. A second resource whose plural HTTP path
 collides with an existing feature-package (`Bus` and `Buse` both become
-`/buses`) is refused.
+`/buses`) is refused. The module path is read from `go.mod` with trailing
+`//` comments stripped, so `module example.com/demo // app` does not leak
+into generated imports.
 
 Frontend pages are React + TypeScript (list/table + React Hook Form create)
 under `frontend/src/<feature>/`. They import types from
@@ -396,6 +398,9 @@ Default package is `internal/commands`. `--package hello` writes
 | `internal/<pkg>/<name>.go` | `New<Name>Command() *cli.Command` |
 | `internal/<pkg>/commands.go` | `RegisterCommands(root *cli.Command)` calling `cli.AddCommand` |
 | `cmd/gombit/main.go` | AST-appends `<pkg>.RegisterCommands(root)` next to `product.RegisterCommands(root)` |
+
+The module path is read from `go.mod` with trailing `//` comments stripped
+(same as `make resource`).
 
 `cli.AddCommand` is a thin wrapper around Cobra `AddCommand` (D13 /
 [ADR-014](adr/014-cli-cobra.md)). Generated apps do not invent a second

--- a/resourcegen/generate.go
+++ b/resourcegen/generate.go
@@ -206,7 +206,7 @@ func readModulePath(workDir string) (string, error) {
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "module ") {
-			module := strings.TrimSpace(strings.TrimPrefix(line, "module "))
+			module := modulePathFromGoModLine(line)
 			if module == "" {
 				break
 			}
@@ -214,6 +214,24 @@ func readModulePath(workDir string) (string, error) {
 		}
 	}
 	return "", errors.New("resourcegen: go.mod is missing a module path")
+}
+
+// modulePathFromGoModLine returns the module path from a `module …` line,
+// stripping a trailing // comment and optional quotes the way go list -m does.
+func modulePathFromGoModLine(line string) string {
+	rest := strings.TrimSpace(strings.TrimPrefix(line, "module "))
+	inQuote := false
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case '"':
+			inQuote = !inQuote
+		case '/':
+			if !inQuote && i+1 < len(rest) && rest[i+1] == '/' {
+				return strings.Trim(strings.TrimSpace(rest[:i]), `"`)
+			}
+		}
+	}
+	return strings.Trim(strings.TrimSpace(rest), `"`)
 }
 
 func readUI(workDir string) string {

--- a/resourcegen/generate_test.go
+++ b/resourcegen/generate_test.go
@@ -484,6 +484,114 @@ func readModulePathMust(t *testing.T, dir string) string {
 	return mod
 }
 
+func TestReadModulePathStripsLineComment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		gomod string
+		want  string
+	}{
+		{
+			name:  "trailing comment",
+			gomod: "module github.com/example/demo // app\n\ngo 1.25\n",
+			want:  "github.com/example/demo",
+		},
+		{
+			name:  "quoted path with comment",
+			gomod: "module \"github.com/example/demo\" // app\n",
+			want:  "github.com/example/demo",
+		},
+		{
+			name:  "no comment",
+			gomod: "module github.com/example/demo\n",
+			want:  "github.com/example/demo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(tt.gomod), 0o600); err != nil {
+				t.Fatalf("write go.mod: %v", err)
+			}
+			got, err := readModulePath(dir)
+			if err != nil {
+				t.Fatalf("readModulePath() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("readModulePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateStripsGoModLineCommentFromImports(t *testing.T) {
+	workDir := t.TempDir()
+	if err := scaffold.Generate(context.Background(), scaffold.Options{
+		Name:     "demo",
+		Database: "sqlite",
+		WorkDir:  workDir,
+		Stdout:   ioDiscard{},
+	}); err != nil {
+		t.Fatalf("scaffold: %v", err)
+	}
+	appDir := filepath.Join(workDir, "demo")
+	appendGoModModuleComment(t, appDir, "app")
+
+	previousLook := lookPath
+	lookPath = func(string) (string, error) { return "", errors.New("atlas missing") }
+	t.Cleanup(func() { lookPath = previousLook })
+
+	err := Generate(context.Background(), Options{
+		WorkDir:   appDir,
+		Name:      "Book",
+		Fields:    []string{"title:string:required"},
+		Stdout:    ioDiscard{},
+		skipAtlas: true,
+	})
+	if err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+	mod := readModulePathMust(t, appDir)
+	if strings.Contains(mod, "//") {
+		t.Fatalf("readModulePath() = %q, want comment stripped", mod)
+	}
+	wantImport := `"` + mod + `/internal/book"`
+	mainSrc := readFile(t, filepath.Join(appDir, "cmd", "server", "main.go"))
+	if !strings.Contains(mainSrc, wantImport) {
+		t.Fatalf("cmd/server/main.go missing import %s:\n%s", wantImport, mainSrc)
+	}
+	if strings.Contains(mainSrc, "// app/") {
+		t.Fatalf("cmd/server/main.go kept go.mod comment in an import:\n%s", mainSrc)
+	}
+	platformSrc := readFile(t, filepath.Join(appDir, "internal", "platform", "database.go"))
+	if strings.Contains(platformSrc, "// app/") {
+		t.Fatalf("internal/platform/database.go kept go.mod comment in an import:\n%s", platformSrc)
+	}
+}
+
+func appendGoModModuleComment(t *testing.T, appDir, comment string) {
+	t.Helper()
+	path := filepath.Join(appDir, "go.mod")
+	data := readFile(t, path)
+	lines := strings.Split(data, "\n")
+	found := false
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "module ") {
+			lines[i] = strings.TrimSpace(line) + " // " + comment
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("go.mod missing module line")
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+}
+
 // TestGenerateFrontendKeepsTypedDefaultPrefix is the #109 contract for
 // make-resource pages: gombit.yaml api_prefix is not baked into list/form
 // OpenAPI path keys. createAppClient rewrites /api/v1 to the live prefix.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`go.mod` allows a trailing comment on the module line (`module example.com/demo // app`). `resourcegen.readModulePath` and `commandgen.readModulePath` took everything after `module `, so `gombit make resource` / `make command` wrote imports like `"example.com/demo // app/internal/book"` and `go build` failed.

Both generators now strip trailing `//` comments (outside quotes) and optional quotes from that line, matching `go list -m`.

Closes #123

## Acceptance criteria

Issue #123 has no formal checklist. This PR satisfies the stated expected behavior:

- [x] `make resource` does not put `go.mod` `//` comments into generated imports
- [x] `make command` does not put `go.mod` `//` comments into generated imports
- [x] Quoted `module "path"` lines still parse

## Scope notes

- Does not add `golang.org/x/mod` as a new direct dependency; the line parser is local and quote-aware.
- The helper is duplicated in `resourcegen` and `commandgen` to avoid a new shared package for ~15 lines.

## Validation

- [x] `go test ./resourcegen ./commandgen -count=1`
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (CI)
- [ ] Project `code-review` skill run against this diff (after CI)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (N/A — generator-only)
- [x] Stable features ship docs and appear in an example app (`docs/cli.md`)
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests (N/A)
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR (N/A)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

