### PR TITLE
fix: let the MySQL dialector initialize from server version

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -154,10 +154,7 @@ func dialectorFor(driver Driver, dsn string) (gorm.Dialector, error) {
 	case DriverPostgres:
 		return postgres.Open(dsn), nil
 	case DriverMySQL:
-		return mysql.New(mysql.Config{
-			DSN:                       dsn,
-			SkipInitializeWithVersion: true,
-		}), nil
+		return mysql.Open(dsn), nil
 	default:
 		return nil, fmt.Errorf("database: unsupported driver %q", driver)
 	}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gombit-dev/gombit/config"
+	"gorm.io/driver/mysql"
 )
 
 type testWidget struct {
@@ -177,6 +178,24 @@ func TestOpenRejectsInvalidConfig(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Open() error = nil, want invalid driver error")
+	}
+}
+
+func TestMySQLDialectorInitializesFromServerVersion(t *testing.T) {
+	t.Parallel()
+	d, err := dialectorFor(DriverMySQL, "user:pass@tcp(127.0.0.1:3306)/app?parseTime=true")
+	if err != nil {
+		t.Fatalf("dialectorFor() error = %v", err)
+	}
+	md, ok := d.(*mysql.Dialector)
+	if !ok {
+		t.Fatalf("dialector type = %T, want *mysql.Dialector", d)
+	}
+	if md.Config == nil {
+		t.Fatal("mysql dialector Config is nil")
+	}
+	if md.SkipInitializeWithVersion {
+		t.Fatal("SkipInitializeWithVersion = true, want false so GORM probes SELECT VERSION() and sets DontSupportRenameColumn on MySQL 5.7/MariaDB")
 	}
 }
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -19,6 +19,13 @@ Gombit migration DSL.
 | PostgreSQL | `postgres` |
 | MySQL | `mysql` |
 
+The MySQL dialector uses GORM's default `mysql.Open` so it probes
+`SELECT VERSION()` and sets capability flags (`DontSupportRenameColumn`,
+`DontSupportDropConstraint`, …) for MySQL 5.7 / MariaDB. It does **not**
+set `SkipInitializeWithVersion`, which would leave those flags at the
+MySQL 8 defaults and emit `RENAME COLUMN` / `DROP CONSTRAINT` that older
+servers reject.
+
 The opened handle embeds `*gorm.DB` and exposes driver metadata:
 
 ```go


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`database.Open` built the MySQL dialector with `SkipInitializeWithVersion: true`. GORM then never ran `SELECT VERSION()` and left `DontSupportRenameColumn` / `DontSupportDropConstraint` at the MySQL 8 defaults (`false`). On MySQL 5.7 / MariaDB, `AutoMigrate` emitted `RENAME COLUMN` / `DROP CONSTRAINT` that those servers reject.

The MySQL branch now uses `mysql.Open(dsn)` like SQLite/Postgres, so the driver initializes from the server version.

Closes #131

## Acceptance criteria

- [x] MySQL dialector does not set `SkipInitializeWithVersion: true`
- [x] GORM can probe `SELECT VERSION()` and set 5.7/MariaDB capability flags (`DontSupportRenameColumn`, etc.)
- [x] Regression test asserts the dialector config (`TestMySQLDialectorInitializesFromServerVersion`)

## Scope notes

- Does not add a MariaDB/5.7 CI image. The unit test pins the dialector flag; CI MySQL 8 still probes VERSION() and remains on the modern-DDL path.
- Does not change Gombit's own `database.Capabilities` (that's a separate, driver-name model).

## Validation

- [x] `go test ./database/ -count=1`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./database/`
- [ ] `go test ./...` (CI)
- [ ] Project `code-review` skill run against this diff (after CI is green)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — unit test of dialector config; CI MySQL still opens via `database.Open`
- [x] Stable features ship docs and appear in an example app — `docs/database.md`
- [ ] Extraction preserves contracts — N/A (runtime database open path)
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — N/A
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

