### PR TITLE
fix: refuse make command names version and createsuperuser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ version.
 
 ### Fixed
 
+- `gombit make command` refuses `version` and `createsuperuser`, which
+  `cli.NewRoot` already registers, so generated stubs cannot shadow the
+  framework commands
+  ([#124](https://github.com/gombit-dev/gombit/issues/124)).
 - `gombit make resource` and `gombit make command` strip trailing `//`
   comments from the `go.mod` module line, so
   `module example.com/demo // app` does not produce invalid imports

--- a/cli/root.go
+++ b/cli/root.go
@@ -29,7 +29,7 @@ func AddCommand(root *Command, cmds ...*Command) {
 }
 
 // NewRoot returns the framework Cobra tree (new, dev, build, make, db, openapi,
-// client, routes, doctor, config, createsuperuser). Generated apps call NewRoot, then
+// client, routes, doctor, config, createsuperuser, version). Generated apps call NewRoot, then
 // feature-package RegisterCommands, then ExecuteRoot.
 func NewRoot(stdout io.Writer, stderr io.Writer) *Command {
 	if stdout == nil {

--- a/commandgen/generate_test.go
+++ b/commandgen/generate_test.go
@@ -295,6 +295,8 @@ func TestGenerateRejectsReservedNames(t *testing.T) {
 		{name: "new", want: "collides"},
 		{name: "make", want: "collides"},
 		{name: "build", want: "collides"},
+		{name: "version", want: "collides"},
+		{name: "createsuperuser", want: "collides"},
 		{name: "platform", pkg: "platform", want: "reserved"},
 		{name: "greet", pkg: "product", want: "reserved"},
 		{name: "greet", pkg: "web", want: "reserved"},

--- a/commandgen/names.go
+++ b/commandgen/names.go
@@ -23,7 +23,8 @@ var reservedPackages = map[string]struct{}{
 
 var reservedCommands = map[string]struct{}{
 	"new": {}, "dev": {}, "build": {}, "make": {}, "db": {}, "openapi": {}, "client": {},
-	"routes": {}, "doctor": {}, "config": {}, "help": {}, "completion": {},
+	"routes": {}, "doctor": {}, "config": {}, "createsuperuser": {}, "version": {},
+	"help": {}, "completion": {},
 	"gombit": {}, "register": {},
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -420,8 +420,8 @@ Registration edits use `go/ast` + `go/parser` + `go/format` (never regex).
 `cmd/gombit/main.go` are additive AST edits of known registration points.
 
 Command names that collide with framework families (`new`, `dev`, `build`,
-`make`, `db`, `openapi`, `client`, `routes`, `doctor`, `config`, `help`,
-`completion`) are rejected.
+`make`, `db`, `openapi`, `client`, `routes`, `doctor`, `config`,
+`createsuperuser`, `version`, `help`, `completion`) are rejected.
 
 ## `gombit db`
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`commandgen` reserved most of the framework Cobra tree (`new`, `dev`, `build`, …) but omitted `version` and `createsuperuser`, which `cli.NewRoot` actually registers. `gombit make command version` therefore emitted a stub that shadowed the framework version printer (same for `createsuperuser`).

Those names are now reserved like `dev` / `doctor`.

Closes #124

## Acceptance criteria

Issue #124 has no formal checklist. This PR satisfies the stated expected behavior:

- [x] `gombit make command version` is refused
- [x] `gombit make command createsuperuser` is refused
- [x] Docs list both names with the other framework families

## Scope notes

- Does not reserve nested subcommands (`db migrate`, `make resource`); collisions are at the root `Use` name.
- A `commandgen` test that walked `cli.NewRoot().Commands()` was dropped because `cli` already imports `commandgen` (import cycle).

## Validation

- [x] `go test ./commandgen ./cli -count=1`
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (CI)
- [ ] Project `code-review` skill run against this diff (after CI)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (N/A — generator-only)
- [x] Stable features ship docs and appear in an example app (`docs/cli.md`)
- [x] Extraction preserves contracts — N/A
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR (N/A)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

