### PR TITLE
fix: stop README from copying .env.example over the JWT secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ version.
 
 ### Fixed
 
+- Generated README Run snippet no longer copies `.env.example` over the
+  per-project `.env` JWT secret
+  ([#126](https://github.com/gombit-dev/gombit/issues/126)).
 - `gombit make resource` refuses `Product` / `product`, the scaffold
   feature-package every `gombit new` app already owns
   ([#125](https://github.com/gombit-dev/gombit/issues/125)).

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -67,8 +67,10 @@ Bearer surface and `cookie` mode; see
 requirements.
 
 `gombit new` writes a gitignored `.env` with a per-project random HMAC secret.
-Generated `.env.example` keeps a short development placeholder so
-`cp .env.example .env` still works locally; production rejects that value.
+Generated `.env.example` keeps a short development placeholder for
+documentation. Do not `cp .env.example .env` over an existing `.env` — that
+replaces the per-project secret with the public placeholder. Production
+rejects that value.
 
 ## Generated frontend
 

--- a/goldentest/testdata/golden/make-command/README.md
+++ b/goldentest/testdata/golden/make-command/README.md
@@ -6,9 +6,8 @@ Scaffolded by `gombit new`. Feature-package layout is build plan §3.2.
 
 ```sh
 # gombit new already wrote a gitignored .env with a generated JWT secret.
-# Copy .env.example only if you need to recreate it; replace the JWT
-# placeholder before production (production rejects the development value).
-cp .env.example .env
+# Do not copy .env.example over it — that file uses the public development
+# placeholder, which production rejects. Recreate .env only if it is missing.
 go run ./cmd/server
 ```
 

--- a/goldentest/testdata/golden/make-resource/README.md
+++ b/goldentest/testdata/golden/make-resource/README.md
@@ -6,9 +6,8 @@ Scaffolded by `gombit new`. Feature-package layout is build plan §3.2.
 
 ```sh
 # gombit new already wrote a gitignored .env with a generated JWT secret.
-# Copy .env.example only if you need to recreate it; replace the JWT
-# placeholder before production (production rejects the development value).
-cp .env.example .env
+# Do not copy .env.example over it — that file uses the public development
+# placeholder, which production rejects. Recreate .env only if it is missing.
 go run ./cmd/server
 ```
 

--- a/goldentest/testdata/golden/new-cookie/README.md
+++ b/goldentest/testdata/golden/new-cookie/README.md
@@ -6,9 +6,8 @@ Scaffolded by `gombit new`. Feature-package layout is build plan §3.2.
 
 ```sh
 # gombit new already wrote a gitignored .env with a generated JWT secret.
-# Copy .env.example only if you need to recreate it; replace the JWT
-# placeholder before production (production rejects the development value).
-cp .env.example .env
+# Do not copy .env.example over it — that file uses the public development
+# placeholder, which production rejects. Recreate .env only if it is missing.
 go run ./cmd/server
 ```
 

--- a/goldentest/testdata/golden/new-mui/README.md
+++ b/goldentest/testdata/golden/new-mui/README.md
@@ -6,9 +6,8 @@ Scaffolded by `gombit new`. Feature-package layout is build plan §3.2.
 
 ```sh
 # gombit new already wrote a gitignored .env with a generated JWT secret.
-# Copy .env.example only if you need to recreate it; replace the JWT
-# placeholder before production (production rejects the development value).
-cp .env.example .env
+# Do not copy .env.example over it — that file uses the public development
+# placeholder, which production rejects. Recreate .env only if it is missing.
 go run ./cmd/server
 ```
 

--- a/goldentest/testdata/golden/new/README.md
+++ b/goldentest/testdata/golden/new/README.md
@@ -6,9 +6,8 @@ Scaffolded by `gombit new`. Feature-package layout is build plan §3.2.
 
 ```sh
 # gombit new already wrote a gitignored .env with a generated JWT secret.
-# Copy .env.example only if you need to recreate it; replace the JWT
-# placeholder before production (production rejects the development value).
-cp .env.example .env
+# Do not copy .env.example over it — that file uses the public development
+# placeholder, which production rejects. Recreate .env only if it is missing.
 go run ./cmd/server
 ```
 

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -198,6 +198,12 @@ func TestGenerateWritesFeaturePackageLayout(t *testing.T) {
 	if strings.Contains(appReadme, "API docs, Admin") {
 		t.Fatal("jwt README.md must not list Admin in the gombit dev service table")
 	}
+	if strings.Contains(appReadme, "cp .env.example .env") {
+		t.Fatal("README.md must not copy .env.example over the generated .env JWT secret")
+	}
+	if !strings.Contains(appReadme, "go run ./cmd/server") {
+		t.Fatal("README.md missing go run ./cmd/server")
+	}
 	indexHTML := readFile(t, filepath.Join(dest, "frontend", "index.html"))
 	if !strings.Contains(indexHTML, `content="__GOMBIT_API_PREFIX__"`) {
 		t.Fatal("frontend/index.html missing __GOMBIT_API_PREFIX__ placeholder")

--- a/scaffold/templates/README.md.tmpl
+++ b/scaffold/templates/README.md.tmpl
@@ -6,9 +6,8 @@ Scaffolded by `gombit new`. Feature-package layout is build plan §3.2.
 
 ```sh
 # gombit new already wrote a gitignored .env with a generated JWT secret.
-# Copy .env.example only if you need to recreate it; replace the JWT
-# placeholder before production (production rejects the development value).
-cp .env.example .env
+# Do not copy .env.example over it — that file uses the public development
+# placeholder, which production rejects. Recreate .env only if it is missing.
 go run ./cmd/server
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`gombit new` writes a gitignored `.env` with a random ≥32-character `GOMBIT_JWT_SECRET`. The generated README Run snippet still ran `cp .env.example .env`, replacing that secret with the public placeholder `dev-only-not-for-production`.

The Run block now starts the server against the already-written `.env` and warns not to copy `.env.example` over it.

Closes #126

## Acceptance criteria

Issue #126 has no formal checklist. This PR satisfies the stated expected behavior:

- [x] Generated README Run snippet does not `cp .env.example .env`
- [x] Snippet still runs `go run ./cmd/server` against the generated `.env`
- [x] Goldens and `docs/auth.md` match

## Scope notes

- Does not change `.env.example` contents; that file still documents the placeholder.

## Validation

- [x] `go test ./scaffold ./goldentest -count=1`
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (CI)
- [ ] Project `code-review` skill run against this diff (after CI)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (N/A — docs/generator copy)
- [x] Stable features ship docs and appear in an example app
- [x] Extraction preserves contracts — N/A
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR (N/A)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

