### PR TITLE
fix: map unexpected Huma 500s to D10 internal, not validation_error

### DIFF
--- a/contract/error_mapping_test.go
+++ b/contract/error_mapping_test.go
@@ -3,6 +3,7 @@ package contract
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -120,5 +121,72 @@ func TestDataMetaPageMetaAppearsInOpenAPI(t *testing.T) {
 		if !strings.Contains(spec, want) {
 			t.Fatalf("OpenAPI missing %s; body: %s", want, spec)
 		}
+	}
+}
+
+func TestUnexpectedHandlerErrorIsInternal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	api := humagin.New(router, HumaConfig("contract-test", "0.0.0"))
+
+	huma.Register(api, huma.Operation{
+		OperationID: "boom",
+		Method:      http.MethodGet,
+		Path:        "/boom",
+	}, func(ctx context.Context, in *struct{}) (*struct{}, error) {
+		return nil, errors.New("sql: connection refused")
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/boom", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body: %s", rec.Code, rec.Body.String())
+	}
+	var body ErrorEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v; body: %s", err, rec.Body.String())
+	}
+	if body.Body.Code != string(CategoryInternal) {
+		t.Fatalf("code = %q, want internal; body: %s", body.Body.Code, rec.Body.String())
+	}
+	if len(body.Body.Fields) != 0 {
+		t.Fatalf("fields = %#v, want empty (no driver string)", body.Body.Fields)
+	}
+	if strings.Contains(body.Body.Message, "sql: connection refused") {
+		t.Fatalf("message leaked driver error: %q", body.Body.Message)
+	}
+}
+
+func TestMissingJSONBodyIsValidationError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	api := humagin.New(router, HumaConfig("contract-test", "0.0.0"))
+
+	type createInput struct {
+		Body struct {
+			Name string `json:"name"`
+		}
+	}
+	huma.Register(api, huma.Operation{
+		OperationID: "create-required-body",
+		Method:      http.MethodPost,
+		Path:        "/required-body",
+	}, func(ctx context.Context, input *createInput) (*struct{}, error) {
+		return &struct{}{}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/required-body", http.NoBody)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body: %s", rec.Code, rec.Body.String())
+	}
+	var body ErrorEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v; body: %s", err, rec.Body.String())
+	}
+	if body.Body.Code != CodeValidationError {
+		t.Fatalf("code = %q, want %q; body: %s", body.Body.Code, CodeValidationError, rec.Body.String())
 	}
 }

--- a/contract/fields.go
+++ b/contract/fields.go
@@ -61,7 +61,10 @@ func fieldFromError(err error) (key, message string) {
 	if inferred := fieldFromMessage(message); inferred != "" {
 		return inferred, message
 	}
-	return "_error", message
+	// Generic errors are not field-level validation details. Huma's
+	// unexpected-500 path wraps the handler error here; putting it in
+	// fields._error would classify the response as validation_error.
+	return "", ""
 }
 
 func fieldKey(location string) string {

--- a/contract/fields_test.go
+++ b/contract/fields_test.go
@@ -56,9 +56,9 @@ func TestFieldsFromErrors(t *testing.T) {
 			want: map[string][]string{"email": {"required", "invalid format"}},
 		},
 		{
-			name: "plain error falls back",
+			name: "plain error is not a field detail",
 			errs: []error{errString("boom")},
-			want: map[string][]string{"_error": {"boom"}},
+			want: nil,
 		},
 		{
 			name: "required property inferred from message",

--- a/contract/install.go
+++ b/contract/install.go
@@ -17,9 +17,9 @@ type InstallOptions struct {
 }
 
 var (
-	installOnce    sync.Once
-	requestIDFrom  func(context.Context) string
-	requestIDMu    sync.RWMutex
+	installOnce   sync.Once
+	requestIDFrom func(context.Context) string
+	requestIDMu   sync.RWMutex
 )
 
 // Install replaces Huma's default RFC 9457 Problem Details errors with the D10
@@ -73,7 +73,10 @@ func WithContext(ctx context.Context, err *ErrorEnvelope) *ErrorEnvelope {
 
 func newEnvelope(status int, msg, requestID string, errs ...error) *ErrorEnvelope {
 	fields := FieldsFromErrors(errs...)
-	code, message := classifyError(status, msg, fields)
+	if isValidationFailure(status) {
+		status = http.StatusUnprocessableEntity
+	}
+	code, message := classifyError(status, msg)
 	return &ErrorEnvelope{
 		status: status,
 		Body: ErrorBody{
@@ -85,9 +88,9 @@ func newEnvelope(status int, msg, requestID string, errs ...error) *ErrorEnvelop
 	}
 }
 
-func classifyError(status int, msg string, fields map[string][]string) (code, message string) {
+func classifyError(status int, msg string) (code, message string) {
 	msg = strings.TrimSpace(msg)
-	if isValidationFailure(status, msg, fields) {
+	if isValidationFailure(status) {
 		message = validationMessage
 		if msg != "" && !strings.EqualFold(msg, "validation failed") {
 			message = msg
@@ -100,23 +103,26 @@ func classifyError(status int, msg string, fields map[string][]string) (code, me
 	if msg == "" {
 		msg = "request failed"
 	}
-	return statusCodeSlug(status), msg
+	return codeForHTTPStatus(status), msg
 }
 
-func isValidationFailure(status int, msg string, fields map[string][]string) bool {
-	// Huma Install path only: field details or 422/validation-failed indicate
-	// request validation. Application constructors (New/NotFound/...) bypass
-	// this function entirely.
-	if len(fields) > 0 {
-		return true
+func isValidationFailure(status int) bool {
+	// Install only classifies Huma NewError hooks. 5xx is never request
+	// validation — Huma's last-resort path is NewErrorWithContext(500,
+	// "unexpected error occurred", err) and must stay D10 internal.
+	if status >= 500 {
+		return false
 	}
-	if status == http.StatusUnprocessableEntity {
-		return true
+	return status == http.StatusUnprocessableEntity || status == http.StatusBadRequest
+}
+
+func codeForHTTPStatus(status int) string {
+	for cat, s := range categoryStatus {
+		if s == status {
+			return CodeFor(cat)
+		}
 	}
-	if status == http.StatusBadRequest && strings.EqualFold(msg, "validation failed") {
-		return true
-	}
-	return false
+	return statusCodeSlug(status)
 }
 
 func statusCodeSlug(status int) string {

--- a/contract/install_test.go
+++ b/contract/install_test.go
@@ -8,9 +8,7 @@ import (
 func TestClassifyErrorValidation(t *testing.T) {
 	t.Parallel()
 
-	code, message := classifyError(http.StatusUnprocessableEntity, "validation failed", map[string][]string{
-		"name": {"required"},
-	})
+	code, message := classifyError(http.StatusUnprocessableEntity, "validation failed")
 	if code != CodeValidationError {
 		t.Fatalf("code = %q, want %q", code, CodeValidationError)
 	}
@@ -27,5 +25,54 @@ func TestStatusCodeSlug(t *testing.T) {
 	}
 	if got := statusCodeSlug(0); got != "error" {
 		t.Fatalf("statusCodeSlug(0) = %q, want error", got)
+	}
+}
+
+func TestClassifyErrorUnexpected500IsInternal(t *testing.T) {
+	t.Parallel()
+	code, message := classifyError(http.StatusInternalServerError, "unexpected error occurred")
+	if code != string(CategoryInternal) {
+		t.Fatalf("code = %q, want %q", code, CategoryInternal)
+	}
+	if message != "unexpected error occurred" {
+		t.Fatalf("message = %q, want unexpected error occurred (no driver string)", message)
+	}
+}
+
+func TestClassifyErrorMapsHTTPStatusToCategoryCodes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		status int
+		want   string
+	}{
+		{http.StatusUnauthorized, string(CategoryAuthentication)},
+		{http.StatusForbidden, string(CategoryAuthorization)},
+		{http.StatusNotFound, string(CategoryNotFound)},
+		{http.StatusConflict, string(CategoryConflict)},
+		{http.StatusTooManyRequests, string(CategoryRateLimited)},
+		{http.StatusServiceUnavailable, string(CategoryDependencyUnavailable)},
+		{http.StatusInternalServerError, string(CategoryInternal)},
+	}
+	for _, tc := range cases {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			code, _ := classifyError(tc.status, "")
+			if code != tc.want {
+				t.Fatalf("classifyError(%d) code = %q, want %q", tc.status, code, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewEnvelopeUnexpectedErrorOmitsFields(t *testing.T) {
+	t.Parallel()
+	env := newEnvelope(http.StatusInternalServerError, "unexpected error occurred", "req-1", errString("sql: connection refused"))
+	if env.GetStatus() != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", env.GetStatus())
+	}
+	if env.Body.Code != string(CategoryInternal) {
+		t.Fatalf("code = %q, want internal", env.Body.Code)
+	}
+	if len(env.Body.Fields) != 0 {
+		t.Fatalf("fields = %#v, want empty (no driver string)", env.Body.Fields)
 	}
 }

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -180,6 +180,10 @@ cookie CSRF uses `Authorization` (403). Do not treat 413 as a handler-level
 `WithFields` attaches D10 `fields` without forcing the code to
 `validation_error` (for example a `conflict` with a field detail). Huma tag
 validation still uses the Install path and always yields `validation_error`.
+A missing JSON body is HTTP **422** `validation_error` (Huma may start as
+400; Install remaps it). An unexpected non-`StatusError` from a handler is
+HTTP **500** `internal` with no `fields` — not `validation_error` and not
+the raw driver string.
 
 The `validation_error` code is preserved from M3-1 / D10 (not renamed to
 `validation`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Huma's last-resort path is `NewErrorWithContext(ctx, 500, "unexpected error occurred", err)`. `isValidationFailure` treated any non-empty `fields` map as validation, and `FieldsFromErrors` put a plain `errors.New` into `fields._error`. The client saw HTTP 500 with `error.code` `validation_error` and the driver string in `fields`.

`statusCodeSlug` also used HTTP reason phrases (`internal_server_error`, `unauthorized`, `too_many_requests`) instead of D10 §41 codes (`internal`, `authentication`, `rate_limited`). Missing required JSON body was HTTP 400 `bad_request`, not 422 `validation_error`.

Install now: 5xx is never validation; generic errors are not field details; HTTP status maps to category codes; Huma 400 remaps to 422 `validation_error`.

Closes #132

## Acceptance criteria

- [x] Unexpected non-`StatusError` from a handler is HTTP 500, `code: internal`, no driver string in `fields`
- [x] Install maps 401/403/429/500/503 to `authentication` / `authorization` / `rate_limited` / `internal` / `dependency_unavailable`
- [x] Missing JSON body is HTTP 422 `validation_error`
- [x] Application constructors (`NotFound`, `Conflict`+fields) still bypass Install classification

## Scope notes

- Does not change OpenAPI schema (still `ErrorEnvelope`); no client regen.
- Tag validation (`{}` missing required property) remains 422 `validation_error` with `fields`.

## Validation

- [x] `go test ./contract/ -count=1`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./contract/`
- [ ] `go test ./...` (CI)
- [ ] Project `code-review` skill run against this diff (after CI is green)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — contract unit/HTTP tests; no DB change
- [x] Stable features ship docs and appear in an example app — `docs/contract.md`
- [ ] Extraction preserves contracts — N/A
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — N/A
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A (error object shape unchanged; codes were already strings)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

