### PR TITLE
fix: refuse make resource Product, the scaffold package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ version.
 
 ### Fixed
 
+- `gombit make resource` refuses `Product` / `product`, the scaffold
+  feature-package every `gombit new` app already owns
+  ([#125](https://github.com/gombit-dev/gombit/issues/125)).
 - `gombit make command` refuses `version` and `createsuperuser`, which
   `cli.NewRoot` already registers, so generated stubs cannot shadow the
   framework commands

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -313,7 +313,9 @@ Route registration is appended in `cmd/server/main.go` via `go/ast` +
 `internal/platform` AutoMigrate is updated the same way. Re-running does not
 duplicate the `Register` call. A second resource whose plural HTTP path
 collides with an existing feature-package (`Bus` and `Buse` both become
-`/buses`) is refused. The module path is read from `go.mod` with trailing
+`/buses`) is refused. `Product` is reserved: every `gombit new` app already
+owns `internal/product` and the `/products` SPA routes (same as
+`make command --package product`). The module path is read from `go.mod` with trailing
 `//` comments stripped, so `module example.com/demo // app` does not leak
 into generated imports.
 

--- a/resourcegen/fields_test.go
+++ b/resourcegen/fields_test.go
@@ -157,4 +157,13 @@ func TestParseResourceName(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "reserved") {
 		t.Fatalf("web error = %v, want reserved", err)
 	}
+
+	_, err = parseResourceName("Product")
+	if err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("Product error = %v, want reserved package product", err)
+	}
+	_, err = parseResourceName("product")
+	if err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("product error = %v, want reserved package product", err)
+	}
 }

--- a/resourcegen/names.go
+++ b/resourcegen/names.go
@@ -18,7 +18,7 @@ var goKeywords = map[string]struct{}{
 var reservedPackages = map[string]struct{}{
 	"platform": {}, "cmd": {}, "config": {}, "database": {}, "frontend": {},
 	"internal": {}, "main": {}, "testdata": {}, "vendor": {}, "commands": {},
-	"web": {},
+	"web": {}, "product": {},
 }
 
 var reservedFields = map[string]struct{}{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Every `gombit new` app owns `internal/product` and SPA routes `/` + `/products/new`. `gombit make command --package product` was already refused. `gombit make resource Product` was not, so `--force` rewrote the scaffold product package and double-mounted `/products` in `resources.tsx` vs `router.tsx`.

`product` is now in `resourcegen` `reservedPackages`, matching commandgen.

Closes #125

## Acceptance criteria

Issue #125 has no formal checklist. This PR satisfies the stated expected behavior:

- [x] `make resource Product` errors as a reserved package (same idea as `make command --package product`)
- [x] `make resource product` is also refused

## Scope notes

- Does not change the scaffold product feature-package itself.

## Validation

- [x] `go test ./resourcegen -count=1 -run TestParseResourceName`
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (CI)
- [ ] Project `code-review` skill run against this diff (after CI)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (N/A — generator-only)
- [x] Stable features ship docs and appear in an example app (`docs/cli.md`)
- [x] Extraction preserves contracts — N/A
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR (N/A)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

