### PR TITLE
fix: Close HTTP server when graceful shutdown times out

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -23,9 +23,12 @@ return framework.Run(app)
 
 Start hooks run in registration order. Stop hooks run in reverse registration
 order so cleanup unwinds deterministically. Stop hooks receive a bounded
-shutdown context; the default timeout is 10 seconds. Stop hooks also run after
-a start-hook failure, so they must tolerate partial application startup and be
-safe to call when the resource they clean up was never initialized.
+shutdown context; the default timeout is 10 seconds. If `http.Server.Shutdown`
+hits that deadline while handlers are still in flight, Gombit calls
+`server.Close()` so remaining connections are dropped and `Run`/`RunContext`
+can return. Stop hooks also run after a start-hook failure, so they must
+tolerate partial application startup and be safe to call when the resource
+they clean up was never initialized.
 
 `RunContext` binds the listener before start hooks run, which lets hooks read
 `App.Addr()` even when the configured HTTP address uses port `0`. The HTTP
@@ -60,7 +63,7 @@ steps that need their own runtime surfaces.
 | 11. readiness/liveness endpoints | Basic raw Gin probes are owned in M1-2; DB/cache-aware readiness is deferred to M1-4/M1-5. |
 | 12. frontend static asset mounting when embedded | Owned in M5-5 through `framework.WithEmbeddedFrontend` (application SPA) and ADMIN-2 through explicit `/admin` Gin routes over `internal/adminui` embed. Application SPA fallback is installed only when the FS has `index.html`; the `gombit new` placeholder embed (`.keep` only) is a no-op so `go run ./cmd/server` works without a Vite `dist`. Admin `/admin/` is cookie-mode only. See [`docs/build.md`](build.md) and [`docs/admin.md`](admin.md). |
 | 13. signal handling | Owned in M1-2 through `framework.Run`. |
-| 14. graceful shutdown | Owned in M1-2 through bounded `http.Server.Shutdown`. |
+| 14. graceful shutdown | Owned in M1-2 through bounded `http.Server.Shutdown`; on timeout, `server.Close()` drops remaining connections so `Run`/`RunContext` can return with `Serve` stopped. |
 | 15. dependency cleanup | Owned in M1-2 through `OnStop`; concrete DB/cache/log sink cleanup lands with those features. |
 
 The current probes are raw Gin routes with D10-style success bodies. They must

--- a/framework/app.go
+++ b/framework/app.go
@@ -375,13 +375,11 @@ func RunContext(ctx context.Context, app *App) error {
 
 	select {
 	case <-ctx.Done():
-		if err := app.shutdown(); err != nil {
-			return err
+		err := app.shutdown()
+		if serveErr := <-serverErr; serveErr != nil {
+			err = errors.Join(err, fmt.Errorf("framework: serve: %w", serveErr))
 		}
-		if err := <-serverErr; err != nil {
-			return fmt.Errorf("framework: serve: %w", err)
-		}
-		return nil
+		return err
 	case err := <-serverErr:
 		stopErr := app.runStopHooks()
 		if err != nil {
@@ -430,6 +428,7 @@ func (a *App) shutdown() error {
 
 	if server != nil {
 		if err := server.Shutdown(shutdownCtx); err != nil {
+			_ = server.Close()
 			return errors.Join(
 				fmt.Errorf("framework: shutdown: %w", err),
 				a.runStopHooksWithContext(shutdownCtx),

--- a/framework/app_test.go
+++ b/framework/app_test.go
@@ -10,11 +10,70 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/gombit-dev/gombit/config"
 	"github.com/gombit-dev/gombit/database"
-	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
+
+func TestRunContextClosesServerAfterShutdownTimeout(t *testing.T) {
+	app := newTestApp(t, WithShutdownTimeout(200*time.Millisecond))
+	started := make(chan struct{})
+	var startOnce sync.Once
+	app.Router().GET("/slow", func(c *gin.Context) {
+		startOnce.Do(func() { close(started) })
+		time.Sleep(5 * time.Second)
+		c.Status(http.StatusOK)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- RunContext(ctx, app)
+	}()
+
+	waitForHTTP(t, app, "/livez")
+
+	reqDone := make(chan error, 1)
+	go func() {
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Get("http://" + app.Addr() + "/slow")
+		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+		reqDone <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow handler did not start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("RunContext() error = nil, want shutdown timeout")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("RunContext() error = %v, want context.DeadlineExceeded", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunContext() did not return after shutdown timeout")
+	}
+
+	select {
+	case err := <-reqDone:
+		if err == nil {
+			t.Fatal("in-flight GET /slow error = nil, want connection closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight GET /slow still held after RunContext returned; server.Close() was not called")
+	}
+}
 
 func TestRunContextBootsAndShutsDown(t *testing.T) {
 	app := newTestApp(t)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #134

On SIGTERM / `RunContext` cancel, `framework.shutdown` calls `http.Server.Shutdown` with a bounded context. If that deadline expires, Go's `Shutdown` does not close remaining connections. Gombit then returned without `server.Close()`, so handlers that ignore `Request.Context()` kept the connection alive after `Run`/`RunContext` had already returned.

This change:

- calls `server.Close()` when `Shutdown` returns an error (typically `context.DeadlineExceeded`)
- always waits for `Serve` after shutdown so `RunContext` does not return while the accept loop is still finishing

## Acceptance criteria

- [x] Handler that ignores `Request.Context()` and sleeps past the shutdown timeout no longer holds the connection after `RunContext` returns
- [x] `RunContext` still returns `context.DeadlineExceeded` on that path
- [x] Successful graceful shutdown (no in-flight work) is unchanged (`TestRunContextBootsAndShutsDown`)
- [x] Regression test: `TestRunContextClosesServerAfterShutdownTimeout`

## Scope notes

Stop hooks still receive the same bounded (and, on timeout, already expired) shutdown context. This PR does not change hook semantics.

## Validation

- [x] `go test ./framework ./dev` (new test failed before `Close()`; passed after)
- [ ] `go test ./...` (CI)
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (CI)
- [ ] Project `code-review` skill run against this diff (after CI is green)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (N/A — HTTP lifecycle, no DB)
- [x] Stable features ship docs and appear in an example app (`docs/lifecycle.md`)
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) (N/A — no generator changes)
- [x] API changes regenerate the OpenAPI doc + TS client in this PR (N/A — no API/OpenAPI change)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public (N/A — no frontend)
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eb88a40-b7ad-4972-b695-1e06b1fd8282&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

