### PR TITLE
ci: add Merge Warden PR review workflow

### DIFF
--- a/.github/workflows/merge-warden.yml
+++ b/.github/workflows/merge-warden.yml
@@ -1,0 +1,59 @@
+name: Merge Warden
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  review:
+    name: Merge Warden
+
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
+
+    steps:
+      # workflow_run executes from the trusted default branch.
+      # Never checkout or execute the PR head here.
+      - name: Checkout trusted default branch
+        uses: actions/checkout@v7
+
+      - name: Resolve pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          pr_number="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+              --jq '.[0].number // empty'
+          )"
+
+          if [ -z "$pr_number" ]; then
+            echo "::error::Could not resolve PR for ${HEAD_SHA}"
+            exit 1
+          fi
+
+          echo "number=${pr_number}" >> "$GITHUB_OUTPUT"
+
+      - name: Review PR
+        uses: leo-aa88/merge-warden@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          xai-api-key: ${{ secrets.XAI_API_KEY }}
+          pr-number: ${{ steps.pr.outputs.number }}
+          expected-head-sha: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Summary

- Adds a `Merge Warden` GitHub Actions workflow, ported from
  [Brainrotlang/brainrot](https://github.com/Brainrotlang/brainrot/blob/main/.github/workflows/merge-warden.yml).
- Triggers via `workflow_run` after the `CI` workflow completes successfully
  on a pull request, resolves the PR number from the run's head SHA, and
  runs `leo-aa88/merge-warden@v1` to post an automated review.
- Uses `workflow_run` (not `pull_request_target`) so the review step always
  executes from the trusted default branch, never the PR head — same
  security posture as upstream.

No linked issue: this is repo tooling/CI infrastructure, not a
`docs/GOMBIT_BUILD_PLAN.md` §4 backlog item.

## Acceptance criteria

N/A — no linked issue (see Summary).

## Scope notes

- Adapted from upstream: `ubuntu-24.04` → `ubuntu-latest` and the trigger
  workflow name `Brainrot CI` → `CI` to match this repo's existing
  [ci.yml](.github/workflows/ci.yml).
- Requires a repo secret `XAI_API_KEY` (xAI/Grok API key) to be configured
  by a repo admin under Settings → Secrets and variables → Actions before
  this workflow can run successfully. `GITHUB_TOKEN` is used as-is with no
  extra setup.

## Validation

- [x] `actionlint` not run (not installed locally) — workflow YAML
      structure mirrors the upstream file verbatim aside from the two
      naming changes noted above.
- [ ] `go test ./...` — N/A, no Go code changed
- [ ] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — N/A, no Go code changed
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [ ] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A, CI workflow file only, not app behavior
- [ ] Stable features ship docs and appear in an example app — N/A, CI tooling
- [ ] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests — N/A
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — N/A
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no API change
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public — N/A
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n) — pure CI infra, no product scope added
- [ ] This PR links its issue and states which acceptance criteria it satisfies — no backlog issue exists for this; flagging per AGENTS.md rather than inventing one