### PR TITLE
fix: keep leading colons in namespaced cache keys

### DIFF
--- a/cache/namespace.go
+++ b/cache/namespace.go
@@ -41,5 +41,5 @@ func (n namespaced) Increment(ctx context.Context, key string, delta int64) (int
 }
 
 func (n namespaced) key(key string) string {
-	return n.namespace + ":" + strings.TrimLeft(key, ":")
+	return n.namespace + ":" + key
 }

--- a/cache/namespace_test.go
+++ b/cache/namespace_test.go
@@ -1,0 +1,125 @@
+package cache
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gombit-dev/gombit/config"
+)
+
+type recordingCache struct {
+	keys []string
+}
+
+func (r *recordingCache) Get(_ context.Context, key string, _ any) (bool, error) {
+	r.keys = append(r.keys, key)
+	return false, nil
+}
+
+func (r *recordingCache) Set(_ context.Context, key string, _ any, _ time.Duration) error {
+	r.keys = append(r.keys, key)
+	return nil
+}
+
+func (r *recordingCache) Delete(_ context.Context, keys ...string) error {
+	r.keys = append(r.keys, keys...)
+	return nil
+}
+
+func (r *recordingCache) Increment(_ context.Context, key string, _ int64) (int64, error) {
+	r.keys = append(r.keys, key)
+	return 0, nil
+}
+
+func TestNamespacePrefixesCallerKeysAsIs(t *testing.T) {
+	inner := &recordingCache{}
+	c := Namespace("gombit:test", inner)
+	ctx := context.Background()
+
+	if err := c.Set(ctx, "foo", "a", 0); err != nil {
+		t.Fatalf("Set(foo) error = %v, want nil", err)
+	}
+	if err := c.Set(ctx, ":foo", "b", 0); err != nil {
+		t.Fatalf("Set(:foo) error = %v, want nil", err)
+	}
+	if err := c.Set(ctx, "::foo", "c", 0); err != nil {
+		t.Fatalf("Set(::foo) error = %v, want nil", err)
+	}
+	if _, err := c.Get(ctx, "foo", nil); err != nil {
+		t.Fatalf("Get(foo) error = %v, want nil", err)
+	}
+	if err := c.Delete(ctx, "foo", ":foo"); err != nil {
+		t.Fatalf("Delete() error = %v, want nil", err)
+	}
+	if _, err := c.Increment(ctx, ":foo", 1); err != nil {
+		t.Fatalf("Increment(:foo) error = %v, want nil", err)
+	}
+
+	want := []string{
+		"gombit:test:foo",
+		"gombit:test::foo",
+		"gombit:test:::foo",
+		"gombit:test:foo",
+		"gombit:test:foo",
+		"gombit:test::foo",
+		"gombit:test::foo",
+	}
+	if !reflect.DeepEqual(inner.keys, want) {
+		t.Fatalf("namespaced keys = %#v, want %#v", inner.keys, want)
+	}
+}
+
+func TestNamespaceDoesNotCollapseKeysDifferingByLeadingColons(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.Default().Cache
+	cfg.Driver = config.CacheDriverMemory
+	cfg.Namespace = "gombit:test"
+
+	store, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("Open() error = %v, want nil", err)
+	}
+
+	if err := store.Set(ctx, "foo", "a", 0); err != nil {
+		t.Fatalf("Set(foo) error = %v, want nil", err)
+	}
+	if err := store.Set(ctx, ":foo", "b", 0); err != nil {
+		t.Fatalf("Set(:foo) error = %v, want nil", err)
+	}
+
+	var got string
+	found, err := store.Get(ctx, "foo", &got)
+	if err != nil {
+		t.Fatalf("Get(foo) error = %v, want nil", err)
+	}
+	if !found {
+		t.Fatal("Get(foo) found = false, want true")
+	}
+	if got != "a" {
+		t.Fatalf("Get(foo) = %q, want %q (Set(\":foo\") must not overwrite foo)", got, "a")
+	}
+
+	found, err = store.Get(ctx, ":foo", &got)
+	if err != nil {
+		t.Fatalf("Get(:foo) error = %v, want nil", err)
+	}
+	if !found {
+		t.Fatal("Get(:foo) found = false, want true")
+	}
+	if got != "b" {
+		t.Fatalf("Get(:foo) = %q, want %q", got, "b")
+	}
+
+	if err := store.Delete(ctx, ":foo"); err != nil {
+		t.Fatalf("Delete(:foo) error = %v, want nil", err)
+	}
+	found, err = store.Get(ctx, "foo", &got)
+	if err != nil {
+		t.Fatalf("Get(foo) after Delete(:foo) error = %v, want nil", err)
+	}
+	if !found || got != "a" {
+		t.Fatalf("Get(foo) after Delete(:foo) = (%t, %q), want (true, a)", found, got)
+	}
+}

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -66,5 +66,7 @@ when configured namespacing is required.
 | `GOMBIT_REDIS_TLS_INSECURE` | `Config.Cache.Redis.TLSInsecure` | `false` |
 
 Cache keys opened through `cache.Open` are prefixed with the configured
-namespace. When no namespace is configured explicitly, `config.Load` derives it
-from the normalized app name and environment, such as `gombit:development`.
+namespace. Caller keys are prefixed as-is: leading colons are not stripped, so
+`foo` and `:foo` occupy distinct slots. When no namespace is configured
+explicitly, `config.Load` derives it from the normalized app name and
+environment, such as `gombit:development`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #133

Namespaced cache keys collapsed caller keys that differed only by leading colons. `namespaced.key` used `strings.TrimLeft(key, ":")`, so `foo`, `:foo`, and `::foo` all mapped to the same Redis/memory slot.

This change prefixes caller keys as-is. The namespace still trims surrounding colons before wrapping (`Namespace("::gombit::")` is still `gombit`).

## Acceptance criteria

- [x] `Set("foo", "a")` then `Set(":foo", "b")` leaves `Get("foo")` as `"a"`
- [x] `foo`, `:foo`, and `::foo` produce distinct namespaced keys (`ns:foo`, `ns::foo`, `ns:::foo`)
- [x] Delete of `:foo` does not remove `foo`
- [x] Regression tests: `TestNamespaceDoesNotCollapseKeysDifferingByLeadingColons`, `TestNamespacePrefixesCallerKeysAsIs`

## Scope notes

Nested namespaces that already contain `:` can still collide by construction (`Namespace("gombit")` + `development:x` vs `Namespace("gombit:development")` + `x`). That is the separator contract, not this bug. This PR only stops folding keys that differ by leading colons.

## Validation

- [x] `go test ./cache` (pass after the fix; the new tests failed before removing `TrimLeft`)
- [ ] `go test ./...` (CI)
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (CI)
- [ ] Project `code-review` skill run against this diff (after CI is green)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (N/A — in-memory cache key prefixing, no DB)
- [x] Stable features ship docs and appear in an example app (`docs/cache.md` notes that caller keys are prefixed as-is)
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) (N/A — no generator changes)
- [x] API changes regenerate the OpenAPI doc + TS client in this PR (N/A — no API/OpenAPI change)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public (N/A — no frontend)
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

