### PR TITLE
feat: BENCH-1 real Gombit CRUD app + cross-implementation fairness check (Phase 3b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,32 @@ jobs:
             -database.dsn \
             'postgres://gombit:gombit@127.0.0.1:5432/gombit_bench?sslmode=disable'
 
+      # A third, separate database: the gombit benchmark app applies its
+      # schema via a real Atlas migration (committed under
+      # benchmarks/apps/gombit/database/migrations/), not AutoMigrate, so it
+      # can't safely share gombit_bench's already-AutoMigrate'd tables
+      # either.
+      - name: Create gombit benchmark app database
+        run: |
+          PGPASSWORD=gombit psql -h 127.0.0.1 -U gombit -d gombit \
+            -c 'CREATE DATABASE gombit_bench_gombit;'
+
+      - name: Install Atlas CLI
+        run: curl -sSf https://atlasgo.sh | sh -s -- --community
+
+      - name: Apply gombit benchmark app migration
+        working-directory: benchmarks/apps/gombit
+        env:
+          GOMBIT_DATABASE_DRIVER: postgres
+          GOMBIT_DATABASE_DSN: postgres://gombit:gombit@127.0.0.1:5432/gombit_bench_gombit?sslmode=disable
+        run: go run github.com/gombit-dev/gombit/cmd/gombit db migrate
+
+      - name: Run gombit benchmark app integration tests
+        run: |
+          go test -tags integration ./benchmarks/apps/gombit/... \
+            -database.dsn \
+            'postgres://gombit:gombit@127.0.0.1:5432/gombit_bench_gombit?sslmode=disable'
+
   database-mysql:
     name: Database (mysql)
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,9 +199,18 @@ jobs:
           GOMBIT_DATABASE_DSN: postgres://gombit:gombit@127.0.0.1:5432/gombit_bench_gombit?sslmode=disable
         run: go run github.com/gombit-dev/gombit/cmd/gombit db migrate
 
+      # -p 1: this expands to two packages (benchmarks/apps/gombit and its
+      # internal/project), each a separate test binary that TRUNCATEs the
+      # same gombit_bench_gombit tables at the start of every test. go test
+      # runs different packages' binaries in parallel by default (bounded by
+      # -p, which defaults to GOMAXPROCS) — reproduced locally by racing the
+      # two binaries against one database directly: both failed on every one
+      # of 15 runs (one package's TRUNCATE landing mid-assertion in the
+      # other). -p 1 serializes the two binaries so only one truncates the
+      # shared tables at a time.
       - name: Run gombit benchmark app integration tests
         run: |
-          go test -tags integration ./benchmarks/apps/gombit/... \
+          go test -tags integration -p 1 ./benchmarks/apps/gombit/... \
             -database.dsn \
             'postgres://gombit:gombit@127.0.0.1:5432/gombit_bench_gombit?sslmode=disable'
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,14 +17,16 @@ benchmarks/
 │   ├── huma/              bare Huma-over-Gin row
 │   └── gombit/             full framework.App row
 └── apps/                 canonical realistic-application CRUD comparison (Phase 3)
-    ├── shared/             response-shape types common to the Go implementations
-    └── gin-gorm/            primary framework-tax control — see its own README
+    ├── shared/             response-shape + seed-content types common to both Go implementations
+    ├── gin-gorm/            primary framework-tax control — see its own README
+    ├── gombit/              real Gombit app (Huma, Atlas migrations) — see its own README
+    └── fairness_test.go     cross-implementation check: builds and runs both real binaries, compares over HTTP
 ```
 
 Everything else in the suite's target layout (`workloads/`, `scripts/`,
-`config/`, `results/`, `docs/methodology.md`, `Makefile`, and the `gombit`,
-`django`, `rails`, `laravel`, `nestjs` implementations under `apps/`) is
-scoped to later phases of the plan above and doesn't exist yet.
+`config/`, `results/`, `docs/methodology.md`, `Makefile`, and the `django`,
+`rails`, `laravel`, `nestjs` implementations under `apps/`) is scoped to
+later phases of the plan above and doesn't exist yet.
 
 ## Running the framework-tax matrix
 

--- a/benchmarks/apps/fairness_test.go
+++ b/benchmarks/apps/fairness_test.go
@@ -1,0 +1,177 @@
+//go:build integration
+
+// Package apps_test holds the cross-implementation fairness check (issue
+// #141 §15): the same paginated record count, the same ordered IDs and
+// content for a known query, and the same route surface for a not-found
+// request. It builds and runs the real gin-gorm and gombit binaries against
+// their own already-seeded databases and compares them over HTTP — not by
+// importing their internals — because gin-gorm is package main (not
+// importable) and gombit's routes only exist behind its own framework.App.
+// This is also the only shape of comparison that will still work once
+// Phase 4 adds Django/Rails/Laravel/NestJS: two Go packages sharing
+// internals is not a pattern those can participate in.
+package apps_test
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/gombit-dev/gombit/benchmarks/apps/shared"
+)
+
+// Both databases must already be seeded with the canonical dataset
+// (`go run ./benchmarks/apps/gin-gorm -seed` /
+// `go run ./benchmarks/apps/gombit -seed`) and, for gombit, already
+// Atlas-migrated (see benchmarks/apps/gombit/internal/project/handler_test.go's
+// doc comment) — this test seeds nothing itself, matching real deployment
+// order (migrate/seed is a deploy step, this is a runtime check).
+var (
+	ginGormDSN = flag.String("gin-gorm.dsn", "", "PostgreSQL DSN for the already-seeded gin-gorm app")
+	gombitDSN  = flag.String("gombit.dsn", "", "PostgreSQL DSN for the already-migrated, already-seeded gombit app")
+)
+
+// TestCrossImplementationFairness is the Phase 3b fairness check
+// docs/plans/BENCH-1-benchmark-suite.md describes: same paginated record
+// count, same ordered IDs and content for a known query (page 1 of the
+// canonical seed), and same route surface for a not-found id. Timestamps
+// are excluded from the row comparison: each binary was seeded at a
+// different real wall-clock time, so CreatedAt/UpdatedAt legitimately
+// differ — content and ordering do not.
+func TestCrossImplementationFairness(t *testing.T) {
+	if *ginGormDSN == "" || *gombitDSN == "" {
+		t.Skip("set -gin-gorm.dsn and -gombit.dsn to run the cross-implementation fairness check")
+	}
+
+	ginGormAddr := startApp(t, "gin-gorm", "./gin-gorm", "18091", *ginGormDSN)
+	gombitAddr := startApp(t, "gombit", "./gombit", "18090", *gombitDSN)
+
+	ginGormPage := fetchPage(t, ginGormAddr, "/api/projects?page=1&limit=20")
+	gombitPage := fetchPage(t, gombitAddr, "/api/projects?page=1&limit=20")
+
+	if ginGormPage.Meta != gombitPage.Meta {
+		t.Fatalf("page meta differs: gin-gorm=%+v gombit=%+v", ginGormPage.Meta, gombitPage.Meta)
+	}
+	if len(ginGormPage.Data) != len(gombitPage.Data) {
+		t.Fatalf("page length differs: gin-gorm=%d gombit=%d", len(ginGormPage.Data), len(gombitPage.Data))
+	}
+	for i := range ginGormPage.Data {
+		a, b := stripTimestamps(ginGormPage.Data[i]), stripTimestamps(gombitPage.Data[i])
+		if a != b {
+			t.Fatalf("row %d differs (timestamps excluded): gin-gorm=%+v gombit=%+v", i, a, b)
+		}
+	}
+
+	// Same route surface: a nonexistent id 404s on both, not just one.
+	for _, addr := range []string{ginGormAddr, gombitAddr} {
+		if code := getStatus(t, addr, "/api/projects/999999999"); code != http.StatusNotFound {
+			t.Fatalf("%s: GET nonexistent id status = %d, want %d", addr, code, http.StatusNotFound)
+		}
+	}
+}
+
+func stripTimestamps(p shared.ProjectData) shared.ProjectData {
+	p.CreatedAt, p.UpdatedAt = time.Time{}, time.Time{}
+	return p
+}
+
+type pageEnvelope struct {
+	Data []shared.ProjectData `json:"data"`
+	Meta shared.PageMeta      `json:"meta"`
+}
+
+func fetchPage(t *testing.T, addr, path string) pageEnvelope {
+	t.Helper()
+	body := getBody(t, addr, path)
+	var env pageEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("decode %s%s: %v; body: %s", addr, path, err, body)
+	}
+	return env
+}
+
+func getBody(t *testing.T, addr, path string) []byte {
+	t.Helper()
+	resp, err := http.Get("http://" + addr + path)
+	if err != nil {
+		t.Fatalf("GET %s%s: %v", addr, path, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read GET %s%s body: %v", addr, path, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s%s status = %d; body: %s", addr, path, resp.StatusCode, body)
+	}
+	return body
+}
+
+func getStatus(t *testing.T, addr, path string) int {
+	t.Helper()
+	resp, err := http.Get("http://" + addr + path)
+	if err != nil {
+		t.Fatalf("GET %s%s: %v", addr, path, err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// startApp builds and runs one implementation's binary against dsn on port,
+// waits for /livez, and returns its address. The process is killed via
+// t.Cleanup.
+func startApp(t *testing.T, name, pkgDir, port, dsn string) string {
+	t.Helper()
+
+	binPath := t.TempDir() + "/" + name
+	build := exec.Command("go", "build", "-o", binPath, pkgDir)
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build %s: %v\n%s", name, err, out)
+	}
+
+	cmd := exec.Command(binPath)
+	cmd.Env = append(cmd.Environ(), "DATABASE_URL="+dsn, "PORT="+port)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %s: %v", name, err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	addr := "127.0.0.1:" + port
+	waitForHealth(t, name, addr)
+	return addr
+}
+
+func waitForHealth(t *testing.T, name, addr string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("%s did not become healthy on %s within 10s", name, addr)
+		default:
+		}
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			resp, err := http.Get(fmt.Sprintf("http://%s/livez", addr))
+			if err == nil {
+				_ = resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					return
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/benchmarks/apps/fairness_test.go
+++ b/benchmarks/apps/fairness_test.go
@@ -45,6 +45,15 @@ var (
 // are excluded from the row comparison: each binary was seeded at a
 // different real wall-clock time, so CreatedAt/UpdatedAt legitimately
 // differ — content and ordering do not.
+//
+// The relative comparison (gin-gorm's page equals gombit's page) is
+// necessary but not sufficient: two empty, unseeded databases satisfy it
+// too, by both returning total=0/data=[]. assertCanonicalSeed pins each
+// side against the actual canonical dataset — shared.SeedProjectCount,
+// shared.ProjectName, shared.ProjectOwnerID, the id-DESC insert order —
+// before the two are ever compared to each other, so an empty or
+// wrongly-seeded pair fails here regardless of whether it happens to agree
+// with itself.
 func TestCrossImplementationFairness(t *testing.T) {
 	if *ginGormDSN == "" || *gombitDSN == "" {
 		t.Skip("set -gin-gorm.dsn and -gombit.dsn to run the cross-implementation fairness check")
@@ -55,6 +64,9 @@ func TestCrossImplementationFairness(t *testing.T) {
 
 	ginGormPage := fetchPage(t, ginGormAddr, "/api/projects?page=1&limit=20")
 	gombitPage := fetchPage(t, gombitAddr, "/api/projects?page=1&limit=20")
+
+	assertCanonicalSeed(t, "gin-gorm", ginGormPage)
+	assertCanonicalSeed(t, "gombit", gombitPage)
 
 	if ginGormPage.Meta != gombitPage.Meta {
 		t.Fatalf("page meta differs: gin-gorm=%+v gombit=%+v", ginGormPage.Meta, gombitPage.Meta)
@@ -74,6 +86,41 @@ func TestCrossImplementationFairness(t *testing.T) {
 		if code := getStatus(t, addr, "/api/projects/999999999"); code != http.StatusNotFound {
 			t.Fatalf("%s: GET nonexistent id status = %d, want %d", addr, code, http.StatusNotFound)
 		}
+	}
+}
+
+// assertCanonicalSeed checks one implementation's page-1 response against
+// the actual canonical dataset (benchmarks/docs/schema.md), independent of
+// what the other implementation returns — the oracle the relative
+// comparison in TestCrossImplementationFairness alone can't provide.
+func assertCanonicalSeed(t *testing.T, label string, page pageEnvelope) {
+	t.Helper()
+
+	if page.Meta.Total != shared.SeedProjectCount {
+		t.Fatalf("%s: meta.total = %d, want %d (canonical seed size — is this database actually seeded?)",
+			label, page.Meta.Total, shared.SeedProjectCount)
+	}
+	if len(page.Data) != 20 {
+		t.Fatalf("%s: len(data) = %d, want 20 (page size)", label, len(page.Data))
+	}
+
+	// id DESC, sequential insert: page 1 starts at the last seeded project.
+	last := shared.SeedProjectCount
+	first := page.Data[0]
+	if first.Name != shared.ProjectName(last) {
+		t.Fatalf("%s: data[0].Name = %q, want %q (last seeded project — wrong seed content or wrong ordering)",
+			label, first.Name, shared.ProjectName(last))
+	}
+	if first.Description != shared.ProjectDescription(last) {
+		t.Fatalf("%s: data[0].Description = %q, want %q", label, first.Description, shared.ProjectDescription(last))
+	}
+	wantOwner := shared.ProjectOwnerID(last, shared.SeedUserCount)
+	if first.OwnerID != wantOwner {
+		t.Fatalf("%s: data[0].OwnerID = %d, want %d (round-robin owner of the last seeded project)",
+			label, first.OwnerID, wantOwner)
+	}
+	if first.OwnerName != shared.UserName(int(wantOwner)) {
+		t.Fatalf("%s: data[0].OwnerName = %q, want %q", label, first.OwnerName, shared.UserName(int(wantOwner)))
 	}
 }
 
@@ -137,6 +184,15 @@ func startApp(t *testing.T, name, pkgDir, port, dsn string) string {
 	}
 
 	cmd := exec.Command(binPath)
+	// Appending, not prepending or stripping first, is deliberate and safe
+	// even if the parent process already exports DATABASE_URL/PORT (both
+	// apps document that env var name, so a caller's shell easily could):
+	// os/exec.Cmd.Start dedupes cmd.Env before exec, keeping the *last*
+	// occurrence of each key (os/exec/exec.go's dedupEnvCase, "Construct
+	// the output in reverse order, to preserve the last occurrence of each
+	// key") — verified directly, including with a real child process
+	// reading via os.Getenv while the parent had DATABASE_URL set to a
+	// different value. These appended values always win.
 	cmd.Env = append(cmd.Environ(), "DATABASE_URL="+dsn, "PORT="+port)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start %s: %v", name, err)

--- a/benchmarks/apps/gin-gorm/README.md
+++ b/benchmarks/apps/gin-gorm/README.md
@@ -31,10 +31,9 @@ Env vars (all optional, defaults match `benchmarks/compose.yml`):
 ## Test
 
 ```sh
-# pure unit tests (seed content formulas) — no DB, no build tag
-go test ./benchmarks/apps/gin-gorm/...
-
-# full suite, needs a live PostgreSQL instance
+# needs a live PostgreSQL instance — this package has no non-integration
+# test files of its own; the seed-content formulas it shares with gombit
+# are tested once in benchmarks/apps/shared
 docker compose -f benchmarks/compose.yml up -d postgres
 go test -tags integration ./benchmarks/apps/gin-gorm/... \
   -database.dsn "postgres://gombit:gombit@127.0.0.1:55432/gombit_bench?sslmode=disable"
@@ -58,19 +57,24 @@ boundary; query-count regression guards for both a non-empty page
 (`TestListDoesNotN1`, exactly 3 SQL statements — count, page, one batched
 owner `IN (...)` preload, not one owner query per row) and an empty one
 (`TestListDoesNotN1EmptyPage`, exactly 2 — no rows means no owners to
-preload); and the seed contract itself — deterministic content formulas
-(`TestSeedContentIsDeterministic`, `TestProjectOwnerIDRoundRobin`, no DB
-needed) and the real truncate-then-seed path run twice at reduced scale to
-confirm it's idempotent rather than accumulating duplicate data
-(`TestSeedDatabaseNIsIdempotentAndCorrect`).
+preload); and the seed contract's own DB-backed half — the real
+truncate-then-seed path run twice at reduced scale to confirm it's
+idempotent rather than accumulating duplicate data
+(`TestSeedDatabaseNIsIdempotentAndCorrect`). The seed content formulas
+themselves (`UserEmail`, `ProjectOwnerID`, ...) and their pure,
+no-database tests (`TestSeedContentIsDeterministic`,
+`TestProjectOwnerIDRoundRobin`) live in
+[../shared](../shared) — shared with `gombit` so the two apps can't
+silently seed different content for the same row N.
 
 ## Status
 
-Schema, seed, and this control app are done. Still open (tracked in
-[docs/plans/BENCH-1-benchmark-suite.md](../../../docs/plans/BENCH-1-benchmark-suite.md)
-Phase 3): the `gombit` app implementing the same API, and the
-cross-implementation fairness checks (same route surface, same JSON shape,
-same query count) that only make sense once a second implementation exists
-to compare against. `benchmarks/compose.yml` currently only runs the
-`postgres` service; an app service for this container is added once
-resource-limit parity across implementations is being measured, not before.
+Schema, seed, this control app, the `gombit` app implementing the same API,
+and the cross-implementation fairness check comparing them are all done
+(tracked in [docs/plans/BENCH-1-benchmark-suite.md](../../../docs/plans/BENCH-1-benchmark-suite.md)
+Phase 3). See [../gombit/README.md](../gombit/README.md) for the Gombit-side
+details, including one discovered framework gap and two bugs the fairness
+comparison caught. Still open: wiring the fairness check into automated CI
+(it needs both databases at the full canonical 1,000/100,000 scale, deferred
+to Phase 8's lighter-seed CI work) and `benchmarks/compose.yml` app services
+for both apps — currently only the `postgres` service runs.

--- a/benchmarks/apps/gin-gorm/main_test.go
+++ b/benchmarks/apps/gin-gorm/main_test.go
@@ -382,8 +382,8 @@ func TestSeedDatabaseNIsIdempotentAndCorrect(t *testing.T) {
 		if err := db.First(&firstUser, 1).Error; err != nil {
 			t.Fatalf("run %d: load user 1: %v", run, err)
 		}
-		if firstUser.Email != userEmail(1) || firstUser.Name != userName(1) {
-			t.Fatalf("run %d: user 1 = %+v, want email=%s name=%s", run, firstUser, userEmail(1), userName(1))
+		if firstUser.Email != shared.UserEmail(1) || firstUser.Name != shared.UserName(1) {
+			t.Fatalf("run %d: user 1 = %+v, want email=%s name=%s", run, firstUser, shared.UserEmail(1), shared.UserName(1))
 		}
 
 		// Project userCount+1 (8th project, userCount=7) is the first to
@@ -396,8 +396,8 @@ func TestSeedDatabaseNIsIdempotentAndCorrect(t *testing.T) {
 		if wrapped.OwnerID != 1 {
 			t.Fatalf("run %d: project %d owner = %d, want 1 (round-robin wrap)", run, userCount+1, wrapped.OwnerID)
 		}
-		if wrapped.Name != projectName(userCount+1) {
-			t.Fatalf("run %d: project %d name = %q, want %q", run, userCount+1, wrapped.Name, projectName(userCount+1))
+		if wrapped.Name != shared.ProjectName(userCount+1) {
+			t.Fatalf("run %d: project %d name = %q, want %q", run, userCount+1, wrapped.Name, shared.ProjectName(userCount+1))
 		}
 	}
 }
@@ -425,8 +425,7 @@ func seedFixture(t *testing.T, db *gorm.DB, userCount, projectCount int) {
 		}
 	}
 	for i := 1; i <= projectCount; i++ {
-		ownerID := uint((i-1)%userCount + 1)
-		if err := db.Create(&Project{OwnerID: ownerID, Name: fmt.Sprintf("Fixture Project %d", i), Description: "fixture"}).Error; err != nil {
+		if err := db.Create(&Project{OwnerID: shared.ProjectOwnerID(i, userCount), Name: fmt.Sprintf("Fixture Project %d", i), Description: "fixture"}).Error; err != nil {
 			t.Fatalf("seed fixture project %d: %v", i, err)
 		}
 	}

--- a/benchmarks/apps/gin-gorm/seed.go
+++ b/benchmarks/apps/gin-gorm/seed.go
@@ -4,33 +4,33 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gombit-dev/gombit/benchmarks/apps/shared"
 	"gorm.io/gorm"
 )
 
-// seedUserCount/seedProjectCount are the issue's recommended initial
-// dataset (benchmarks/docs/schema.md "Seed dataset").
-const (
-	seedUserCount    = 1000
-	seedProjectCount = 100000
-	seedBatchSize    = 1000
-)
+// seedBatchSize is a gin-gorm-specific implementation detail (how many rows
+// per INSERT), not part of the cross-implementation seed contract, so it
+// stays local rather than moving to benchmarks/apps/shared with the
+// content formulas and row counts.
+const seedBatchSize = 1000
 
 // seedDatabase truncates and repopulates the canonical benchmark dataset at
 // production scale. See seedDatabaseN.
 func seedDatabase(ctx context.Context, db *gorm.DB) error {
-	return seedDatabaseN(ctx, db, seedUserCount, seedProjectCount)
+	return seedDatabaseN(ctx, db, shared.SeedUserCount, shared.SeedProjectCount)
 }
 
 // seedDatabaseN is seedDatabase parameterized by row counts, so tests can
 // exercise the real truncate-then-seed path (including idempotency) at a
 // small scale instead of paying for a 100,000-row insert in CI.
 // seedDatabase always calls this with the canonical
-// seedUserCount/seedProjectCount; tests call it directly with small counts.
+// shared.SeedUserCount/SeedProjectCount; tests call it directly with small
+// counts.
 //
 // Truncating first (RESTART IDENTITY) makes repeated invocations idempotent
 // instead of accumulating duplicate data, and resets the users sequence to
-// 1 so projectOwnerID's round-robin computation stays correct without
-// reading back generated IDs.
+// 1 so shared.ProjectOwnerID's round-robin computation stays correct
+// without reading back generated IDs.
 func seedDatabaseN(ctx context.Context, db *gorm.DB, userCount, projectCount int) error {
 	if err := db.WithContext(ctx).Exec("TRUNCATE TABLE projects, users RESTART IDENTITY CASCADE").Error; err != nil {
 		return fmt.Errorf("truncate: %w", err)
@@ -44,7 +44,7 @@ func seedDatabaseN(ctx context.Context, db *gorm.DB, userCount, projectCount int
 func seedUsersN(ctx context.Context, db *gorm.DB, userCount int) error {
 	batch := make([]User, 0, seedBatchSize)
 	for i := 1; i <= userCount; i++ {
-		batch = append(batch, User{Email: userEmail(i), Name: userName(i)})
+		batch = append(batch, User{Email: shared.UserEmail(i), Name: shared.UserName(i)})
 		if len(batch) == seedBatchSize || i == userCount {
 			if err := db.WithContext(ctx).Create(&batch).Error; err != nil {
 				return fmt.Errorf("seed users: %w", err)
@@ -56,16 +56,16 @@ func seedUsersN(ctx context.Context, db *gorm.DB, userCount int) error {
 }
 
 // seedProjectsN distributes projects round-robin across users (project i
-// belongs to user projectOwnerID(i, userCount)), so every user owns
+// belongs to user shared.ProjectOwnerID(i, userCount)), so every user owns
 // projectCount/userCount projects and two implementations' seeded row N are
 // content-identical.
 func seedProjectsN(ctx context.Context, db *gorm.DB, userCount, projectCount int) error {
 	batch := make([]Project, 0, seedBatchSize)
 	for i := 1; i <= projectCount; i++ {
 		batch = append(batch, Project{
-			OwnerID:     projectOwnerID(i, userCount),
-			Name:        projectName(i),
-			Description: projectDescription(i),
+			OwnerID:     shared.ProjectOwnerID(i, userCount),
+			Name:        shared.ProjectName(i),
+			Description: shared.ProjectDescription(i),
 		})
 		if len(batch) == seedBatchSize || i == projectCount {
 			if err := db.WithContext(ctx).Create(&batch).Error; err != nil {
@@ -76,23 +76,3 @@ func seedProjectsN(ctx context.Context, db *gorm.DB, userCount, projectCount int
 	}
 	return nil
 }
-
-// userEmail, userName, projectOwnerID, projectName, and projectDescription
-// are the pure, deterministic-content formulas issue #141's seed dataset
-// requires ("the same values for every implementation"). Extracted to plain
-// functions (rather than left inline in the batch-building loops) so
-// TestSeedContentIsDeterministic can check the actual formulas directly,
-// without a database, instead of only exercising them indirectly through a
-// full seed run that no CI job executes.
-func userEmail(i int) string { return fmt.Sprintf("user-%04d@example.com", i) }
-func userName(i int) string  { return fmt.Sprintf("User %04d", i) }
-
-func projectOwnerID(i, userCount int) uint {
-	if i < 1 || userCount < 1 {
-		panic("projectOwnerID: i and userCount must be positive")
-	}
-	return uint((i-1)%userCount + 1) //nolint:gosec // i,userCount > 0 is checked above; (i-1)%userCount+1 is always in [1,userCount]
-}
-
-func projectName(i int) string        { return fmt.Sprintf("Project %06d", i) }
-func projectDescription(i int) string { return fmt.Sprintf("Seeded benchmark project %06d", i) }

--- a/benchmarks/apps/gombit/README.md
+++ b/benchmarks/apps/gombit/README.md
@@ -63,8 +63,13 @@ surface wouldn't have matched its own control.
 # pure unit tests — none of this package's own; the seed formulas it shares
 # with gin-gorm are tested in benchmarks/apps/shared
 
-# per-app integration suite, needs a live, already-migrated PostgreSQL instance
-go test -tags integration ./benchmarks/apps/gombit/... \
+# per-app integration suite, needs a live, already-migrated PostgreSQL
+# instance. -p 1 is required, not cosmetic: this expands to two packages
+# (this one and internal/project), each its own test binary, and both
+# TRUNCATE the same tables on every test's setup. Without -p 1, go test
+# runs those binaries in parallel (bounded by GOMAXPROCS) and one's
+# TRUNCATE can land mid-assertion in the other.
+go test -tags integration -p 1 ./benchmarks/apps/gombit/... \
   -database.dsn "postgres://gombit:gombit@127.0.0.1:55432/gombit_bench_gombit?sslmode=disable"
 
 # cross-implementation fairness check: builds and runs both real binaries,

--- a/benchmarks/apps/gombit/README.md
+++ b/benchmarks/apps/gombit/README.md
@@ -1,0 +1,119 @@
+# gombit
+
+The BENCH-1 Gombit-runtime implementation of the canonical `/api/projects`
+CRUD API (issue #141, [../../docs/schema.md](../../docs/schema.md)): a
+normal Gombit app — Huma handlers (`internal/project`), GORM, `framework.App`
+— using Gombit's normal public APIs unmodified, run in production mode.
+Compared against [`../gin-gorm`](../gin-gorm), the primary framework-tax
+control implementing the same API without Gombit.
+
+## Migrations
+
+Unlike `gin-gorm` (GORM `AutoMigrate`, its own idiomatic mechanism), this app
+uses Gombit's real migration path — Atlas, via `gombit db makemigrations`/
+`migrate` (AGENTS.md D3: never `AutoMigrate` for a real Gombit app). The
+generated migration is committed under `database/migrations/` like any real
+Gombit app's would be; regenerate it only if the models change:
+
+```sh
+cd benchmarks/apps/gombit
+go run github.com/gombit-dev/gombit/cmd/gombit db makemigrations create_projects \
+  --driver postgres \
+  --model github.com/gombit-dev/gombit/benchmarks/apps/gombit/internal/project.User \
+  --model github.com/gombit-dev/gombit/benchmarks/apps/gombit/internal/project.Project
+```
+
+## Run
+
+```sh
+docker compose -f benchmarks/compose.yml up -d postgres
+
+# create a database separate from gin-gorm's (see benchmarks/apps/gin-gorm/README.md
+# for why AutoMigrate and Atlas schemas shouldn't share a database) and migrate — once
+createdb -h 127.0.0.1 -p 55432 -U gombit gombit_bench_gombit
+cd benchmarks/apps/gombit
+GOMBIT_DATABASE_DRIVER=postgres \
+GOMBIT_DATABASE_DSN="postgres://gombit:gombit@127.0.0.1:55432/gombit_bench_gombit?sslmode=disable" \
+  go run github.com/gombit-dev/gombit/cmd/gombit db migrate
+
+# seed (1,000 users, 100,000 projects) — idempotent, truncates first
+go run . -seed
+
+# serve
+go run .
+```
+
+Env vars (all optional, defaults match `benchmarks/compose.yml`):
+
+| Var | Default | |
+| --- | --- | --- |
+| `DATABASE_URL` | `postgres://gombit:gombit@127.0.0.1:55432/gombit_bench_gombit?sslmode=disable` | |
+| `PORT` | `8080` | |
+| `POOL_MAX_OPEN` | `20` | issue #141 "Connection pooling" pins this to 20 across every implementation |
+| `POOL_MAX_IDLE` | `20` | |
+
+`cfg.API.Prefix` is set to `/api` in `main.go`, overriding Gombit's own
+`/api/v1` default — the canonical route spec and `gin-gorm` both use `/api`
+with no version segment; left at the framework default this app's own route
+surface wouldn't have matched its own control.
+
+## Test
+
+```sh
+# pure unit tests — none of this package's own; the seed formulas it shares
+# with gin-gorm are tested in benchmarks/apps/shared
+
+# per-app integration suite, needs a live, already-migrated PostgreSQL instance
+go test -tags integration ./benchmarks/apps/gombit/... \
+  -database.dsn "postgres://gombit:gombit@127.0.0.1:55432/gombit_bench_gombit?sslmode=disable"
+
+# cross-implementation fairness check: builds and runs both real binaries,
+# needs both databases already seeded (`-seed` on each app) — heavier than
+# the per-app suite, so it isn't wired into routine PR CI yet (see
+# docs/plans/BENCH-1-benchmark-suite.md Phase 3b); run it locally:
+go test -tags integration ./benchmarks/apps/ -run TestCrossImplementationFairness \
+  -gin-gorm.dsn "postgres://gombit:gombit@127.0.0.1:55432/gombit_bench?sslmode=disable" \
+  -gombit.dsn "postgres://gombit:gombit@127.0.0.1:55432/gombit_bench_gombit?sslmode=disable"
+```
+
+CI runs the per-app suite in `.github/workflows/ci.yml`'s `database-postgres`
+job, against a third database (`gombit_bench_gombit`) separate from both
+`gombit` (auth/database/admin) and `gombit_bench` (gin-gorm) — this app's
+`users`/`projects` tables come from a real Atlas migration, not
+`AutoMigrate`, so they shouldn't share a database with either.
+
+Covers the same contract `gin-gorm`'s suite does — full CRUD round trip,
+blank-name rejection on both create and update, pagination/ordering, and the
+3-query / 2-query (empty page) N+1 guard — plus one difference documented
+below.
+
+## A discovered framework gap, not a benchmark bug
+
+`POST /api/projects` with a nonexistent `owner_id` returns **500 internal**,
+not a 4xx client error. This app uses Gombit's normal
+`database.MapPersistError` (`github.com/gombit-dev/gombit/database`)
+unmodified, and that function only special-cases unique-constraint
+violations — a foreign-key violation falls through to `internal`.
+`gin-gorm`'s control implementation doesn't use that framework helper (see
+its README) and correctly maps the same input to 422.
+
+This is deliberately **not patched here**: issue #141 requires using
+Gombit's normal public APIs as-is ("do not bypass ... normal Gombit response
+handling"), and the entire point of this app is measuring what a real
+Gombit user gets today. `TestCreateInvalidOwnerIDReturnsInternalError` pins
+this actual behavior so a future framework fix (or regression) shows up
+here as an expected test change, not a mysterious fairness-check failure.
+Fixing `database.MapPersistError` itself is out of scope for BENCH-1 — see
+docs/plans/BENCH-1-benchmark-suite.md Phase 3b for the writeup and a
+pointer to file it as its own issue.
+
+## Status
+
+Implementation, migration, and both test suites are done and verified
+against real PostgreSQL (schema diffed statement-log-for-statement-log
+against `gin-gorm`'s N+1 behavior, and cross-checked live via
+`TestCrossImplementationFairness`). Still open (tracked in
+[docs/plans/BENCH-1-benchmark-suite.md](../../../docs/plans/BENCH-1-benchmark-suite.md)
+Phase 3b): wiring the cross-implementation fairness check into CI (needs a
+lighter seed-size mechanism than the canonical 1,000/100,000, which is
+Phase 8's concern), and `benchmarks/compose.yml` app services for both apps.

--- a/benchmarks/apps/gombit/database/migrations/20260826020335_create_projects.sql
+++ b/benchmarks/apps/gombit/database/migrations/20260826020335_create_projects.sql
@@ -1,0 +1,25 @@
+-- Create "users" table
+CREATE TABLE "users" (
+  "id" bigserial NOT NULL,
+  "email" text NOT NULL,
+  "name" text NOT NULL,
+  "created_at" timestamptz NOT NULL,
+  PRIMARY KEY ("id")
+);
+-- Create index "idx_users_email" to table: "users"
+CREATE UNIQUE INDEX "idx_users_email" ON "users" ("email");
+-- Create "projects" table
+CREATE TABLE "projects" (
+  "id" bigserial NOT NULL,
+  "owner_id" bigint NOT NULL,
+  "name" text NOT NULL,
+  "description" text NOT NULL DEFAULT '',
+  "created_at" timestamptz NOT NULL,
+  "updated_at" timestamptz NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "fk_projects_owner" FOREIGN KEY ("owner_id") REFERENCES "users" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+-- Create index "idx_projects_created_at" to table: "projects"
+CREATE INDEX "idx_projects_created_at" ON "projects" ("created_at");
+-- Create index "idx_projects_owner_id" to table: "projects"
+CREATE INDEX "idx_projects_owner_id" ON "projects" ("owner_id");

--- a/benchmarks/apps/gombit/database/migrations/atlas.sum
+++ b/benchmarks/apps/gombit/database/migrations/atlas.sum
@@ -1,0 +1,2 @@
+h1:+lb+gMiuPauqHWKusjFfTLCwdmUrVXemrV6lXmR57Do=
+20260826020335_create_projects.sql h1:ROmRXaszJdAysTwamIiD1hHhvdLlAQJ52rLeykn/F54=

--- a/benchmarks/apps/gombit/database/migrations/models.json
+++ b/benchmarks/apps/gombit/database/migrations/models.json
@@ -1,0 +1,12 @@
+{
+  "models": [
+    {
+      "import_path": "github.com/gombit-dev/gombit/benchmarks/apps/gombit/internal/project",
+      "type_name": "Project"
+    },
+    {
+      "import_path": "github.com/gombit-dev/gombit/benchmarks/apps/gombit/internal/project",
+      "type_name": "User"
+    }
+  ]
+}

--- a/benchmarks/apps/gombit/internal/project/handler.go
+++ b/benchmarks/apps/gombit/internal/project/handler.go
@@ -1,0 +1,242 @@
+package project
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/gombit-dev/gombit/benchmarks/apps/shared"
+	"github.com/gombit-dev/gombit/contract"
+	"github.com/gombit-dev/gombit/database"
+	"gorm.io/gorm"
+)
+
+// Handler serves the canonical /api/projects routes (benchmarks/docs/schema.md)
+// over Gombit's normal public APIs: Huma-typed operations, GORM, and the
+// framework's own contract.ErrorEnvelope / database.MapLoadError /
+// database.MapPersistError for error mapping — used as-is, not patched or
+// worked around, because the whole point of this app is measuring Gombit's
+// actual behavior. Response success shapes come from benchmarks/apps/shared
+// so the wire format matches benchmarks/apps/gin-gorm's exactly (issue #141
+// "same JSON shape"); error mapping deliberately does not, since Gombit's
+// own D10 error mapping is itself one of the things being measured.
+type Handler struct {
+	DB *gorm.DB
+}
+
+type listProjectsInput struct {
+	Page  int `query:"page" doc:"1-based page"`
+	Limit int `query:"limit" doc:"Page size"`
+}
+
+type listProjectsOutput struct {
+	Body shared.DataMeta[[]shared.ProjectData, shared.PageMeta]
+}
+
+type getProjectInput struct {
+	ID string `path:"id" doc:"Project identifier"`
+}
+
+type getProjectOutput struct {
+	Body shared.Data[shared.ProjectData]
+}
+
+type createProjectBody struct {
+	OwnerID     uint   `json:"owner_id" doc:"Owner user id"`
+	Name        string `json:"name" minLength:"1" maxLength:"255" doc:"Project name"`
+	Description string `json:"description,omitempty" doc:"Project description"`
+}
+
+type createProjectInput struct {
+	Body createProjectBody
+}
+
+type createProjectOutput struct {
+	Body shared.Data[shared.ProjectData]
+}
+
+type updateProjectBody struct {
+	Name        *string `json:"name,omitempty" minLength:"1" maxLength:"255" doc:"Project name"`
+	Description *string `json:"description,omitempty" doc:"Project description"`
+}
+
+type updateProjectInput struct {
+	ID   string `path:"id" doc:"Project identifier"`
+	Body updateProjectBody
+}
+
+type updateProjectOutput struct {
+	Body shared.Data[shared.ProjectData]
+}
+
+type deleteProjectInput struct {
+	ID string `path:"id" doc:"Project identifier"`
+}
+
+type deleteProjectOutput struct {
+	Body shared.Data[map[string]bool]
+}
+
+// list handles GET /api/projects?page=&limit=: a single page of projects,
+// deterministically ordered (id DESC), owner preloaded in one batched
+// query — see benchmarks/apps/gin-gorm/handlers.go's list for the exact
+// query-count contract (benchmarks/docs/schema.md "Canonical CRUD API")
+// this mirrors.
+func (h *Handler) list(ctx context.Context, input *listProjectsInput) (*listProjectsOutput, error) {
+	page, limit := clampPage(input.Page, input.Limit)
+
+	var total int64
+	if err := h.DB.WithContext(ctx).Model(&Project{}).Count(&total).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("count projects"))
+	}
+
+	var rows []Project
+	err := h.DB.WithContext(ctx).
+		Preload("Owner").
+		Order("id DESC").
+		Offset((page - 1) * limit).
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("list projects"))
+	}
+
+	items := make([]shared.ProjectData, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, toProjectData(row))
+	}
+
+	return &listProjectsOutput{
+		Body: shared.DataMeta[[]shared.ProjectData, shared.PageMeta]{
+			Data: items,
+			Meta: &shared.PageMeta{Page: page, Limit: limit, Total: total},
+		},
+	}, nil
+}
+
+// get handles GET /api/projects/{id}.
+func (h *Handler) get(ctx context.Context, input *getProjectInput) (*getProjectOutput, error) {
+	id, err := strconv.ParseUint(input.ID, 10, 64)
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.NotFound("project not found"))
+	}
+
+	var row Project
+	if err := h.DB.WithContext(ctx).Preload("Owner").First(&row, uint(id)).Error; err != nil {
+		return nil, database.MapLoadError(ctx, err, "project not found", "load project")
+	}
+
+	return &getProjectOutput{Body: shared.Data[shared.ProjectData]{Data: toProjectData(row)}}, nil
+}
+
+// create handles POST /api/projects. blankNameError is checked explicitly
+// even though Body.Name already carries minLength:"1": Huma's minLength
+// rejects an absent/zero-length string, not a whitespace-only one, the same
+// gap benchmarks/apps/gin-gorm's binding tags have — checked symmetrically
+// here from the start instead of waiting to reproduce that asymmetry.
+func (h *Handler) create(ctx context.Context, input *createProjectInput) (*createProjectOutput, error) {
+	if err := blankNameError(ctx, input.Body.Name); err != nil {
+		return nil, err
+	}
+
+	row := Project{
+		OwnerID:     input.Body.OwnerID,
+		Name:        input.Body.Name,
+		Description: input.Body.Description,
+	}
+	if err := h.DB.WithContext(ctx).Create(&row).Error; err != nil {
+		return nil, database.MapPersistError(ctx, err, "project already exists", "create project")
+	}
+	if err := h.DB.WithContext(ctx).Preload("Owner").First(&row, row.ID).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("reload created project"))
+	}
+
+	return &createProjectOutput{Body: shared.Data[shared.ProjectData]{Data: toProjectData(row)}}, nil
+}
+
+// update handles PATCH /api/projects/{id}: load, apply the provided fields,
+// save the full row — the same load-mutate-save shape the runtime admin's
+// generic update handler uses (admin/resources.go), and the same shape
+// benchmarks/apps/gin-gorm's update uses.
+func (h *Handler) update(ctx context.Context, input *updateProjectInput) (*updateProjectOutput, error) {
+	id, err := strconv.ParseUint(input.ID, 10, 64)
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.NotFound("project not found"))
+	}
+
+	if input.Body.Name != nil {
+		if err := blankNameError(ctx, *input.Body.Name); err != nil {
+			return nil, err
+		}
+	}
+
+	var row Project
+	if err := h.DB.WithContext(ctx).First(&row, uint(id)).Error; err != nil {
+		return nil, database.MapLoadError(ctx, err, "project not found", "load project")
+	}
+
+	if input.Body.Name != nil {
+		row.Name = *input.Body.Name
+	}
+	if input.Body.Description != nil {
+		row.Description = *input.Body.Description
+	}
+	if err := h.DB.WithContext(ctx).Save(&row).Error; err != nil {
+		return nil, database.MapPersistError(ctx, err, "project already exists", "update project")
+	}
+	if err := h.DB.WithContext(ctx).Preload("Owner").First(&row, row.ID).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("reload updated project"))
+	}
+
+	return &updateProjectOutput{Body: shared.Data[shared.ProjectData]{Data: toProjectData(row)}}, nil
+}
+
+// delete handles DELETE /api/projects/{id}.
+func (h *Handler) delete(ctx context.Context, input *deleteProjectInput) (*deleteProjectOutput, error) {
+	id, err := strconv.ParseUint(input.ID, 10, 64)
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.NotFound("project not found"))
+	}
+
+	var row Project
+	if err := h.DB.WithContext(ctx).First(&row, uint(id)).Error; err != nil {
+		return nil, database.MapLoadError(ctx, err, "project not found", "load project")
+	}
+	if err := h.DB.WithContext(ctx).Delete(&row).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("delete project"))
+	}
+
+	return &deleteProjectOutput{Body: shared.Data[map[string]bool]{Data: map[string]bool{"ok": true}}}, nil
+}
+
+func blankNameError(ctx context.Context, name string) error {
+	if strings.TrimSpace(name) == "" {
+		return contract.WithContext(ctx, contract.Validation("name must not be blank", nil))
+	}
+	return nil
+}
+
+func toProjectData(row Project) shared.ProjectData {
+	return shared.ProjectData{
+		ID:          row.ID,
+		OwnerID:     row.OwnerID,
+		OwnerName:   row.Owner.Name,
+		Name:        row.Name,
+		Description: row.Description,
+		CreatedAt:   row.CreatedAt,
+		UpdatedAt:   row.UpdatedAt,
+	}
+}
+
+func clampPage(page, limit int) (int, int) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	return page, limit
+}

--- a/benchmarks/apps/gombit/internal/project/handler.go
+++ b/benchmarks/apps/gombit/internal/project/handler.go
@@ -42,7 +42,17 @@ type getProjectOutput struct {
 }
 
 type createProjectBody struct {
-	OwnerID     uint   `json:"owner_id" doc:"Owner user id"`
+	// minimum:"1" rejects owner_id:0 at validation, matching
+	// benchmarks/apps/gin-gorm's binding:"required" on the same field
+	// (Gin's "required" treats the zero value of a non-pointer uint as
+	// absent). Without this, 0 — a present, well-typed field — reached the
+	// database and hit the same foreign-key violation POST #141's
+	// intentionally-pinned nonexistent-owner case does, conflating two
+	// different inputs behind one 500. See
+	// benchmarks/apps/gombit/README.md for the case that's still meant to
+	// 500 (a nonexistent but well-formed id) versus this one (a value
+	// Huma can reject before it ever reaches GORM).
+	OwnerID     uint   `json:"owner_id" minimum:"1" doc:"Owner user id"`
 	Name        string `json:"name" minLength:"1" maxLength:"255" doc:"Project name"`
 	Description string `json:"description,omitempty" doc:"Project description"`
 }

--- a/benchmarks/apps/gombit/internal/project/handler_test.go
+++ b/benchmarks/apps/gombit/internal/project/handler_test.go
@@ -227,6 +227,25 @@ func TestCreateInvalidOwnerIDReturnsInternalError(t *testing.T) {
 	}
 }
 
+// TestCreateRejectsZeroOwnerID checks a different input than
+// TestCreateInvalidOwnerIDReturnsInternalError above: owner_id:0 is not "a
+// nonexistent but well-formed id" (999999), it's the zero value — the same
+// thing gin-gorm's binding:"required" on OwnerID rejects at the validation
+// layer before it ever reaches GORM. Without minimum:"1" on
+// createProjectBody.OwnerID, this case fell through to the same
+// FK-violation 500 as the nonexistent-id case, conflating a validation gap
+// this app can close with the discovered framework gap it deliberately
+// doesn't.
+func TestCreateRejectsZeroOwnerID(t *testing.T) {
+	app := newProjectApp(t)
+
+	response := doJSON(t, app, http.MethodPost, "/api/projects", `{"owner_id":0,"name":"x","description":"y"}`)
+	if response.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("POST with owner_id:0 status = %d, want %d; body: %s",
+			response.Code, http.StatusUnprocessableEntity, response.Body.String())
+	}
+}
+
 // TestListPaginationAndOrdering mirrors
 // benchmarks/apps/gin-gorm/main_test.go's test of the same name: pagination
 // meta shape, deterministic id-DESC ordering across a page boundary, and

--- a/benchmarks/apps/gombit/internal/project/handler_test.go
+++ b/benchmarks/apps/gombit/internal/project/handler_test.go
@@ -1,0 +1,378 @@
+//go:build integration
+
+package project_test
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gombit-dev/gombit/benchmarks/apps/gombit/internal/project"
+	"github.com/gombit-dev/gombit/benchmarks/apps/shared"
+	"github.com/gombit-dev/gombit/config"
+	"github.com/gombit-dev/gombit/database"
+	"github.com/gombit-dev/gombit/framework"
+	"go.uber.org/zap"
+	"gorm.io/gorm/logger"
+)
+
+// Run against a real PostgreSQL instance with the Atlas migration already
+// applied (this package doesn't run `atlas migrate apply` itself — that's a
+// deploy-time step, not a test-time one, matching how a real Gombit app is
+// operated):
+//
+//	docker compose -f benchmarks/compose.yml up -d postgres
+//	createdb -h 127.0.0.1 -p 55432 -U gombit gombit_bench_gombit   # once
+//	(cd benchmarks/apps/gombit && \
+//	  GOMBIT_DATABASE_DRIVER=postgres \
+//	  GOMBIT_DATABASE_DSN="postgres://gombit:gombit@127.0.0.1:55432/gombit_bench_gombit?sslmode=disable" \
+//	  go run github.com/gombit-dev/gombit/cmd/gombit db migrate)
+//	go test -tags integration ./benchmarks/apps/gombit/... \
+//	  -database.dsn "postgres://gombit:gombit@127.0.0.1:55432/gombit_bench_gombit?sslmode=disable"
+var databaseDSN = flag.String("database.dsn", "", "PostgreSQL DSN for gombit app integration tests (schema already migrated)")
+
+func newProjectApp(t *testing.T) *framework.App {
+	t.Helper()
+
+	if *databaseDSN == "" {
+		t.Skip("set -database.dsn to run gombit app integration tests")
+	}
+
+	db, err := database.Open(config.DatabaseConfig{
+		Driver: config.DatabaseDriverPostgres,
+		DSN:    *databaseDSN,
+	})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := db.Exec("TRUNCATE TABLE projects, users RESTART IDENTITY CASCADE").Error; err != nil {
+		t.Fatalf("truncate (is the Atlas migration applied? see this file's doc comment): %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	cfg := config.DefaultFor(config.EnvironmentTest)
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.API.Prefix = "/api" // matches main.go; see its comment
+	app, err := framework.New(
+		framework.WithConfig(cfg),
+		framework.WithDatabase(db),
+		framework.WithLogger(zap.NewNop()),
+	)
+	if err != nil {
+		t.Fatalf("build app: %v", err)
+	}
+	project.Register(app)
+	return app
+}
+
+func doJSON(t *testing.T, app *framework.App, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var request *http.Request
+	if body == "" {
+		request = httptest.NewRequest(method, path, nil)
+	} else {
+		request = httptest.NewRequest(method, path, strings.NewReader(body))
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response := httptest.NewRecorder()
+	app.Router().ServeHTTP(response, request)
+	return response
+}
+
+func decodeData(t *testing.T, body []byte, into *shared.ProjectData) {
+	t.Helper()
+	var envelope struct {
+		Data shared.ProjectData `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode data envelope: %v; body: %s", err, body)
+	}
+	*into = envelope.Data
+}
+
+// TestCRUDRoundTrip exercises create -> get -> update -> delete -> get (404)
+// against a real PostgreSQL instance, mirroring
+// benchmarks/apps/gin-gorm/main_test.go's TestCRUDRoundTrip so the two
+// suites cover the same contract.
+func TestCRUDRoundTrip(t *testing.T) {
+	app := newProjectApp(t)
+	if err := app.DB().Create(&project.User{Email: "owner@example.com", Name: "Owner"}).Error; err != nil {
+		t.Fatalf("seed owner: %v", err)
+	}
+
+	create := doJSON(t, app, http.MethodPost, "/api/projects", `{"owner_id":1,"name":"Test Project","description":"desc"}`)
+	if create.Code != http.StatusCreated {
+		t.Fatalf("POST /api/projects status = %d, want %d; body: %s", create.Code, http.StatusCreated, create.Body.String())
+	}
+	var created shared.ProjectData
+	decodeData(t, create.Body.Bytes(), &created)
+	if created.Name != "Test Project" || created.OwnerName != "Owner" {
+		t.Fatalf("created project = %+v, want Name=Test Project OwnerName=Owner", created)
+	}
+
+	get := doJSON(t, app, http.MethodGet, fmt.Sprintf("/api/projects/%d", created.ID), "")
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET /api/projects/%d status = %d, want %d", created.ID, get.Code, http.StatusOK)
+	}
+
+	update := doJSON(t, app, http.MethodPatch, fmt.Sprintf("/api/projects/%d", created.ID), `{"name":"Renamed"}`)
+	if update.Code != http.StatusOK {
+		t.Fatalf("PATCH status = %d, want %d; body: %s", update.Code, http.StatusOK, update.Body.String())
+	}
+	var updated shared.ProjectData
+	decodeData(t, update.Body.Bytes(), &updated)
+	if updated.Name != "Renamed" || updated.Description != "desc" {
+		t.Fatalf("updated project = %+v, want Name=Renamed Description=desc (unchanged)", updated)
+	}
+	if updated.UpdatedAt.Before(created.UpdatedAt) {
+		t.Fatalf("updated.UpdatedAt = %v, want not before created.UpdatedAt = %v", updated.UpdatedAt, created.UpdatedAt)
+	}
+
+	del := doJSON(t, app, http.MethodDelete, fmt.Sprintf("/api/projects/%d", created.ID), "")
+	if del.Code != http.StatusOK {
+		t.Fatalf("DELETE status = %d, want %d", del.Code, http.StatusOK)
+	}
+
+	getAfterDelete := doJSON(t, app, http.MethodGet, fmt.Sprintf("/api/projects/%d", created.ID), "")
+	if getAfterDelete.Code != http.StatusNotFound {
+		t.Fatalf("GET after delete status = %d, want %d", getAfterDelete.Code, http.StatusNotFound)
+	}
+}
+
+// TestCreateRejectsBlankName and TestUpdateRejectsBlankName check the same
+// blank/whitespace-only name rule benchmarks/apps/gin-gorm enforces,
+// checked symmetrically here from the start (see handler.go's
+// blankNameError). Table-driven over both the empty string (which Huma's
+// own minLength:"1" already rejects, verified separately) and a
+// whitespace-only string (which minLength alone does not catch), so the
+// two rejection paths can't silently diverge from each other the way
+// gin-gorm's create/update once did.
+var blankNames = []string{"", "   "}
+
+func TestCreateRejectsBlankName(t *testing.T) {
+	app := newProjectApp(t)
+	if err := app.DB().Create(&project.User{Email: "owner@example.com", Name: "Owner"}).Error; err != nil {
+		t.Fatalf("seed owner: %v", err)
+	}
+
+	for _, name := range blankNames {
+		t.Run(fmt.Sprintf("name=%q", name), func(t *testing.T) {
+			body := fmt.Sprintf(`{"owner_id":1,"name":%q,"description":"x"}`, name)
+			response := doJSON(t, app, http.MethodPost, "/api/projects", body)
+			if response.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("status = %d, want %d; body: %s", response.Code, http.StatusUnprocessableEntity, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestUpdateRejectsBlankName(t *testing.T) {
+	app := newProjectApp(t)
+	if err := app.DB().Create(&project.User{Email: "owner@example.com", Name: "Owner"}).Error; err != nil {
+		t.Fatalf("seed owner: %v", err)
+	}
+	create := doJSON(t, app, http.MethodPost, "/api/projects", `{"owner_id":1,"name":"Original","description":"desc"}`)
+	var created shared.ProjectData
+	decodeData(t, create.Body.Bytes(), &created)
+
+	for _, name := range blankNames {
+		t.Run(fmt.Sprintf("name=%q", name), func(t *testing.T) {
+			body := fmt.Sprintf(`{"name":%q}`, name)
+			response := doJSON(t, app, http.MethodPatch, fmt.Sprintf("/api/projects/%d", created.ID), body)
+			if response.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("status = %d, want %d; body: %s", response.Code, http.StatusUnprocessableEntity, response.Body.String())
+			}
+		})
+	}
+
+	// A rejected update must not have partially applied.
+	get := doJSON(t, app, http.MethodGet, fmt.Sprintf("/api/projects/%d", created.ID), "")
+	var unchanged shared.ProjectData
+	decodeData(t, get.Body.Bytes(), &unchanged)
+	if unchanged.Name != "Original" {
+		t.Fatalf("project name after rejected PATCH = %q, want unchanged %q", unchanged.Name, "Original")
+	}
+}
+
+// TestCreateInvalidOwnerIDReturnsInternalError documents, rather than hides,
+// a real Gombit framework gap discovered while building this app:
+// database.MapPersistError (github.com/gombit-dev/gombit/database) only
+// special-cases unique-constraint violations, so a foreign-key violation —
+// exactly what a nonexistent owner_id produces — falls through to internal
+// (500). benchmarks/apps/gin-gorm's control implementation does not use
+// that framework helper and maps the same input to 422 (see its
+// TestCreateRejectsInvalidOwnerID); this app uses Gombit's normal public
+// APIs unmodified (issue #141: "do not bypass ... normal Gombit response
+// handling"), so it inherits the gap. This test pins the framework's actual
+// current behavior so a silent fix (or regression) shows up here, not just
+// as an unexplained fairness-check failure when Phase 3b's
+// cross-implementation checks run. See
+// docs/plans/BENCH-1-benchmark-suite.md Phase 3b for the discovered-gap
+// writeup and why it's out of scope to fix as part of BENCH-1.
+func TestCreateInvalidOwnerIDReturnsInternalError(t *testing.T) {
+	app := newProjectApp(t)
+
+	response := doJSON(t, app, http.MethodPost, "/api/projects", `{"owner_id":999999,"name":"Orphan","description":"no such owner"}`)
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("POST with nonexistent owner_id status = %d, want %d (see test doc comment); body: %s",
+			response.Code, http.StatusInternalServerError, response.Body.String())
+	}
+}
+
+// TestListPaginationAndOrdering mirrors
+// benchmarks/apps/gin-gorm/main_test.go's test of the same name: pagination
+// meta shape, deterministic id-DESC ordering across a page boundary, and
+// that the owner relationship is actually populated.
+func TestListPaginationAndOrdering(t *testing.T) {
+	app := newProjectApp(t)
+	seedFixture(t, app, 3, 25)
+
+	first := doJSON(t, app, http.MethodGet, "/api/projects?page=1&limit=20", "")
+	if first.Code != http.StatusOK {
+		t.Fatalf("GET page 1 status = %d, want %d", first.Code, http.StatusOK)
+	}
+	var page1 struct {
+		Data []shared.ProjectData `json:"data"`
+		Meta shared.PageMeta      `json:"meta"`
+	}
+	if err := json.Unmarshal(first.Body.Bytes(), &page1); err != nil {
+		t.Fatalf("decode page 1: %v; body: %s", err, first.Body.String())
+	}
+	if page1.Meta != (shared.PageMeta{Page: 1, Limit: 20, Total: 25}) {
+		t.Fatalf("page 1 meta = %+v, want {Page:1 Limit:20 Total:25}", page1.Meta)
+	}
+	if len(page1.Data) != 20 {
+		t.Fatalf("page 1 len(data) = %d, want 20", len(page1.Data))
+	}
+	if page1.Data[0].ID <= page1.Data[1].ID {
+		t.Fatalf("page 1 not descending: data[0].ID=%d data[1].ID=%d", page1.Data[0].ID, page1.Data[1].ID)
+	}
+	for _, row := range page1.Data {
+		if row.OwnerName == "" {
+			t.Fatalf("project %d has empty OwnerName; owner preload did not populate it", row.ID)
+		}
+	}
+
+	second := doJSON(t, app, http.MethodGet, "/api/projects?page=2&limit=20", "")
+	var page2 struct {
+		Data []shared.ProjectData `json:"data"`
+		Meta shared.PageMeta      `json:"meta"`
+	}
+	if err := json.Unmarshal(second.Body.Bytes(), &page2); err != nil {
+		t.Fatalf("decode page 2: %v; body: %s", err, second.Body.String())
+	}
+	if len(page2.Data) != 5 {
+		t.Fatalf("page 2 len(data) = %d, want 5 (25 total - 20 on page 1)", len(page2.Data))
+	}
+	if page1.Data[19].ID <= page2.Data[0].ID {
+		t.Fatalf("page boundary not descending: page1[19].ID=%d page2[0].ID=%d", page1.Data[19].ID, page2.Data[0].ID)
+	}
+}
+
+// TestListDoesNotN1 and TestListDoesNotN1EmptyPage mirror
+// benchmarks/apps/gin-gorm/main_test.go's tests of the same name: the list
+// endpoint issues exactly 3 SQL statements for a non-empty page (count,
+// page, one batched owner IN (...)) and 2 for an empty one — see
+// benchmarks/docs/schema.md "Canonical CRUD API" for the pinned shape. The
+// counting logger is attached by mutating app.DB()'s shared *gorm.Config
+// (gorm.DB embeds *Config, so this affects every query issued through this
+// app instance) rather than by constructing a second database.DB, since
+// database.DB's driver/capabilities fields aren't exported for a test in
+// another package to set independently.
+func TestListDoesNotN1(t *testing.T) {
+	app := newProjectApp(t)
+	seedFixture(t, app, 5, 20)
+
+	counter := &queryCounter{}
+	app.DB().Logger = counter
+
+	response := doJSON(t, app, http.MethodGet, "/api/projects?page=1&limit=20", "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d; body: %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	if got := counter.Count(); got != 3 {
+		t.Fatalf("list issued %d SQL statements, want exactly 3 (count + page + batched owner preload); got query log: %v", got, counter.Queries())
+	}
+}
+
+func TestListDoesNotN1EmptyPage(t *testing.T) {
+	app := newProjectApp(t)
+	seedFixture(t, app, 5, 20)
+
+	counter := &queryCounter{}
+	app.DB().Logger = counter
+
+	response := doJSON(t, app, http.MethodGet, "/api/projects?page=99&limit=20", "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d; body: %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	if got := counter.Count(); got != 2 {
+		t.Fatalf("empty-page list issued %d SQL statements, want exactly 2 (count + empty page, no owners to preload); got query log: %v", got, counter.Queries())
+	}
+}
+
+// seedFixture inserts userCount users and projectCount projects (round-robin
+// ownership) directly through GORM, independent of seed.go's full
+// 1,000/100,000 dataset, so tests run in milliseconds — matching
+// benchmarks/apps/gin-gorm/main_test.go's helper of the same name.
+func seedFixture(t *testing.T, app *framework.App, userCount, projectCount int) {
+	t.Helper()
+
+	for i := 1; i <= userCount; i++ {
+		if err := app.DB().Create(&project.User{Email: fmt.Sprintf("fixture-%d@example.com", i), Name: fmt.Sprintf("Fixture User %d", i)}).Error; err != nil {
+			t.Fatalf("seed fixture user %d: %v", i, err)
+		}
+	}
+	for i := 1; i <= projectCount; i++ {
+		p := project.Project{
+			OwnerID:     shared.ProjectOwnerID(i, userCount),
+			Name:        fmt.Sprintf("Fixture Project %d", i),
+			Description: "fixture",
+		}
+		if err := app.DB().Create(&p).Error; err != nil {
+			t.Fatalf("seed fixture project %d: %v", i, err)
+		}
+	}
+}
+
+// queryCounter is a minimal gorm.Logger that counts SQL statements traced
+// via Trace, guarded by a mutex — matching
+// benchmarks/apps/gin-gorm/main_test.go's queryCounter exactly (same
+// reasoning: GORM doesn't guarantee Trace runs on the caller's goroutine).
+type queryCounter struct {
+	mu      sync.Mutex
+	count   int
+	queries []string
+}
+
+func (q *queryCounter) LogMode(logger.LogLevel) logger.Interface      { return q }
+func (q *queryCounter) Info(context.Context, string, ...interface{})  {}
+func (q *queryCounter) Warn(context.Context, string, ...interface{})  {}
+func (q *queryCounter) Error(context.Context, string, ...interface{}) {}
+func (q *queryCounter) Trace(_ context.Context, _ time.Time, fc func() (string, int64), _ error) {
+	sql, _ := fc()
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.count++
+	q.queries = append(q.queries, sql)
+}
+
+func (q *queryCounter) Count() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.count
+}
+
+func (q *queryCounter) Queries() []string {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return append([]string(nil), q.queries...)
+}

--- a/benchmarks/apps/gombit/internal/project/handler_test.go
+++ b/benchmarks/apps/gombit/internal/project/handler_test.go
@@ -34,8 +34,18 @@ import (
 //	  GOMBIT_DATABASE_DRIVER=postgres \
 //	  GOMBIT_DATABASE_DSN="postgres://gombit:gombit@127.0.0.1:55432/gombit_bench_gombit?sslmode=disable" \
 //	  go run github.com/gombit-dev/gombit/cmd/gombit db migrate)
-//	go test -tags integration ./benchmarks/apps/gombit/... \
+//	go test -tags integration -p 1 ./benchmarks/apps/gombit/... \
 //	  -database.dsn "postgres://gombit:gombit@127.0.0.1:55432/gombit_bench_gombit?sslmode=disable"
+//
+// -p 1 is load-bearing, not a style choice: this package and the sibling
+// benchmarks/apps/gombit (main_test.go) each TRUNCATE the same
+// gombit_bench_gombit tables at the start of every test, and go test runs
+// different packages' test binaries in parallel by default (bounded by -p,
+// which defaults to GOMAXPROCS) — verified by racing the two compiled test
+// binaries against one database directly outside of `go test`, which failed
+// on every one of 15 runs with one package's TRUNCATE landing mid-assertion
+// in the other. -p 1 serializes the two binaries so only one truncates the
+// shared tables at a time.
 var databaseDSN = flag.String("database.dsn", "", "PostgreSQL DSN for gombit app integration tests (schema already migrated)")
 
 func newProjectApp(t *testing.T) *framework.App {

--- a/benchmarks/apps/gombit/internal/project/models.go
+++ b/benchmarks/apps/gombit/internal/project/models.go
@@ -1,0 +1,31 @@
+// Package project implements the canonical /api/projects CRUD API
+// (benchmarks/docs/schema.md) as a normal Gombit feature package: Huma
+// handlers, GORM models, framework.App wiring — the same shape
+// `gombit make resource` would emit, hand-extended with the update/delete
+// and pagination the generator doesn't produce yet.
+package project
+
+import "time"
+
+// User and Project are the same schema benchmarks/apps/gin-gorm/models.go
+// implements, expressed through this app's own migration mechanism —
+// Atlas, via `gombit db makemigrations`/`migrate` (AGENTS.md D3: never
+// AutoMigrate for a real Gombit app) — instead of GORM AutoMigrate.
+type User struct {
+	ID        uint      `gorm:"primaryKey"`
+	Email     string    `gorm:"uniqueIndex;not null"`
+	Name      string    `gorm:"not null"`
+	CreatedAt time.Time `gorm:"not null"`
+}
+
+// Project.Owner is a belongsTo association, preloaded on the list/get
+// queries so the API never N+1s (see Handler.list).
+type Project struct {
+	ID          uint      `gorm:"primaryKey"`
+	OwnerID     uint      `gorm:"index;not null"`
+	Owner       User      `gorm:"foreignKey:OwnerID"`
+	Name        string    `gorm:"not null"`
+	Description string    `gorm:"not null;default:''"`
+	CreatedAt   time.Time `gorm:"not null;index"`
+	UpdatedAt   time.Time `gorm:"not null"`
+}

--- a/benchmarks/apps/gombit/internal/project/routes.go
+++ b/benchmarks/apps/gombit/internal/project/routes.go
@@ -1,0 +1,60 @@
+package project
+
+import (
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/gombit-dev/gombit/framework"
+)
+
+// Register mounts the canonical /api/projects Huma routes. Called
+// explicitly from main; Gombit does not discover feature packages by
+// reflection.
+func Register(app *framework.App) {
+	h := &Handler{DB: app.DB()}
+	prefix := app.Config().API.Prefix
+	api := app.API()
+
+	huma.Register(api, huma.Operation{
+		OperationID: "list-projects",
+		Method:      http.MethodGet,
+		Path:        prefix + "/projects",
+		Summary:     "List projects",
+		Tags:        []string{"Projects"},
+	}, h.list)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-project",
+		Method:      http.MethodGet,
+		Path:        prefix + "/projects/{id}",
+		Summary:     "Get a project",
+		Tags:        []string{"Projects"},
+	}, h.get)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "create-project",
+		Method:      http.MethodPost,
+		Path:        prefix + "/projects",
+		Summary:     "Create a project",
+		// Huma defaults POST to 200; without this it would silently
+		// diverge from benchmarks/apps/gin-gorm's 201 Created.
+		DefaultStatus: http.StatusCreated,
+		Tags:          []string{"Projects"},
+	}, h.create)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "update-project",
+		Method:      http.MethodPatch,
+		Path:        prefix + "/projects/{id}",
+		Summary:     "Update a project",
+		Tags:        []string{"Projects"},
+	}, h.update)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "delete-project",
+		Method:      http.MethodDelete,
+		Path:        prefix + "/projects/{id}",
+		Summary:     "Delete a project",
+		Tags:        []string{"Projects"},
+	}, h.delete)
+}

--- a/benchmarks/apps/gombit/main.go
+++ b/benchmarks/apps/gombit/main.go
@@ -1,0 +1,93 @@
+// Command gombit is the BENCH-1 Gombit-runtime implementation of the
+// canonical /api/projects CRUD API (issue #141, benchmarks/docs/schema.md):
+// a normal Gombit app — Huma handlers, GORM, framework.App — using Atlas
+// migrations (`gombit db makemigrations`/`migrate`, not AutoMigrate;
+// AGENTS.md D3) applied as a separate step before this binary runs, the
+// same way a deployed Gombit app would. See
+// benchmarks/apps/gombit/database/migrations/ and this directory's README
+// for exact commands.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/gombit-dev/gombit/benchmarks/apps/gombit/internal/project"
+	"github.com/gombit-dev/gombit/config"
+	"github.com/gombit-dev/gombit/database"
+	"github.com/gombit-dev/gombit/framework"
+)
+
+func main() {
+	seed := flag.Bool("seed", false, "seed the deterministic benchmark dataset and exit")
+	flag.Parse()
+
+	cfg := config.DefaultFor(config.EnvironmentProduction)
+	cfg.HTTP.Addr = ":" + envOr("PORT", "8080")
+	// Gombit's own default API.Prefix is "/api/v1"; the canonical route
+	// spec (benchmarks/docs/schema.md, issue #141) and
+	// benchmarks/apps/gin-gorm both use "/api" with no version segment.
+	// Left at the framework default, this app's route surface wouldn't
+	// match its own control's — a real fairness bug, not a style choice.
+	cfg.API.Prefix = "/api"
+	cfg.Database = config.DatabaseConfig{
+		Driver: config.DatabaseDriverPostgres,
+		DSN:    envOr("DATABASE_URL", "postgres://gombit:gombit@127.0.0.1:55432/gombit_bench_gombit?sslmode=disable"),
+		// issue #141 "Connection pooling" pins 20/20 across every
+		// implementation, overriding Gombit's own 25/5 Postgres default
+		// (database/database.go) — the fairness pin is the issue's, not
+		// the framework's, matching benchmarks/apps/gin-gorm/main.go.
+		MaxOpenConns: envOrInt("POOL_MAX_OPEN", 20),
+		MaxIdleConns: envOrInt("POOL_MAX_IDLE", 20),
+	}
+
+	db, err := database.Open(cfg.Database)
+	if err != nil {
+		log.Fatalf("gombit: open database: %v", err)
+	}
+
+	if *seed {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		if err := seedDatabase(ctx, db.DB); err != nil {
+			log.Fatalf("gombit: seed: %v", err)
+		}
+		log.Println("gombit: seed complete")
+		return
+	}
+
+	app, err := framework.New(framework.WithConfig(cfg), framework.WithDatabase(db))
+	if err != nil {
+		log.Fatalf("gombit: build app: %v", err)
+	}
+
+	project.Register(app)
+
+	log.Printf("gombit: listening on %s", cfg.HTTP.Addr)
+	if err := framework.Run(app); err != nil {
+		log.Fatalf("gombit: serve: %v", err)
+	}
+}
+
+func envOr(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func envOrInt(key string, fallback int) int {
+	value := os.Getenv(key)
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}

--- a/benchmarks/apps/gombit/main_test.go
+++ b/benchmarks/apps/gombit/main_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	"github.com/gombit-dev/gombit/benchmarks/apps/gombit/internal/project"
+	"github.com/gombit-dev/gombit/benchmarks/apps/shared"
+	"github.com/gombit-dev/gombit/config"
+	"github.com/gombit-dev/gombit/database"
+)
+
+// Run against a real, already-Atlas-migrated PostgreSQL instance — see
+// internal/project/handler_test.go's doc comment for the exact setup.
+var databaseDSN = flag.String("database.dsn", "", "PostgreSQL DSN for gombit seed tests (schema already migrated)")
+
+func testDB(t *testing.T) *database.DB {
+	t.Helper()
+
+	if *databaseDSN == "" {
+		t.Skip("set -database.dsn to run gombit seed tests")
+	}
+
+	db, err := database.Open(config.DatabaseConfig{
+		Driver: config.DatabaseDriverPostgres,
+		DSN:    *databaseDSN,
+	})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestSeedDatabaseNIsIdempotentAndCorrect mirrors
+// benchmarks/apps/gin-gorm/main_test.go's test of the same name exactly:
+// exercises the real truncate-then-seed path (seedDatabaseN, which
+// seedDatabase calls at production scale) at a small scale against real
+// PostgreSQL — exact row counts, deterministic content for known rows,
+// round-robin ownership, and — running it twice — that repeated seeding
+// truncates rather than accumulates duplicate data. An earlier review round
+// added this test for gin-gorm specifically because the seed contract had
+// no automated coverage; this app copied seedDatabaseN without also
+// copying the test that earns it.
+func TestSeedDatabaseNIsIdempotentAndCorrect(t *testing.T) {
+	db := testDB(t)
+	const userCount, projectCount = 7, 23 // deliberately not a multiple, to exercise the round-robin remainder
+
+	for run := 1; run <= 2; run++ {
+		if err := seedDatabaseN(context.Background(), db.DB, userCount, projectCount); err != nil {
+			t.Fatalf("run %d: seedDatabaseN: %v", run, err)
+		}
+
+		var userTotal, projectTotal int64
+		if err := db.Model(&project.User{}).Count(&userTotal).Error; err != nil {
+			t.Fatalf("run %d: count users: %v", run, err)
+		}
+		if err := db.Model(&project.Project{}).Count(&projectTotal).Error; err != nil {
+			t.Fatalf("run %d: count projects: %v", run, err)
+		}
+		if userTotal != userCount {
+			t.Fatalf("run %d: user count = %d, want %d (seed did not truncate before reseeding)", run, userTotal, userCount)
+		}
+		if projectTotal != projectCount {
+			t.Fatalf("run %d: project count = %d, want %d (seed did not truncate before reseeding)", run, projectTotal, projectCount)
+		}
+
+		var firstUser project.User
+		if err := db.First(&firstUser, 1).Error; err != nil {
+			t.Fatalf("run %d: load user 1: %v", run, err)
+		}
+		if firstUser.Email != shared.UserEmail(1) || firstUser.Name != shared.UserName(1) {
+			t.Fatalf("run %d: user 1 = %+v, want email=%s name=%s", run, firstUser, shared.UserEmail(1), shared.UserName(1))
+		}
+
+		// Project userCount+1 (8th project, userCount=7) is the first to
+		// wrap back to owner 1 — the round-robin boundary a naive off-by-one
+		// would break silently.
+		var wrapped project.Project
+		if err := db.First(&wrapped, userCount+1).Error; err != nil {
+			t.Fatalf("run %d: load project %d: %v", run, userCount+1, err)
+		}
+		if wrapped.OwnerID != 1 {
+			t.Fatalf("run %d: project %d owner = %d, want 1 (round-robin wrap)", run, userCount+1, wrapped.OwnerID)
+		}
+		if wrapped.Name != shared.ProjectName(userCount+1) {
+			t.Fatalf("run %d: project %d name = %q, want %q", run, userCount+1, wrapped.Name, shared.ProjectName(userCount+1))
+		}
+	}
+}

--- a/benchmarks/apps/gombit/seed.go
+++ b/benchmarks/apps/gombit/seed.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gombit-dev/gombit/benchmarks/apps/gombit/internal/project"
+	"github.com/gombit-dev/gombit/benchmarks/apps/shared"
+	"gorm.io/gorm"
+)
+
+// seedBatchSize is an implementation detail of this app's seeder (how many
+// rows per INSERT), not part of the cross-implementation seed contract, so
+// it stays local rather than living in benchmarks/apps/shared with the
+// content formulas and row counts — matching benchmarks/apps/gin-gorm/seed.go.
+const seedBatchSize = 1000
+
+// seedDatabase truncates and repopulates the canonical benchmark dataset at
+// production scale using benchmarks/apps/shared's deterministic content
+// formulas, the same ones benchmarks/apps/gin-gorm/seed.go uses, so the two
+// implementations' seeded row N are content-identical. See
+// benchmarks/apps/gin-gorm/seed.go's seedDatabaseN for the truncate/identity
+// reasoning this mirrors.
+func seedDatabase(ctx context.Context, db *gorm.DB) error {
+	return seedDatabaseN(ctx, db, shared.SeedUserCount, shared.SeedProjectCount)
+}
+
+func seedDatabaseN(ctx context.Context, db *gorm.DB, userCount, projectCount int) error {
+	if err := db.WithContext(ctx).Exec("TRUNCATE TABLE projects, users RESTART IDENTITY CASCADE").Error; err != nil {
+		return fmt.Errorf("truncate: %w", err)
+	}
+	if err := seedUsersN(ctx, db, userCount); err != nil {
+		return err
+	}
+	return seedProjectsN(ctx, db, userCount, projectCount)
+}
+
+func seedUsersN(ctx context.Context, db *gorm.DB, userCount int) error {
+	batch := make([]project.User, 0, seedBatchSize)
+	for i := 1; i <= userCount; i++ {
+		batch = append(batch, project.User{Email: shared.UserEmail(i), Name: shared.UserName(i)})
+		if len(batch) == seedBatchSize || i == userCount {
+			if err := db.WithContext(ctx).Create(&batch).Error; err != nil {
+				return fmt.Errorf("seed users: %w", err)
+			}
+			batch = batch[:0]
+		}
+	}
+	return nil
+}
+
+func seedProjectsN(ctx context.Context, db *gorm.DB, userCount, projectCount int) error {
+	batch := make([]project.Project, 0, seedBatchSize)
+	for i := 1; i <= projectCount; i++ {
+		batch = append(batch, project.Project{
+			OwnerID:     shared.ProjectOwnerID(i, userCount),
+			Name:        shared.ProjectName(i),
+			Description: shared.ProjectDescription(i),
+		})
+		if len(batch) == seedBatchSize || i == projectCount {
+			if err := db.WithContext(ctx).Create(&batch).Error; err != nil {
+				return fmt.Errorf("seed projects: %w", err)
+			}
+			batch = batch[:0]
+		}
+	}
+	return nil
+}

--- a/benchmarks/apps/shared/seed.go
+++ b/benchmarks/apps/shared/seed.go
@@ -1,0 +1,36 @@
+package shared
+
+import "fmt"
+
+// SeedUserCount and SeedProjectCount are issue #141's recommended initial
+// dataset (benchmarks/docs/schema.md "Seed dataset"), shared so every
+// implementation seeds the same row counts without two copies of these
+// numbers to keep in sync by hand.
+const (
+	SeedUserCount    = 1000
+	SeedProjectCount = 100000
+)
+
+// UserEmail, UserName, ProjectOwnerID, ProjectName, and ProjectDescription
+// are the pure, deterministic-content formulas issue #141's seed dataset
+// requires ("the same values for every implementation"). Shared across
+// every Go implementation under benchmarks/apps/ so two of them can't
+// silently seed different content for the same row N — the exact drift
+// risk a hand-duplicated second copy would carry (this package already
+// exists to avoid that for response shapes; seed content is the same
+// problem).
+func UserEmail(i int) string { return fmt.Sprintf("user-%04d@example.com", i) }
+func UserName(i int) string  { return fmt.Sprintf("User %04d", i) }
+
+// ProjectOwnerID returns the 1-based owner id for project i, round-robin
+// over 1..userCount, so every user owns projectCount/userCount projects and
+// two implementations' seeded row N are content-identical.
+func ProjectOwnerID(i, userCount int) uint {
+	if i < 1 || userCount < 1 {
+		panic("shared.ProjectOwnerID: i and userCount must be positive")
+	}
+	return uint((i-1)%userCount + 1) //nolint:gosec // i,userCount > 0 is checked above; (i-1)%userCount+1 is always in [1,userCount]
+}
+
+func ProjectName(i int) string        { return fmt.Sprintf("Project %06d", i) }
+func ProjectDescription(i int) string { return fmt.Sprintf("Seeded benchmark project %06d", i) }

--- a/benchmarks/apps/shared/seed_test.go
+++ b/benchmarks/apps/shared/seed_test.go
@@ -1,12 +1,10 @@
-package main
+package shared
 
 import "testing"
 
 // TestSeedContentIsDeterministic pins the exact deterministic-content
 // formulas issue #141's seed dataset requires ("the same values for every
-// implementation"). No database, no build tag — this runs in plain
-// `go test ./...`, unlike the DB-backed idempotency/round-trip check in
-// main_test.go (gated behind -tags integration).
+// implementation"). No database, no build tag.
 func TestSeedContentIsDeterministic(t *testing.T) {
 	tests := []struct {
 		name string
@@ -19,24 +17,24 @@ func TestSeedContentIsDeterministic(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := userEmail(tt.i); got != tt.want {
-				t.Errorf("userEmail(%d) = %q, want %q", tt.i, got, tt.want)
+			if got := UserEmail(tt.i); got != tt.want {
+				t.Errorf("UserEmail(%d) = %q, want %q", tt.i, got, tt.want)
 			}
 		})
 	}
 
-	if got, want := userName(1), "User 0001"; got != want {
-		t.Errorf("userName(1) = %q, want %q", got, want)
+	if got, want := UserName(1), "User 0001"; got != want {
+		t.Errorf("UserName(1) = %q, want %q", got, want)
 	}
-	if got, want := userName(1000), "User 1000"; got != want {
-		t.Errorf("userName(1000) = %q, want %q", got, want)
+	if got, want := UserName(1000), "User 1000"; got != want {
+		t.Errorf("UserName(1000) = %q, want %q", got, want)
 	}
 
-	if got, want := projectName(1), "Project 000001"; got != want {
-		t.Errorf("projectName(1) = %q, want %q", got, want)
+	if got, want := ProjectName(1), "Project 000001"; got != want {
+		t.Errorf("ProjectName(1) = %q, want %q", got, want)
 	}
-	if got, want := projectDescription(1), "Seeded benchmark project 000001"; got != want {
-		t.Errorf("projectDescription(1) = %q, want %q", got, want)
+	if got, want := ProjectDescription(1), "Seeded benchmark project 000001"; got != want {
+		t.Errorf("ProjectDescription(1) = %q, want %q", got, want)
 	}
 }
 
@@ -60,8 +58,8 @@ func TestProjectOwnerIDRoundRobin(t *testing.T) {
 		{100000, 1000}, // last seeded project, per benchmarks/docs/schema.md
 	}
 	for _, tt := range tests {
-		if got := projectOwnerID(tt.project, userCount); got != tt.want {
-			t.Errorf("projectOwnerID(%d, %d) = %d, want %d", tt.project, userCount, got, tt.want)
+		if got := ProjectOwnerID(tt.project, userCount); got != tt.want {
+			t.Errorf("ProjectOwnerID(%d, %d) = %d, want %d", tt.project, userCount, got, tt.want)
 		}
 	}
 
@@ -70,7 +68,7 @@ func TestProjectOwnerIDRoundRobin(t *testing.T) {
 	const projectCount = 100000
 	counts := make(map[uint]int, userCount)
 	for i := 1; i <= projectCount; i++ {
-		counts[projectOwnerID(i, userCount)]++
+		counts[ProjectOwnerID(i, userCount)]++
 	}
 	if len(counts) != userCount {
 		t.Fatalf("projects owned by %d distinct users, want %d", len(counts), userCount)
@@ -79,5 +77,18 @@ func TestProjectOwnerIDRoundRobin(t *testing.T) {
 		if count != projectCount/userCount {
 			t.Fatalf("user %d owns %d projects, want %d", owner, count, projectCount/userCount)
 		}
+	}
+}
+
+// TestSeedCountsMatchIssueRecommendation pins SeedUserCount/SeedProjectCount
+// to the issue's recommended dataset size, so a future "let's shrink this
+// for CI speed" edit has to touch this test deliberately instead of
+// silently drifting from what benchmarks/docs/schema.md documents.
+func TestSeedCountsMatchIssueRecommendation(t *testing.T) {
+	if SeedUserCount != 1000 {
+		t.Errorf("SeedUserCount = %d, want 1000", SeedUserCount)
+	}
+	if SeedProjectCount != 100000 {
+		t.Errorf("SeedProjectCount = %d, want 100000", SeedProjectCount)
 	}
 }

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -560,6 +560,47 @@ one claim checked and found incorrect, three real gaps fixed:
   `TestProjectOwnerIDRoundRobin` as if they were still gin-gorm's own —
   they moved to `shared` in this same PR. Updated both.
 
+**Post-landing correction, round 2 (review on PR #177,
+github.com/gombit-dev/gombit/pull/177#pullrequestreview-5026402067):** one
+real, blocking gap, confirmed by reproducing the failure rather than taking
+the claim on faith.
+
+- Claim: `go test -tags integration ./benchmarks/apps/gombit/...` expands to
+  two packages — `benchmarks/apps/gombit` (`main_test.go`, added in round 1)
+  and `benchmarks/apps/gombit/internal/project` (`handler_test.go`) — each
+  compiled to its own test binary, and both `TRUNCATE TABLE projects, users
+  RESTART IDENTITY CASCADE` at the start of every test against the same
+  `gombit_bench_gombit` database. `go test` runs different packages' test
+  binaries in parallel by default (bounded by `-p`, which defaults to
+  `GOMAXPROCS`), so one package's `TRUNCATE` can land mid-assertion in the
+  other. CI being green doesn't rule this out — it's a race, not a
+  deterministic failure.
+- Verified true two ways. First, built both packages' test binaries
+  separately (`go test -tags integration -c`) and ran them concurrently
+  against one throwaway, freshly Atlas-migrated database: 15/15 runs failed,
+  every time on the expected symptom (`TestSeedDatabaseNIsIdempotentAndCorrect`
+  or `TestCRUDRoundTrip` seeing row counts/content from the other package's
+  concurrent truncate). Second — to rule out an artifact of manually racing
+  the binaries — ran the actual documented command,
+  `go test -tags integration ./benchmarks/apps/gombit/...`, 25 times
+  unmodified against a fresh throwaway database: 2/25 failed with the same
+  symptom, confirming it reproduces (intermittently, as expected of a race)
+  through `go test`'s own scheduling, not just under contrived concurrency.
+- Fixed with the reviewer's own "cheapest, honest" option: added `-p 1` to
+  the CI step (`.github/workflows/ci.yml`), the `benchmarks/apps/gombit`
+  README recipe, and `internal/project/handler_test.go`'s doc-comment
+  recipe, each with a comment explaining why it's load-bearing rather than
+  a style choice. Chose this over moving the seed test into
+  `internal/project` (the reviewer's "better" alternative) because
+  `seedDatabaseN` is unexported in `package main` alongside `main.go`,
+  mirroring where a real generated Gombit app's seed command would live —
+  moving it would misrepresent that layout, and `internal/project` can't
+  import `package main` to reuse it without a cycle in the wrong direction.
+  A third database (the reviewer's "heavier than the bug" fallback) was not
+  needed. Verified the fix at the same rigor as the failure: 25/25 passes
+  with `-p 1` added to the identical command that failed 2/25 times without
+  it, against the same throwaway database.
+
 ### Phase 4 — Remaining competitor apps (Django, Rails, Laravel, NestJS)
 
 - One sub-slice per framework (can be up to 4 separate PRs if easier to

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -511,6 +511,55 @@ same misread again.
 - `benchmarks/compose.yml` app services for both apps — still open, moved
   to a follow-up alongside Phase 8's CI work.
 
+**Post-landing correction (review on PR #177, github.com/gombit-dev/gombit/pull/177#pullrequestreview-5026216966):**
+one claim checked and found incorrect, three real gaps fixed:
+
+- Claimed the child-process env override in `startApp` (`cmd.Env =
+  append(cmd.Environ(), "DATABASE_URL="+dsn, ...)`) loses to a
+  pre-existing `DATABASE_URL` in the parent's environment, because
+  `os.Getenv` returns the first match. Checked at the source rather than
+  argued about: `syscall`'s `copyenv()` does document first-occurrence-wins
+  for a process's *own* already-received environ — but `os/exec.Cmd.Start`
+  calls `dedupEnv` before ever calling `execve`, and that function's own
+  comment says "Construct the output in reverse order, to preserve the
+  *last* occurrence of each key." Verified directly with a real child Go
+  binary reading via `os.Getenv` while the parent had `DATABASE_URL` set to
+  a different value — the appended override won, every time. No code
+  change; added a comment at the call site citing the exact source so the
+  same claim doesn't recur.
+- `TestCrossImplementationFairness` compared the two implementations'
+  pages to each other but never against the actual canonical dataset —
+  two empty, unseeded (but migrated) databases would return matching
+  `{total:0, data:[]}` on both sides and pass. Confirmed by literally
+  reproducing it: pointed the test at two fresh, Atlas-migrated-but-never-seeded
+  databases before the fix (would have passed) and after (fails with
+  `meta.total = 0, want 100000`). Fixed by adding `assertCanonicalSeed`,
+  checking each side independently against `shared.SeedProjectCount`,
+  `shared.ProjectName`, `shared.ProjectOwnerID`, and page size *before*
+  the relative comparison runs.
+- `createProjectBody.OwnerID` had no lower bound, so `{"owner_id":0,...}`
+  — a present, well-typed field, not the "nonexistent id" case
+  `TestCreateInvalidOwnerIDReturnsInternalError` documents — passed Huma
+  validation and hit the same FK-violation 500. gin-gorm's
+  `binding:"required"` already rejects this input (Gin's `required`
+  treats a non-pointer `uint` zero value as absent), so this was a real,
+  fixable asymmetry, not another instance of the discovered
+  `database.MapPersistError` gap. Fixed with `minimum:"1"` on `OwnerID`;
+  verified live that `owner_id:0` now 422s while `owner_id:999999` still
+  500s — two different inputs, two different (and now each individually
+  correct) outcomes. Added `TestCreateRejectsZeroOwnerID`.
+- `benchmarks/apps/gombit`'s `seedDatabaseN` was copied from `gin-gorm`
+  without the idempotency test an earlier review round added specifically
+  because the seed contract had no automated coverage
+  (`TestSeedDatabaseNIsIdempotentAndCorrect`). Added the same test for
+  `gombit` (`benchmarks/apps/gombit/main_test.go`), verified passing
+  against real Postgres.
+- `benchmarks/apps/gin-gorm/README.md` still described Phase 3b (the
+  `gombit` app, the fairness check) as future work, and its Test section
+  still pointed at `TestSeedContentIsDeterministic`/
+  `TestProjectOwnerIDRoundRobin` as if they were still gin-gorm's own —
+  they moved to `shared` in this same PR. Updated both.
+
 ### Phase 4 — Remaining competitor apps (Django, Rails, Laravel, NestJS)
 
 - One sub-slice per framework (can be up to 4 separate PRs if easier to

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -439,22 +439,77 @@ instead of naming the framework function first — the ambiguity was real
 even though the bug wasn't, and it's a one-time fix to stop tripping the
 same misread again.
 
-**Phase 3b — still open:**
+**Phase 3b — the `gombit` app and cross-implementation fairness checks — done
+(CI wiring for the fairness check itself deferred to Phase 8; see below).**
 
-- `benchmarks/apps/gombit`: the same canonical API as a normal Gombit app
-  (Huma handlers, `framework.App`, Atlas migrations, production mode).
-- Cross-implementation fairness checks (issue §15/§16) — same route
-  surface, same paginated record count, same ordered IDs for a known query
-  — which need a second implementation to compare against and so couldn't
-  land in 3a. `TestListDoesNotN1` (3a) is the query-count half of this,
-  already passing for gin-gorm alone.
-- `benchmarks/compose.yml` app services for both apps, with resource
-  limits.
+- `benchmarks/apps/gombit/internal/project`: the canonical API as a normal
+  Gombit app — Huma handlers, `framework.App`, GORM, using
+  `benchmarks/apps/shared`'s response types for the success envelope and
+  Gombit's own `contract`/`database` packages for error mapping,
+  unmodified (issue "do not bypass ... normal Gombit response handling").
+- Real Atlas migration (`gombit db makemigrations`/`migrate`, AGENTS.md D3
+  — not `AutoMigrate`), committed under
+  `benchmarks/apps/gombit/database/migrations/`. Verified the generated
+  DDL is structurally identical to `gin-gorm`'s `AutoMigrate` output down
+  to the auto-generated index names (`idx_users_email`,
+  `idx_projects_owner_id`, `idx_projects_created_at`,
+  `fk_projects_owner`) — both use the same `gormschema` code underneath,
+  just through different appliers.
+- **Two real bugs caught by testing against the live control, not just
+  against the spec:**
+  - Huma defaults `POST` to 200; `gin-gorm` returns 201. Fixed with
+    `huma.Operation.DefaultStatus`.
+  - Gombit's own `API.Prefix` default is `/api/v1`; the canonical route
+    spec and `gin-gorm` both use `/api` with no version segment. Left at
+    the framework default, this app's route surface would not have
+    matched its own control's. Fixed by setting `cfg.API.Prefix = "/api"`
+    explicitly in `main.go`.
+- **One discovered, deliberately unpatched framework gap:**
+  `database.MapPersistError` only special-cases unique-constraint
+  violations, so `POST /api/projects` with a nonexistent `owner_id` (a
+  foreign-key violation) falls through to 500 `internal`, unlike
+  `gin-gorm`'s 422. Not fixed here — issue #141 requires using Gombit's
+  normal public APIs as-is, and this app's whole point is measuring what a
+  real Gombit user gets today, warts included. Pinned by
+  `TestCreateInvalidOwnerIDReturnsInternalError` so a future framework fix
+  (or regression) shows up as an expected test change; see
+  `benchmarks/apps/gombit/README.md` for the full writeup. Fixing
+  `database.MapPersistError` is out of scope for BENCH-1 — worth its own
+  follow-up issue against the `database` package.
+- `internal/project`'s own integration suite (`TestCRUDRoundTrip`,
+  blank-name rejection on create and update, pagination/ordering, the
+  3-query/2-query N+1 guard via mutating `app.DB().Logger` — `gorm.DB`
+  embeds `*Config` by pointer, so this affects every query the app
+  instance issues without needing a second `database.DB`) mirrors
+  `gin-gorm`'s suite test-for-test, gated behind `-tags integration` the
+  same way, wired into the same CI job against a third database
+  (`gombit_bench_gombit`, since this app's Atlas-migrated tables shouldn't
+  share a database with `gin-gorm`'s `AutoMigrate`'d ones either).
+  Verified the full CI recipe (create database, install Atlas, `gombit db
+  migrate`, run tests) locally against a freshly created database, not
+  just written and assumed correct.
+- `benchmarks/apps/fairness_test.go`: `TestCrossImplementationFairness`
+  builds and runs both real binaries (subprocess + HTTP, not shared Go
+  internals — gin-gorm is `package main`, and this is also the only shape
+  of comparison that will still work once Phase 4 adds
+  Django/Rails/Laravel/NestJS) against their own already-seeded databases
+  and checks: identical paginated content and ordering for the canonical
+  seed (timestamps excluded — each binary was seeded at a different real
+  time), and identical 404 behavior for a nonexistent id. Passes,
+  verified twice for flakiness, with confirmed clean subprocess teardown.
+  **Not yet wired into routine PR CI**: it needs both databases seeded at
+  the full canonical 1,000/100,000 scale, which is heavier than what
+  belongs in a PR smoke job — needs the lighter seed-size mechanism
+  Phase 8 (CI integration, smoke vs. full) already anticipates. Verified
+  locally in this phase instead.
 - **AC:** `make benchmark-crud` runs Gombit and Gin+GORM against the same
   Postgres instance and produces comparable `results.json` rows; fairness
-  tests fail loudly on route/shape/query-count divergence. Not yet
-  satisfied — `results.json` also still depends on Phase 1's open
-  result-schema/summarizer work.
+  tests fail loudly on route/shape/query-count divergence. The fairness
+  check itself is done and passing; `make benchmark-crud` and
+  `results.json` still depend on Phase 1's open result-schema/summarizer
+  work and are not yet satisfied.
+- `benchmarks/compose.yml` app services for both apps — still open, moved
+  to a follow-up alongside Phase 8's CI work.
 
 ### Phase 4 — Remaining competitor apps (Django, Rails, Laravel, NestJS)
 


### PR DESCRIPTION
## Summary

Phase 3b of the BENCH-1 plan ([docs/plans/BENCH-1-benchmark-suite.md](docs/plans/BENCH-1-benchmark-suite.md)):
`benchmarks/apps/gombit` implementing the same canonical `/api/projects` API
as `benchmarks/apps/gin-gorm` (Phase 3a, merged in #176), using Gombit's
normal public APIs — Huma handlers, `framework.App`, GORM, a real Atlas
migration — plus the cross-implementation fairness check Phase 3a couldn't
land without a second implementation to compare against.

- `benchmarks/apps/gombit/internal/project`: Huma handlers using
  `benchmarks/apps/shared`'s response types for the success envelope (same
  wire shape as `gin-gorm`) and Gombit's own `contract`/`database` packages
  for error mapping, unmodified — the point of this app is measuring
  Gombit's actual behavior, not a hand-tuned approximation of it.
- Real Atlas migration (`gombit db makemigrations`/`migrate`, AGENTS.md D3,
  not `AutoMigrate`), committed under `database/migrations/`. Verified the
  generated DDL is structurally identical to `gin-gorm`'s `AutoMigrate`
  output down to the auto-generated index names — both go through the same
  `gormschema` code, just different appliers.
- **Two real bugs caught by testing against the live control**, not just
  against the spec: Huma defaults `POST` to 200 (`gin-gorm` returns 201;
  fixed with `DefaultStatus`), and Gombit's own `API.Prefix` default is
  `/api/v1` while the canonical spec and `gin-gorm` both use `/api` (fixed
  in `main.go`).
- **One discovered, deliberately unpatched framework gap**:
  `database.MapPersistError` only special-cases unique violations, so a
  foreign-key violation (nonexistent `owner_id`) returns 500 instead of
  `gin-gorm`'s 422. Not fixed here — issue #141 requires normal Gombit APIs
  as-is, and this app measures what a user gets today, warts included.
  Pinned by `TestCreateInvalidOwnerIDReturnsInternalError`; full writeup in
  [benchmarks/apps/gombit/README.md](benchmarks/apps/gombit/README.md).
  Fixing `database.MapPersistError` itself is out of scope for BENCH-1.
- `benchmarks/apps/fairness_test.go`: `TestCrossImplementationFairness`
  builds and runs both real binaries and compares them over HTTP
  (subprocess, not shared internals — `gin-gorm` is `package main`, and this
  is the only comparison shape that still works once Phase 4 adds
  Django/Rails/Laravel/NestJS). Checks identical paginated content/ordering
  for the canonical seed and identical 404 behavior. Verified passing twice,
  with confirmed clean subprocess teardown. **Not yet wired into routine PR
  CI** — needs both databases at the full 1,000/100,000 scale, heavier than
  a PR smoke job; verified locally, deferred to Phase 8's lighter-seed CI
  work.
- CI: `internal/project`'s integration suite wired into the existing
  `database-postgres` job against a third database (`gombit_bench_gombit` —
  this app's Atlas-migrated tables can't safely share a database with
  `gin-gorm`'s `AutoMigrate`'d ones either), with Atlas CLI installation and
  a real `gombit db migrate` step. Verified the exact CI recipe locally
  against a freshly created database before trusting the YAML.

Also includes a small prerequisite refactor: seed-content formulas
(`UserEmail`, `ProjectOwnerID`, etc.) moved from `gin-gorm`'s `seed.go` into
`benchmarks/apps/shared`, so both apps seed byte-identical content without
two hand-maintained copies.

Part of #141. Not closing it — Phase 4 (Django/Rails/Laravel/NestJS) and
later phases remain.

## Acceptance criteria

- [x] `benchmarks/apps/gombit` exposes the canonical CRUD routes as a normal
      Gombit app (Huma, `framework.App`, GORM, Atlas migrations, production
      mode)
- [x] Cross-implementation fairness check exists and passes (route surface,
      paginated content/ordering, N+1 query-count parity already covered
      per-app in Phase 3a)
- [x] Schema verified structurally identical to `gin-gorm`'s
- [ ] `make benchmark-crud` / `results.json` output — still depends on
      Phase 1's open result-schema/summarizer work
- [ ] Fairness check wired into automated CI — deferred to Phase 8 (needs a
      lighter seed-size mechanism than the canonical 1,000/100,000)
- [ ] `benchmarks/compose.yml` app services — still open

## Scope notes

Deferred, documented in the plan doc:

- Wiring `TestCrossImplementationFairness` into GitHub Actions CI (Phase 8)
- `benchmarks/compose.yml` app services for both apps
- Fixing `database.MapPersistError`'s FK-violation gap in the `database`
  package (out of scope for BENCH-1; worth its own follow-up issue)
- Django/Rails/Laravel/NestJS apps (Phase 4)
- Load harness, auth/TechEmpower/concurrency/footprint benchmarks, README
  `## Performance` section (Phases 5–8)

No locked architecture decision is touched.

## Validation

- [x] `go build ./...`
- [x] `go test ./...` — green except the same two pre-existing, unrelated
      `error obtaining VCS status` failures confirmed on unmodified `main`
      in earlier PRs against this issue
- [x] `go vet` / `go vet -tags integration` — clean
- [x] `gofmt -l` — clean
- [x] `golangci-lint run ./benchmarks/...` — 0 issues
- [x] `go test -tags integration -race ./benchmarks/apps/gombit/...` against
      real Postgres — green, no races
- [x] `go test -tags integration ./benchmarks/apps/gin-gorm/...` — still
      green after the shared seed-formula refactor
- [x] `TestCrossImplementationFairness` — green, run twice, clean subprocess
      teardown confirmed
- [x] The exact new CI recipe (create database, install Atlas, `gombit db
      migrate`, run tests) reproduced locally against a freshly created
      database, not just written and assumed correct
- [x] Manual end-to-end verification: seed, every CRUD route, 404, 422
      blank-name rejection, the FK-violation 500, and Postgres
      statement-log inspection confirming the same 3-query list shape as
      `gin-gorm`
- [ ] Project `code-review` skill run against this diff — not yet run

## Working agreement checklist

- [x] New behavior has tests; DB-touching change covered by an
      integration-tagged suite run against real PostgreSQL (this benchmark
      specifically requires PostgreSQL parity per issue #141, not the v0.1
      SQLite/MySQL matrix)
- [ ] Stable features ship docs and appear in an example app — N/A,
      benchmark tooling under `benchmarks/`, not a user-facing framework
      feature; has its own README instead
- [x] Extraction preserves contracts — N/A, no extraction; uses Gombit's
      `contract`/`database` packages as-is
- [ ] Generators are idempotent/additive, AST-safe — N/A, no generator
      changes (the Atlas migration was generated via the real `gombit db
      makemigrations` CLI, then committed)
- [x] API changes regenerate OpenAPI/TS client — N/A, no public Gombit
      framework API changes (this is a separate benchmark app)
- [x] No secrets in generated frontend source — N/A, no frontend changes
- [x] Scope stays inside milestone — post-v0.1, no M6 battery pulled in
- [x] This PR links its issue and states which AC it satisfies