### PR TITLE
fix: populate json.RawMessage and uuid.UUID on admin writes

### DIFF
--- a/admin/fields.go
+++ b/admin/fields.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"database/sql"
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -9,6 +11,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
 )
@@ -98,6 +101,8 @@ func inferFieldType(sf *schema.Field) FieldType {
 		return TypeDateTime
 	case reflect.TypeOf(json.RawMessage{}):
 		return TypeJSON
+	case reflect.TypeOf(uuid.UUID{}):
+		return TypeUUID
 	}
 	switch t.Kind() {
 	case reflect.String:
@@ -256,7 +261,85 @@ func convertTo(val any, dest reflect.Type) (reflect.Value, error) {
 	if dest.Kind() == reflect.String {
 		return reflect.ValueOf(fmt.Sprint(val)).Convert(dest), nil
 	}
+
+	out := reflect.New(dest)
+	if tu, ok := out.Interface().(encoding.TextUnmarshaler); ok {
+		if text, err := asTextBytes(val); err == nil {
+			if err := tu.UnmarshalText(text); err != nil {
+				return reflect.Value{}, err
+			}
+			return out.Elem(), nil
+		}
+	}
+
+	payload, jsonErr := asJSONBytes(val)
+	if dest.Kind() == reflect.Slice && dest.Elem().Kind() == reflect.Uint8 {
+		if jsonErr != nil {
+			return reflect.Value{}, fmt.Errorf("cannot assign %T to %s", val, dest)
+		}
+		slice := reflect.MakeSlice(dest, len(payload), len(payload))
+		reflect.Copy(slice, reflect.ValueOf(payload))
+		return slice, nil
+	}
+	if ju, ok := out.Interface().(json.Unmarshaler); ok && jsonErr == nil {
+		if err := ju.UnmarshalJSON(payload); err != nil {
+			return reflect.Value{}, err
+		}
+		return out.Elem(), nil
+	}
+	switch dest.Kind() {
+	case reflect.Struct, reflect.Map, reflect.Slice, reflect.Array:
+		if jsonErr != nil {
+			return reflect.Value{}, fmt.Errorf("cannot assign %T to %s", val, dest)
+		}
+		if err := json.Unmarshal(payload, out.Interface()); err != nil {
+			return reflect.Value{}, fmt.Errorf("cannot assign %T to %s", val, dest)
+		}
+		return out.Elem(), nil
+	}
+	if scanner, ok := out.Interface().(sql.Scanner); ok {
+		if err := scanner.Scan(val); err != nil {
+			return reflect.Value{}, err
+		}
+		return out.Elem(), nil
+	}
 	return reflect.Value{}, fmt.Errorf("cannot assign %T to %s", val, dest)
+}
+
+func asTextBytes(val any) ([]byte, error) {
+	switch v := val.(type) {
+	case string:
+		return []byte(v), nil
+	case []byte:
+		return v, nil
+	case json.RawMessage:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("not text")
+	}
+}
+
+func asJSONBytes(val any) ([]byte, error) {
+	switch v := val.(type) {
+	case json.RawMessage:
+		if json.Valid(v) {
+			return v, nil
+		}
+		return json.Marshal(v)
+	case []byte:
+		if json.Valid(v) {
+			return v, nil
+		}
+		return json.Marshal(v)
+	case string:
+		b := []byte(v)
+		if json.Valid(b) {
+			return b, nil
+		}
+		return json.Marshal(v)
+	default:
+		return json.Marshal(val)
+	}
 }
 
 func makeNewInstance(elem reflect.Type) func() any {

--- a/admin/fields_test.go
+++ b/admin/fields_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type setterRow struct {
@@ -128,5 +130,102 @@ func TestMakeSetterClearsPresentNil(t *testing.T) {
 	clear("Name", TypeString, nil)
 	if inst.Name != "" {
 		t.Fatalf("Name after null = %q, want empty", inst.Name)
+	}
+}
+
+func TestConvertToJSONAndUUID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("map into json.RawMessage", func(t *testing.T) {
+		got, err := convertTo(map[string]any{"a": float64(1)}, reflect.TypeOf(json.RawMessage{}))
+		if err != nil {
+			t.Fatalf("convertTo: %v", err)
+		}
+		raw, ok := got.Interface().(json.RawMessage)
+		if !ok {
+			t.Fatalf("type %T, want json.RawMessage", got.Interface())
+		}
+		if string(raw) != `{"a":1}` {
+			t.Fatalf("RawMessage = %s, want {\"a\":1}", raw)
+		}
+	})
+
+	t.Run("map into []byte", func(t *testing.T) {
+		got, err := convertTo(map[string]any{"a": float64(1)}, reflect.TypeOf([]byte(nil)))
+		if err != nil {
+			t.Fatalf("convertTo: %v", err)
+		}
+		b, ok := got.Interface().([]byte)
+		if !ok {
+			t.Fatalf("type %T, want []byte", got.Interface())
+		}
+		if string(b) != `{"a":1}` {
+			t.Fatalf("[]byte = %s, want {\"a\":1}", b)
+		}
+	})
+
+	t.Run("map into nested struct", func(t *testing.T) {
+		type nested struct {
+			A int `json:"a"`
+		}
+		got, err := convertTo(map[string]any{"a": float64(7)}, reflect.TypeOf(nested{}))
+		if err != nil {
+			t.Fatalf("convertTo: %v", err)
+		}
+		n, ok := got.Interface().(nested)
+		if !ok {
+			t.Fatalf("type %T, want nested", got.Interface())
+		}
+		if n.A != 7 {
+			t.Fatalf("nested.A = %d, want 7", n.A)
+		}
+	})
+
+	t.Run("string into uuid.UUID", func(t *testing.T) {
+		const s = "550e8400-e29b-41d4-a716-446655440000"
+		got, err := convertTo(s, reflect.TypeOf(uuid.UUID{}))
+		if err != nil {
+			t.Fatalf("convertTo: %v", err)
+		}
+		id, ok := got.Interface().(uuid.UUID)
+		if !ok {
+			t.Fatalf("type %T, want uuid.UUID", got.Interface())
+		}
+		if id.String() != s {
+			t.Fatalf("uuid = %s, want %s", id, s)
+		}
+	})
+}
+
+func TestMakeSetterJSONObjectAndUUID(t *testing.T) {
+	t.Parallel()
+	type row struct {
+		Payload json.RawMessage
+		Token   uuid.UUID
+	}
+	inst := &row{}
+	rt := reflect.TypeOf(row{})
+
+	payloadField, ok := rt.FieldByName("Payload")
+	if !ok {
+		t.Fatal("Payload missing")
+	}
+	if err := makeSetter(payloadField.Index, TypeJSON, payloadField.Type)(inst, map[string]any{"a": float64(1)}); err != nil {
+		t.Fatalf("set Payload: %v", err)
+	}
+	if string(inst.Payload) != `{"a":1}` {
+		t.Fatalf("Payload = %s, want {\"a\":1}", inst.Payload)
+	}
+
+	tokenField, ok := rt.FieldByName("Token")
+	if !ok {
+		t.Fatal("Token missing")
+	}
+	const s = "550e8400-e29b-41d4-a716-446655440000"
+	if err := makeSetter(tokenField.Index, TypeUUID, tokenField.Type)(inst, s); err != nil {
+		t.Fatalf("set Token: %v", err)
+	}
+	if inst.Token.String() != s {
+		t.Fatalf("Token = %s, want %s", inst.Token, s)
 	}
 }

--- a/admin/register_test.go
+++ b/admin/register_test.go
@@ -1,12 +1,14 @@
 package admin_test
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 
-	"github.com/gombit-dev/gombit/admin"
 	"github.com/gin-gonic/gin"
+	"github.com/gombit-dev/gombit/admin"
+	"github.com/google/uuid"
 )
 
 func TestRegisterMissingSlug(t *testing.T) {
@@ -190,6 +192,36 @@ func TestFieldsFromUsesJSONNames(t *testing.T) {
 	}
 	if _, ok := byName["created_at"]; !ok {
 		t.Fatalf("FieldsFrom missing created_at; fields=%v", fields)
+	}
+}
+
+func TestFieldsFromInfersUUIDAndJSON(t *testing.T) {
+	type Token struct {
+		ID      uuid.UUID       `gorm:"type:uuid;primaryKey" json:"id"`
+		Payload json.RawMessage `json:"payload"`
+		Name    string          `json:"name"`
+	}
+	fields, err := admin.FieldsFrom(Token{})
+	if err != nil {
+		t.Fatalf("FieldsFrom: %v", err)
+	}
+	byName := map[string]admin.Field{}
+	for _, f := range fields {
+		byName[f.Name] = f
+	}
+	id, ok := byName["id"]
+	if !ok {
+		t.Fatalf("FieldsFrom missing id; fields=%v", fields)
+	}
+	if id.Type != admin.TypeUUID {
+		t.Fatalf("id type = %q, want %q", id.Type, admin.TypeUUID)
+	}
+	payload, ok := byName["payload"]
+	if !ok {
+		t.Fatalf("FieldsFrom missing payload; fields=%v", fields)
+	}
+	if payload.Type != admin.TypeJSON {
+		t.Fatalf("payload type = %q, want %q", payload.Type, admin.TypeJSON)
 	}
 }
 

--- a/admin/resources_test.go
+++ b/admin/resources_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gombit-dev/gombit/auth"
 	"github.com/gombit-dev/gombit/contract"
 	"github.com/gombit-dev/gombit/framework"
+	"github.com/google/uuid"
 )
 
 type rowEnvelope struct {
@@ -190,6 +191,66 @@ func TestResourcePatchClearsNullablePointerAndJSON(t *testing.T) {
 	}
 	if stored.Due != nil {
 		t.Fatalf("due = %#v, want nil", stored.Due)
+	}
+}
+
+func TestResourceJSONAndUUIDWrites(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Token struct {
+		ID      uint            `gorm:"primaryKey" json:"id"`
+		Token   uuid.UUID       `gorm:"type:uuid;not null" json:"token"`
+		Payload json.RawMessage `json:"payload"`
+		Title   string          `json:"title"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&Token{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	if err := admin.Register(app, Token{}, admin.Options{
+		Slug: "tokens",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "token", Type: admin.TypeUUID, Required: true},
+			{Name: "payload", Type: admin.TypeJSON},
+			{Name: "title", Type: admin.TypeString, Required: true},
+		},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	jar := loginSuperuser(t, app)
+
+	exampleUUID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	create := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/tokens",
+		fmt.Sprintf(`{"title":"k","token":"%s","payload":{"a":1}}`, exampleUUID))
+	if create.Code != http.StatusOK {
+		t.Fatalf("create status = %d; body: %s", create.Code, create.Body.String())
+	}
+	var created rowEnvelope
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	id := fmt.Sprint(asInt(created.Data["id"]))
+
+	var stored Token
+	if err := app.DB().First(&stored, created.Data["id"]).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if stored.Token != exampleUUID {
+		t.Fatalf("token = %s, want %s", stored.Token, exampleUUID)
+	}
+	if string(stored.Payload) != `{"a":1}` {
+		t.Fatalf("payload = %s, want {\"a\":1}", stored.Payload)
+	}
+
+	patch := doRequest(app, jar, http.MethodPatch, "/api/v1/admin/resources/tokens/"+id, `{"payload":{"b":2}}`)
+	if patch.Code != http.StatusOK {
+		t.Fatalf("patch status = %d; body: %s", patch.Code, patch.Body.String())
+	}
+	if err := app.DB().First(&stored, created.Data["id"]).Error; err != nil {
+		t.Fatalf("reload after patch: %v", err)
+	}
+	if string(stored.Payload) != `{"b":2}` {
+		t.Fatalf("patched payload = %s, want {\"b\":2}", stored.Payload)
 	}
 }
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -232,7 +232,11 @@ Row JSON is keyed by registered field names, plus implicit `created_at` /
 SQL NULL, non-pointer strings become `""`, `time.Time` becomes zero,
 `json.RawMessage` / `[]byte` become nil. Required fields with `null` still
 422 (`is required`). Unknown keys, readonly keys, and type failures render
-D10 `validation_error` with `fields`.
+D10 `validation_error` with `fields`. JSON object/array values populate
+`json.RawMessage`, `[]byte`, and nested structs (`json.Unmarshal` /
+`json.Unmarshaler`). UUID strings populate `uuid.UUID`
+(`encoding.TextUnmarshaler` / `sql.Scanner`). `FieldsFrom` infers
+`uuid.UUID` as `uuid`, not `json`.
 
 The application's public CRUD API stays the feature's own typed Huma
 routes. Admin does not replace them.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/danielgtaylor/huma/v2 v2.39.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/uuid v1.6.0
 	github.com/pb33f/libopenapi v0.38.7
 	github.com/pb33f/libopenapi-validator v0.14.0
 	github.com/redis/go-redis/v9 v9.22.0
@@ -65,7 +66,6 @@ require (
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/googleapis/go-gorm-spanner v1.8.6 // indirect


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Admin create/update could not write JSON objects into `json.RawMessage` / `[]byte` / nested structs, or UUID strings into `uuid.UUID`. `convertTo` only used `AssignableTo` / `ConvertibleTo` / `fmt.Sprint` for strings, so a JSON object became `cannot assign map[string]interface {} to json.RawMessage` and a UUID string became `cannot assign string to uuid.UUID`. `FieldsFrom` inferred `uuid.UUID` (`[16]byte`) as `json`.

`convertTo` now unmarshals through `encoding.TextUnmarshaler`, JSON bytes into `[]byte`/`json.RawMessage`, `json.Unmarshaler`, `json.Unmarshal` into struct/map/slice/array, and `sql.Scanner`. `FieldsFrom` treats `github.com/google/uuid`.UUID as `uuid`.

Closes #129

## Acceptance criteria

- [x] JSON object/array bodies populate `json.RawMessage`, `[]byte`, and nested structs inferred as `json`
- [x] UUID strings populate `uuid.UUID` when the field is `TypeUUID`
- [x] `FieldsFrom` infers `uuid.UUID` as `uuid`, not `json`
- [x] Existing null-clear of `json.RawMessage` still works (#108 / `TestMakeSetterClearsPresentNil`)

## Scope notes

- Does not add a new UUID library of our own; uses `github.com/google/uuid` (already in the module, now a direct require) as the inferred UUID type.
- Does not change the SPA JSON widget; it already POSTs parsed objects. The data plane now accepts them.
- `applyWrite` still overwrites a failed setter error with `is required` on create when the field never entered `seen` — pre-existing, not this bug.

## Validation

- [x] `go test ./admin/ -count=1`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./admin/`
- [ ] `go test ./...` (CI)
- [ ] Project `code-review` skill run against this diff (after CI is green)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — unit tests plus `TestResourceJSONAndUUIDWrites` (SQLite locally; CI matrix)
- [x] Stable features ship docs and appear in an example app — `docs/admin.md`
- [ ] Extraction preserves contracts — N/A (admin convert path, not an extraction)
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — N/A
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A (no OpenAPI shape change; body is still `map[string]any`)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

