### PR TITLE
feat: BENCH-1 result schema + reproducibility metadata collector (Phase 1 completion)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,31 +8,51 @@ Full plan: [docs/plans/BENCH-1-benchmark-suite.md](../docs/plans/BENCH-1-benchma
 ```text
 benchmarks/
 ├── compose.yml          PostgreSQL only so far (see docs/schema.md)
+├── config/
+│   └── versions.env     pinned load generator (k6), Postgres image, resource limits, workload defaults
 ├── docs/
 │   └── schema.md        canonical schema/API/envelope every benchmarks/apps/ implementation targets
+├── internal/            machine-readable output plumbing (Phase 1)
+│   ├── result/           results.json/results.csv schema + encoders (issue §9)
+│   └── metadata/         reproducibility metadata struct + host/toolchain collector
+├── scripts/
+│   └── collect-host-info/ CLI over internal/metadata: writes metadata.json for a run
 ├── micro/                Go abstraction-overhead microbenchmarks (Phase 2)
 │   ├── scenario/          shared resource types, Huma route registration, correctness assertions
 │   ├── nethttp/           net/http row (no router, no framework)
 │   ├── gin/               idiomatic plain-Gin row
 │   ├── huma/              bare Huma-over-Gin row
 │   └── gombit/             full framework.App row
-└── apps/                 canonical realistic-application CRUD comparison (Phase 3-4)
-    ├── shared/             response-shape + seed-content types common to both Go implementations
-    ├── gin-gorm/            primary framework-tax control — see its own README
-    ├── gombit/              real Gombit app (Huma, Atlas migrations) — see its own README
-    ├── django/              Django + DRF ecosystem-context app (Phase 4) — see its own README
-    ├── rails/               Rails + ActiveRecord ecosystem-context app (Phase 4) — see its own README
-    ├── laravel/             Laravel + Eloquent ecosystem-context app (Phase 4) — see its own README
-    ├── nestjs/              NestJS + TypeORM ecosystem-context app (Phase 4) — see its own README
-    └── fairness_test.go     cross-implementation check: builds and runs both real binaries, compares over HTTP
+├── apps/                 canonical realistic-application CRUD comparison (Phase 3-4)
+│   ├── shared/             response-shape + seed-content types common to both Go implementations
+│   ├── gin-gorm/            primary framework-tax control — see its own README
+│   ├── gombit/              real Gombit app (Huma, Atlas migrations) — see its own README
+│   ├── django/              Django + DRF ecosystem-context app (Phase 4) — see its own README
+│   ├── rails/               Rails + ActiveRecord ecosystem-context app (Phase 4) — see its own README
+│   ├── laravel/             Laravel + Eloquent ecosystem-context app (Phase 4) — see its own README
+│   ├── nestjs/              NestJS + TypeORM ecosystem-context app (Phase 4) — see its own README
+│   └── fairness_test.go     cross-implementation check: builds and runs both real binaries, compares over HTTP
+└── results/             generated output (issue §9); results/README.md documents the layout
 ```
 
 All six canonical CRUD implementations now exist (the Go control, the real
-Gombit app, and the four ecosystem apps). Everything else in the suite's
-target layout (`workloads/`, `scripts/`, `config/`, `results/`,
-`docs/methodology.md`, `Makefile`, per-app `compose.yml` services, and the
-extension of `fairness_test.go` to all six) is scoped to later phases of the
-plan above and doesn't exist yet.
+Gombit app, and the four ecosystem apps), and the result schema, metadata
+collector, and run-config pins are in place. Everything else in the suite's
+target layout (`workloads/`, the `make benchmark-*` orchestration that fills
+`results/latest/`, `docs/methodology.md`, per-app `compose.yml` services, and
+the extension of `fairness_test.go` to all six) is scoped to later phases of
+the plan above and doesn't exist yet.
+
+## Result schema and run metadata
+
+`go run ./benchmarks/scripts/collect-host-info` prints the reproducibility
+metadata (git SHA + dirty state, OS/kernel/arch, CPU/RAM, Go/Docker/Compose
+versions, plus the run parameters passed as flags) as `metadata.json`. The
+canonical results shape lives in
+[`benchmarks/internal/result`](internal/result) (JSON + CSV encoders); the
+Markdown report is always generated from that, never the other way around.
+Pinned versions and limits are in
+[`benchmarks/config/versions.env`](config/versions.env).
 
 ## Running the framework-tax matrix
 

--- a/benchmarks/compose.yml
+++ b/benchmarks/compose.yml
@@ -4,12 +4,18 @@
 # developed and fairness-tested against it locally.
 #
 # Version pin: issue #141 requires major.minor (or digest), not a
-# major-only floating tag. This repo's CI (.github/workflows/ci.yml) already
-# uses postgres:16-alpine for the SQLite/PostgreSQL/MySQL matrix; this pins
-# the same major version to minor precision rather than diverging from it.
+# major-only floating tag. The pin lives once in
+# benchmarks/config/versions.env (POSTGRES_IMAGE); this file references it via
+# ${POSTGRES_IMAGE}. Run compose with that env file so the two can't drift:
+#
+#   docker compose --env-file benchmarks/config/versions.env \
+#     -f benchmarks/compose.yml up -d postgres
+#
+# The `:-postgres:16.4-alpine` default keeps a bare `docker compose up` (no
+# env file) working with the same pinned image.
 services:
   postgres:
-    image: postgres:16.4-alpine
+    image: ${POSTGRES_IMAGE:-postgres:16.4-alpine}
     environment:
       POSTGRES_USER: gombit
       POSTGRES_PASSWORD: gombit

--- a/benchmarks/config/versions.env
+++ b/benchmarks/config/versions.env
@@ -1,0 +1,35 @@
+# Pinned, machine-readable benchmark run configuration (issue #141 §7/§8/§18).
+# The orchestrator (a later slice's `make benchmark-*` targets) sources this
+# and passes the values to benchmarks/scripts/collect-host-info so the
+# recorded metadata.json matches what actually ran. Kept here as one source
+# of truth rather than duplicated across scripts.
+
+# Load generator (issue #141 §"Load generator": pin one, use it for every
+# service). The load generator runs OUTSIDE the application container.
+K6_VERSION=0.55.0
+
+# PostgreSQL image — minor-pinned, matching benchmarks/compose.yml.
+POSTGRES_IMAGE=postgres:16.4-alpine
+
+# Resource limits (issue #141 §7). PostgreSQL: 2 vCPU / 2 GiB. Each
+# application container: 2 vCPU / 2 GiB (the same CPU budget the Rails/Laravel
+# worker counts and every app's pool size were sized against). Docker Compose
+# only enforces these under Swarm/`--compatibility`; the orchestrator must
+# detect and report when they were not applied rather than pretend (§7).
+POSTGRES_CPUS=2
+POSTGRES_MEMORY=2g
+APP_CPUS=2
+APP_MEMORY=2g
+
+# Connection pooling (issue #141 §18): 20 max open connections, every
+# implementation.
+POOL_MAX_OPEN=20
+
+# Workload defaults (issue #141 §"Concurrency sweep"): the concurrency levels,
+# per-trial measured duration, warm-up, and trial count the CRUD workload
+# uses. 1000 is attempted and dropped from the reported set if it can't be
+# sustained (documented, not silently omitted).
+CONCURRENCY=1,10,100,500
+DURATION_SECONDS=30
+WARMUP_SECONDS=10
+TRIALS=5

--- a/benchmarks/config/versions.env
+++ b/benchmarks/config/versions.env
@@ -8,28 +8,35 @@
 # service). The load generator runs OUTSIDE the application container.
 K6_VERSION=0.55.0
 
-# PostgreSQL image — minor-pinned, matching benchmarks/compose.yml.
+# PostgreSQL image — minor-pinned. This is the single source of truth:
+# benchmarks/compose.yml references ${POSTGRES_IMAGE} (run compose with
+# `--env-file benchmarks/config/versions.env`) rather than hardcoding it, so
+# the pin can't drift between the two files.
 POSTGRES_IMAGE=postgres:16.4-alpine
 
-# Resource limits (issue #141 §7). PostgreSQL: 2 vCPU / 2 GiB. Each
-# application container: 2 vCPU / 2 GiB (the same CPU budget the Rails/Laravel
-# worker counts and every app's pool size were sized against). Docker Compose
-# only enforces these under Swarm/`--compatibility`; the orchestrator must
+# Resource limits (issue #141 §7 "Target initial default"). PostgreSQL:
+# 2 vCPU / 2 GiB. Each application container: 2 vCPU / 1 GiB — the issue's
+# app budget is 1 GiB, not Postgres's 2 GiB (an earlier draft copied the
+# Postgres number onto the app; corrected on review). Docker Compose only
+# enforces these under Swarm/`--compatibility`; the orchestrator must
 # detect and report when they were not applied rather than pretend (§7).
 POSTGRES_CPUS=2
 POSTGRES_MEMORY=2g
 APP_CPUS=2
-APP_MEMORY=2g
+APP_MEMORY=1g
 
 # Connection pooling (issue #141 §18): 20 max open connections, every
 # implementation.
 POOL_MAX_OPEN=20
 
-# Workload defaults (issue #141 §"Concurrency sweep"): the concurrency levels,
-# per-trial measured duration, warm-up, and trial count the CRUD workload
-# uses. 1000 is attempted and dropped from the reported set if it can't be
-# sustained (documented, not silently omitted).
-CONCURRENCY=1,10,100,500
+# Workload defaults (issue #141 §7 "Concurrency and tail latency"): the
+# concurrency levels, per-trial measured duration, warm-up, and trial count
+# the CRUD workload uses. 1000 is in the pinned set (the issue's minimum is
+# 1/10/100/500/1000); the orchestrator attempts it and, if the test machine
+# can't sustain it without the load generator becoming the bottleneck, records
+# that limitation and drops it from the *reported* set rather than publishing
+# bogus data — the attempt is pinned here as data, not left to a comment.
+CONCURRENCY=1,10,100,500,1000
 DURATION_SECONDS=30
 WARMUP_SECONDS=10
 TRIALS=5

--- a/benchmarks/internal/metadata/json.go
+++ b/benchmarks/internal/metadata/json.go
@@ -1,0 +1,14 @@
+package metadata
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// WriteJSON encodes the metadata as pretty-printed JSON (results/latest/
+// metadata.json).
+func WriteJSON(w io.Writer, m Metadata) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(m)
+}

--- a/benchmarks/internal/metadata/json_test.go
+++ b/benchmarks/internal/metadata/json_test.go
@@ -1,0 +1,48 @@
+package metadata
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The required framework_versions / runtime_versions / concurrency fields must
+// never serialize as JSON null, even at the CLI's default (no version flags,
+// no concurrency): Collect initializes empty maps/slice, so the wire shape is
+// {} / [], the honest "collected, nothing to record" value.
+func TestWriteJSONNeverNullForRequiredFields(t *testing.T) {
+	m := Collect(context.Background(), Options{
+		Run: func(context.Context, string, ...string) (string, error) { return "", nil },
+	})
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, m); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	s := buf.String()
+	for _, wantNull := range []string{"framework_versions", "runtime_versions", "concurrency"} {
+		if strings.Contains(s, `"`+wantNull+`": null`) {
+			t.Errorf("%s serialized as null:\n%s", wantNull, s)
+		}
+	}
+	for _, want := range []string{
+		`"framework_versions": {}`,
+		`"runtime_versions": {}`,
+		`"concurrency": []`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("json missing %q:\n%s", want, s)
+		}
+	}
+
+	// It must round-trip back to equal values.
+	var decoded Metadata
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.FrameworkVersions == nil || decoded.Concurrency == nil {
+		t.Errorf("round trip lost empty collections: %+v", decoded)
+	}
+}

--- a/benchmarks/internal/metadata/metadata.go
+++ b/benchmarks/internal/metadata/metadata.go
@@ -27,7 +27,11 @@ type Metadata struct {
 	Timestamp     string `json:"timestamp"`
 
 	GitCommit string `json:"git_commit"`
-	GitDirty  bool   `json:"git_dirty"`
+	// GitDirty is a pointer, not a bool, so the metadata can honestly say "I
+	// did not determine this" (null) when `git status` failed or git was
+	// missing — a plain bool's zero value (false = clean) would claim a
+	// clean tree on the exact runs where the check could not run.
+	GitDirty *bool `json:"git_dirty"`
 
 	OS          string `json:"os"`
 	Kernel      string `json:"kernel"`
@@ -88,18 +92,44 @@ func Collect(ctx context.Context, opts Options) Metadata {
 		run = execRunner
 	}
 
-	commit, _ := run(ctx, "git", "rev-parse", "HEAD")
-	status, _ := run(ctx, "git", "status", "--porcelain")
+	commit, commitErr := run(ctx, "git", "rev-parse", "HEAD")
+	if commitErr != nil {
+		commit = ""
+	}
 	kernel, _ := run(ctx, "uname", "-r")
 	dockerVersion, _ := run(ctx, "docker", "version", "--format", "{{.Server.Version}}")
 	composeVersion, _ := run(ctx, "docker", "compose", "version", "--short")
+
+	// git_dirty is set only when the porcelain status actually succeeded;
+	// a failed check (or missing git) leaves it nil -> JSON null -> "unknown".
+	var gitDirty *bool
+	if status, statusErr := run(ctx, "git", "status", "--porcelain"); statusErr == nil {
+		dirty := strings.TrimSpace(status) != ""
+		gitDirty = &dirty
+	}
+
+	// Never serialize the required version maps / concurrency as JSON null:
+	// an empty {} / [] is the honest "collected, nothing to record" shape,
+	// distinct from a field that was dropped.
+	frameworkVersions := opts.FrameworkVersions
+	if frameworkVersions == nil {
+		frameworkVersions = map[string]string{}
+	}
+	runtimeVersions := opts.RuntimeVersions
+	if runtimeVersions == nil {
+		runtimeVersions = map[string]string{}
+	}
+	concurrency := opts.Concurrency
+	if concurrency == nil {
+		concurrency = []int{}
+	}
 
 	return Metadata{
 		SchemaVersion: SchemaVersion,
 		Timestamp:     now().UTC().Format(time.RFC3339),
 
 		GitCommit: commit,
-		GitDirty:  strings.TrimSpace(status) != "",
+		GitDirty:  gitDirty,
 
 		OS:          runtime.GOOS,
 		Kernel:      kernel,
@@ -113,14 +143,14 @@ func Collect(ctx context.Context, opts Options) Metadata {
 		DockerComposeVersion: composeVersion,
 		PostgresVersion:      opts.PostgresVersion,
 
-		FrameworkVersions: opts.FrameworkVersions,
-		RuntimeVersions:   opts.RuntimeVersions,
+		FrameworkVersions: frameworkVersions,
+		RuntimeVersions:   runtimeVersions,
 		BenchmarkTool:     opts.BenchmarkTool,
 
 		ResourceLimits:  opts.ResourceLimits,
 		DurationSeconds: opts.DurationSeconds,
 		WarmupSeconds:   opts.WarmupSeconds,
-		Concurrency:     opts.Concurrency,
+		Concurrency:     concurrency,
 		Trials:          opts.Trials,
 	}
 }
@@ -151,11 +181,26 @@ func ramBytes() int64 {
 	return parseMemTotalBytes(string(data))
 }
 
+// parseCPUModel reads the CPU model from /proc/cpuinfo text. x86 uses
+// "model name"; ARM/aarch64 typically has no such line, so it falls back to
+// the devicetree "Model" and then "Hardware" keys. On a host that exposes
+// none of them (a bare ARM /proc/cpuinfo with only "CPU part" hex codes) it
+// returns "" — recorded as unknown rather than a fabricated string.
 func parseCPUModel(cpuinfo string) string {
+	found := map[string]string{}
 	for _, line := range strings.Split(cpuinfo, "\n") {
 		key, value, ok := strings.Cut(line, ":")
-		if ok && strings.TrimSpace(key) == "model name" {
-			return strings.TrimSpace(value)
+		if !ok {
+			continue
+		}
+		k := strings.TrimSpace(key)
+		if _, seen := found[k]; !seen {
+			found[k] = strings.TrimSpace(value)
+		}
+	}
+	for _, key := range []string{"model name", "Model", "Hardware"} {
+		if v := found[key]; v != "" {
+			return v
 		}
 	}
 	return ""

--- a/benchmarks/internal/metadata/metadata.go
+++ b/benchmarks/internal/metadata/metadata.go
@@ -1,0 +1,183 @@
+// Package metadata collects the reproducibility metadata every full benchmark
+// run must capture (issue #141 "Reproducibility metadata"): enough about the
+// host, toolchain, and run parameters that a published table can be
+// reproduced. "Never publish a table without enough metadata to reproduce
+// it."
+package metadata
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SchemaVersion is bumped when the Metadata shape changes incompatibly.
+const SchemaVersion = 1
+
+// Metadata is the machine-readable run environment (written to
+// results/latest/metadata.json). Discovered fields come from the host and
+// toolchain; the rest are run parameters the orchestrator supplies via
+// Options because they are choices, not facts about the machine.
+type Metadata struct {
+	SchemaVersion int    `json:"schema_version"`
+	Timestamp     string `json:"timestamp"`
+
+	GitCommit string `json:"git_commit"`
+	GitDirty  bool   `json:"git_dirty"`
+
+	OS          string `json:"os"`
+	Kernel      string `json:"kernel"`
+	Arch        string `json:"arch"`
+	CPUModel    string `json:"cpu_model"`
+	LogicalCPUs int    `json:"logical_cpus"`
+	RAMBytes    int64  `json:"ram_bytes"`
+
+	GoVersion            string `json:"go_version"`
+	DockerVersion        string `json:"docker_version"`
+	DockerComposeVersion string `json:"docker_compose_version"`
+	PostgresVersion      string `json:"postgres_version"`
+
+	FrameworkVersions map[string]string `json:"framework_versions"`
+	RuntimeVersions   map[string]string `json:"runtime_versions"`
+	BenchmarkTool     string            `json:"benchmark_tool"`
+
+	ResourceLimits  string  `json:"resource_limits"`
+	DurationSeconds float64 `json:"duration_seconds"`
+	WarmupSeconds   float64 `json:"warmup_seconds"`
+	Concurrency     []int   `json:"concurrency"`
+	Trials          int     `json:"trials"`
+}
+
+// Runner runs a command and returns its trimmed stdout. It exists so tests can
+// stub git/uname/docker without those tools being installed; production uses
+// execRunner.
+type Runner func(ctx context.Context, name string, args ...string) (string, error)
+
+// Options carries the injectable seams (Now, Run) and the run-parameter fields
+// the orchestrator knows but the host does not.
+type Options struct {
+	Now func() time.Time
+	Run Runner
+
+	PostgresVersion   string
+	FrameworkVersions map[string]string
+	RuntimeVersions   map[string]string
+	BenchmarkTool     string
+	ResourceLimits    string
+	DurationSeconds   float64
+	WarmupSeconds     float64
+	Concurrency       []int
+	Trials            int
+}
+
+// Collect gathers the metadata. Discovery is best-effort: a missing tool
+// (docker on a CI runner without it, git outside a checkout) leaves its field
+// empty rather than failing the whole collection — a benchmark run should
+// still record everything it *can*.
+func Collect(ctx context.Context, opts Options) Metadata {
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now() }
+	}
+	run := opts.Run
+	if run == nil {
+		run = execRunner
+	}
+
+	commit, _ := run(ctx, "git", "rev-parse", "HEAD")
+	status, _ := run(ctx, "git", "status", "--porcelain")
+	kernel, _ := run(ctx, "uname", "-r")
+	dockerVersion, _ := run(ctx, "docker", "version", "--format", "{{.Server.Version}}")
+	composeVersion, _ := run(ctx, "docker", "compose", "version", "--short")
+
+	return Metadata{
+		SchemaVersion: SchemaVersion,
+		Timestamp:     now().UTC().Format(time.RFC3339),
+
+		GitCommit: commit,
+		GitDirty:  strings.TrimSpace(status) != "",
+
+		OS:          runtime.GOOS,
+		Kernel:      kernel,
+		Arch:        runtime.GOARCH,
+		CPUModel:    cpuModel(),
+		LogicalCPUs: runtime.NumCPU(),
+		RAMBytes:    ramBytes(),
+
+		GoVersion:            runtime.Version(),
+		DockerVersion:        dockerVersion,
+		DockerComposeVersion: composeVersion,
+		PostgresVersion:      opts.PostgresVersion,
+
+		FrameworkVersions: opts.FrameworkVersions,
+		RuntimeVersions:   opts.RuntimeVersions,
+		BenchmarkTool:     opts.BenchmarkTool,
+
+		ResourceLimits:  opts.ResourceLimits,
+		DurationSeconds: opts.DurationSeconds,
+		WarmupSeconds:   opts.WarmupSeconds,
+		Concurrency:     opts.Concurrency,
+		Trials:          opts.Trials,
+	}
+}
+
+func execRunner(ctx context.Context, name string, args ...string) (string, error) {
+	// The command names are fixed literals at the call sites (git, uname,
+	// docker), never user input — G204 does not apply.
+	out, err := exec.CommandContext(ctx, name, args...).Output() //nolint:gosec
+	return strings.TrimSpace(string(out)), err
+}
+
+// cpuModel and ramBytes read Linux's /proc directly (best-effort); on other
+// platforms, or if the files are unreadable, they return the zero value. The
+// parsing is split into pure functions so it's unit-tested without /proc.
+func cpuModel() string {
+	data, err := os.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		return ""
+	}
+	return parseCPUModel(string(data))
+}
+
+func ramBytes() int64 {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	return parseMemTotalBytes(string(data))
+}
+
+func parseCPUModel(cpuinfo string) string {
+	for _, line := range strings.Split(cpuinfo, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if ok && strings.TrimSpace(key) == "model name" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+// parseMemTotalBytes reads the "MemTotal:" line of /proc/meminfo, which is in
+// kibibytes ("MemTotal:  16311072 kB"), and returns bytes.
+func parseMemTotalBytes(meminfo string) int64 {
+	for _, line := range strings.Split(meminfo, "\n") {
+		rest, ok := strings.CutPrefix(line, "MemTotal:")
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			return 0
+		}
+		kib, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			return 0
+		}
+		return kib * 1024
+	}
+	return 0
+}

--- a/benchmarks/internal/metadata/metadata_test.go
+++ b/benchmarks/internal/metadata/metadata_test.go
@@ -47,8 +47,8 @@ func TestCollectUsesInjectedRunnerAndClock(t *testing.T) {
 	if m.GitCommit != "abc123def456" {
 		t.Errorf("GitCommit = %q", m.GitCommit)
 	}
-	if !m.GitDirty {
-		t.Error("GitDirty = false, want true (git status was non-empty)")
+	if m.GitDirty == nil || !*m.GitDirty {
+		t.Errorf("GitDirty = %v, want a non-nil true (git status was non-empty)", m.GitDirty)
 	}
 	if m.Kernel != "6.1.0-test" {
 		t.Errorf("Kernel = %q", m.Kernel)
@@ -84,12 +84,47 @@ func TestCollectCleanTreeAndMissingToolsDegrade(t *testing.T) {
 		return "ok", nil
 	}
 	m := Collect(context.Background(), Options{Run: run})
-	if m.GitDirty {
-		t.Error("GitDirty = true, want false for an empty git status")
+	if m.GitDirty == nil || *m.GitDirty {
+		t.Errorf("GitDirty = %v, want a non-nil false for an empty git status", m.GitDirty)
 	}
 	// Missing docker must leave the field empty, not fail collection.
 	if m.DockerVersion != "" || m.DockerComposeVersion != "" {
 		t.Errorf("docker versions should be empty when unavailable: %q/%q", m.DockerVersion, m.DockerComposeVersion)
+	}
+}
+
+// A failed `git status` (or missing git) must leave GitDirty unknown (nil),
+// never fail-open to a clean-tree claim — even when rev-parse succeeded and a
+// SHA was recorded.
+func TestCollectGitStatusErrorIsUnknownNotClean(t *testing.T) {
+	run := func(_ context.Context, name string, args ...string) (string, error) {
+		if name == "git" && args[0] == "rev-parse" {
+			return "deadbeef", nil
+		}
+		if name == "git" && args[0] == "status" {
+			return "fatal: not a git repository", context.Canceled // status failed
+		}
+		return "", nil
+	}
+	m := Collect(context.Background(), Options{Run: run})
+	if m.GitCommit != "deadbeef" {
+		t.Errorf("GitCommit = %q, want the SHA rev-parse returned", m.GitCommit)
+	}
+	if m.GitDirty != nil {
+		t.Errorf("GitDirty = %v, want nil (unknown) when git status failed", *m.GitDirty)
+	}
+}
+
+func TestParseCPUModelArmFallback(t *testing.T) {
+	// aarch64 /proc/cpuinfo: no "model name"; devicetree "Model" is the label.
+	arm := "processor\t: 0\nBogoMIPS\t: 108.00\nCPU implementer\t: 0x41\nCPU part\t: 0xd0b\nModel\t\t: Raspberry Pi 5 Model B Rev 1.0\n"
+	if got := parseCPUModel(arm); got != "Raspberry Pi 5 Model B Rev 1.0" {
+		t.Errorf("parseCPUModel(arm) = %q, want the Model line", got)
+	}
+	// A bare ARM cpuinfo with only CPU part codes records unknown, not junk.
+	bare := "processor\t: 0\nCPU implementer\t: 0x41\nCPU part\t: 0xd0b\n"
+	if got := parseCPUModel(bare); got != "" {
+		t.Errorf("parseCPUModel(bare arm) = %q, want empty (unknown)", got)
 	}
 }
 

--- a/benchmarks/internal/metadata/metadata_test.go
+++ b/benchmarks/internal/metadata/metadata_test.go
@@ -1,0 +1,114 @@
+package metadata
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestCollectUsesInjectedRunnerAndClock(t *testing.T) {
+	fixedTime := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	run := func(_ context.Context, name string, args ...string) (string, error) {
+		switch {
+		case name == "git" && len(args) > 0 && args[0] == "rev-parse":
+			return "abc123def456", nil
+		case name == "git" && len(args) > 0 && args[0] == "status":
+			return " M some/file.go", nil // non-empty -> dirty
+		case name == "uname":
+			return "6.1.0-test", nil
+		case name == "docker" && args[0] == "version":
+			return "27.0.1", nil
+		case name == "docker" && args[0] == "compose":
+			return "v2.29.0", nil
+		default:
+			return "", nil
+		}
+	}
+
+	m := Collect(context.Background(), Options{
+		Now:             func() time.Time { return fixedTime },
+		Run:             run,
+		PostgresVersion: "16.4",
+		BenchmarkTool:   "k6 0.55.0",
+		ResourceLimits:  "app 1cpu/512m; pg 2cpu/2g",
+		DurationSeconds: 30,
+		WarmupSeconds:   10,
+		Concurrency:     []int{1, 10, 100},
+		Trials:          5,
+	})
+
+	if m.SchemaVersion != SchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", m.SchemaVersion, SchemaVersion)
+	}
+	if m.Timestamp != "2026-08-26T12:00:00Z" {
+		t.Errorf("Timestamp = %q, want the injected fixed time", m.Timestamp)
+	}
+	if m.GitCommit != "abc123def456" {
+		t.Errorf("GitCommit = %q", m.GitCommit)
+	}
+	if !m.GitDirty {
+		t.Error("GitDirty = false, want true (git status was non-empty)")
+	}
+	if m.Kernel != "6.1.0-test" {
+		t.Errorf("Kernel = %q", m.Kernel)
+	}
+	if m.DockerVersion != "27.0.1" || m.DockerComposeVersion != "v2.29.0" {
+		t.Errorf("docker versions = %q / %q", m.DockerVersion, m.DockerComposeVersion)
+	}
+	// Deterministic host fields come straight from the Go runtime.
+	if m.OS != runtime.GOOS || m.Arch != runtime.GOARCH || m.LogicalCPUs != runtime.NumCPU() {
+		t.Errorf("runtime fields = %q/%q/%d", m.OS, m.Arch, m.LogicalCPUs)
+	}
+	if m.GoVersion != runtime.Version() {
+		t.Errorf("GoVersion = %q, want %q", m.GoVersion, runtime.Version())
+	}
+	// Provided run-parameter fields are copied through verbatim.
+	if m.PostgresVersion != "16.4" || m.BenchmarkTool != "k6 0.55.0" || m.Trials != 5 {
+		t.Errorf("provided fields not copied: %+v", m)
+	}
+	if len(m.Concurrency) != 3 || m.Concurrency[2] != 100 {
+		t.Errorf("Concurrency = %v", m.Concurrency)
+	}
+}
+
+func TestCollectCleanTreeAndMissingToolsDegrade(t *testing.T) {
+	// A runner that returns "" for git status (clean) and errors for docker.
+	run := func(_ context.Context, name string, args ...string) (string, error) {
+		if name == "git" && args[0] == "status" {
+			return "", nil
+		}
+		if name == "docker" {
+			return "", context.DeadlineExceeded // tool "unavailable"
+		}
+		return "ok", nil
+	}
+	m := Collect(context.Background(), Options{Run: run})
+	if m.GitDirty {
+		t.Error("GitDirty = true, want false for an empty git status")
+	}
+	// Missing docker must leave the field empty, not fail collection.
+	if m.DockerVersion != "" || m.DockerComposeVersion != "" {
+		t.Errorf("docker versions should be empty when unavailable: %q/%q", m.DockerVersion, m.DockerComposeVersion)
+	}
+}
+
+func TestParseCPUModel(t *testing.T) {
+	cpuinfo := "processor\t: 0\nvendor_id\t: GenuineIntel\nmodel name\t: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz\ncpu MHz\t: 2600\n"
+	if got := parseCPUModel(cpuinfo); got != "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz" {
+		t.Errorf("parseCPUModel = %q", got)
+	}
+	if got := parseCPUModel("no model here\n"); got != "" {
+		t.Errorf("parseCPUModel(no model) = %q, want empty", got)
+	}
+}
+
+func TestParseMemTotalBytes(t *testing.T) {
+	meminfo := "MemTotal:       16311072 kB\nMemFree:         1234567 kB\n"
+	if got := parseMemTotalBytes(meminfo); got != 16311072*1024 {
+		t.Errorf("parseMemTotalBytes = %d, want %d", got, int64(16311072)*1024)
+	}
+	if got := parseMemTotalBytes("MemFree: 100 kB\n"); got != 0 {
+		t.Errorf("parseMemTotalBytes(no MemTotal) = %d, want 0", got)
+	}
+}

--- a/benchmarks/internal/result/result.go
+++ b/benchmarks/internal/result/result.go
@@ -49,18 +49,44 @@ type Result struct {
 	RSSBytes          int64   `json:"rss_bytes"`
 }
 
+// sortedCopy returns results ordered deterministically by (framework,
+// benchmark, concurrency, trial), so any regenerated artifact — the canonical
+// results.json as well as the derived results.csv — diffs cleanly regardless
+// of the order rows were collected in.
+func sortedCopy(results []Result) []Result {
+	out := make([]Result, len(results))
+	copy(out, results)
+	sort.SliceStable(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		switch {
+		case a.Framework != b.Framework:
+			return a.Framework < b.Framework
+		case a.Benchmark != b.Benchmark:
+			return a.Benchmark < b.Benchmark
+		case a.Concurrency != b.Concurrency:
+			return a.Concurrency < b.Concurrency
+		default:
+			return a.Trial < b.Trial
+		}
+	})
+	return out
+}
+
 // WriteJSON encodes results as a pretty-printed JSON array. This is the
 // canonical machine-readable output; results.csv and the Markdown report are
-// derived from it.
+// derived from it. Rows are sorted the same way WriteCSV sorts them, so the
+// committed results.json is stable across runs that collected rows in a
+// different order.
 func WriteJSON(w io.Writer, results []Result) error {
 	// Never emit `null` for an empty run — an empty array is the honest,
 	// still-parseable representation.
-	if results == nil {
-		results = []Result{}
+	out := sortedCopy(results)
+	if out == nil {
+		out = []Result{}
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(results)
+	return enc.Encode(out)
 }
 
 // ReadJSON decodes a results.json produced by WriteJSON.
@@ -99,21 +125,7 @@ var csvHeader = []string{
 // (framework, benchmark, concurrency, trial) so a regenerated file diffs
 // cleanly regardless of the order rows were collected in.
 func WriteCSV(w io.Writer, results []Result) error {
-	sorted := make([]Result, len(results))
-	copy(sorted, results)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		a, b := sorted[i], sorted[j]
-		switch {
-		case a.Framework != b.Framework:
-			return a.Framework < b.Framework
-		case a.Benchmark != b.Benchmark:
-			return a.Benchmark < b.Benchmark
-		case a.Concurrency != b.Concurrency:
-			return a.Concurrency < b.Concurrency
-		default:
-			return a.Trial < b.Trial
-		}
-	})
+	sorted := sortedCopy(results)
 
 	cw := csv.NewWriter(w)
 	if err := cw.Write(csvHeader); err != nil {

--- a/benchmarks/internal/result/result.go
+++ b/benchmarks/internal/result/result.go
@@ -1,0 +1,155 @@
+// Package result defines the machine-readable benchmark result schema
+// (issue #141 §9) that every benchmark run writes, and the JSON/CSV encoders
+// the summarizer and report generator read back. Markdown is never the
+// canonical data source — it is generated from this.
+package result
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+)
+
+// SchemaVersion is bumped when the Result shape changes incompatibly, so a
+// stored results.json can be recognized (or rejected) by a later summarizer.
+const SchemaVersion = 1
+
+// Latency holds the tail-latency percentiles for a single trial, in
+// milliseconds.
+type Latency struct {
+	P50 float64 `json:"p50"`
+	P95 float64 `json:"p95"`
+	P99 float64 `json:"p99"`
+}
+
+// Result is one row: one implementation, one workload, one concurrency
+// level, one trial. Issue #141 §9's recommended schema, plus schema_version.
+// One trial per Result — variance across trials is computed by the
+// summarizer from the set of rows sharing a (Framework, Benchmark,
+// Concurrency) key, not stored here.
+type Result struct {
+	SchemaVersion     int     `json:"schema_version"`
+	Framework         string  `json:"framework"`
+	FrameworkVersion  string  `json:"framework_version"`
+	Runtime           string  `json:"runtime"`
+	RuntimeVersion    string  `json:"runtime_version"`
+	Benchmark         string  `json:"benchmark"`
+	Database          string  `json:"database"`
+	Concurrency       int     `json:"concurrency"`
+	Trial             int     `json:"trial"`
+	DurationSeconds   float64 `json:"duration_seconds"`
+	Requests          int64   `json:"requests"`
+	RequestsPerSecond float64 `json:"requests_per_second"`
+	LatencyMs         Latency `json:"latency_ms"`
+	Errors            int64   `json:"errors"`
+	CPUPercent        float64 `json:"cpu_percent"`
+	RSSBytes          int64   `json:"rss_bytes"`
+}
+
+// WriteJSON encodes results as a pretty-printed JSON array. This is the
+// canonical machine-readable output; results.csv and the Markdown report are
+// derived from it.
+func WriteJSON(w io.Writer, results []Result) error {
+	// Never emit `null` for an empty run — an empty array is the honest,
+	// still-parseable representation.
+	if results == nil {
+		results = []Result{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(results)
+}
+
+// ReadJSON decodes a results.json produced by WriteJSON.
+func ReadJSON(r io.Reader) ([]Result, error) {
+	var results []Result
+	if err := json.NewDecoder(r).Decode(&results); err != nil {
+		return nil, fmt.Errorf("decode results json: %w", err)
+	}
+	return results, nil
+}
+
+// csvHeader is the flattened column order for results.csv; latency_ms is
+// spread into p50/p95/p99 columns.
+var csvHeader = []string{
+	"schema_version",
+	"framework",
+	"framework_version",
+	"runtime",
+	"runtime_version",
+	"benchmark",
+	"database",
+	"concurrency",
+	"trial",
+	"duration_seconds",
+	"requests",
+	"requests_per_second",
+	"latency_p50_ms",
+	"latency_p95_ms",
+	"latency_p99_ms",
+	"errors",
+	"cpu_percent",
+	"rss_bytes",
+}
+
+// WriteCSV writes results as CSV with a fixed header, sorted deterministically
+// (framework, benchmark, concurrency, trial) so a regenerated file diffs
+// cleanly regardless of the order rows were collected in.
+func WriteCSV(w io.Writer, results []Result) error {
+	sorted := make([]Result, len(results))
+	copy(sorted, results)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		a, b := sorted[i], sorted[j]
+		switch {
+		case a.Framework != b.Framework:
+			return a.Framework < b.Framework
+		case a.Benchmark != b.Benchmark:
+			return a.Benchmark < b.Benchmark
+		case a.Concurrency != b.Concurrency:
+			return a.Concurrency < b.Concurrency
+		default:
+			return a.Trial < b.Trial
+		}
+	})
+
+	cw := csv.NewWriter(w)
+	if err := cw.Write(csvHeader); err != nil {
+		return fmt.Errorf("write csv header: %w", err)
+	}
+	for _, r := range sorted {
+		row := []string{
+			strconv.Itoa(r.SchemaVersion),
+			r.Framework,
+			r.FrameworkVersion,
+			r.Runtime,
+			r.RuntimeVersion,
+			r.Benchmark,
+			r.Database,
+			strconv.Itoa(r.Concurrency),
+			strconv.Itoa(r.Trial),
+			formatFloat(r.DurationSeconds),
+			strconv.FormatInt(r.Requests, 10),
+			formatFloat(r.RequestsPerSecond),
+			formatFloat(r.LatencyMs.P50),
+			formatFloat(r.LatencyMs.P95),
+			formatFloat(r.LatencyMs.P99),
+			strconv.FormatInt(r.Errors, 10),
+			formatFloat(r.CPUPercent),
+			strconv.FormatInt(r.RSSBytes, 10),
+		}
+		if err := cw.Write(row); err != nil {
+			return fmt.Errorf("write csv row: %w", err)
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+// formatFloat renders a float without a trailing ".0" for integers and with
+// no scientific notation, so the CSV stays human-diffable.
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}

--- a/benchmarks/internal/result/result_test.go
+++ b/benchmarks/internal/result/result_test.go
@@ -1,0 +1,114 @@
+package result
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func sampleResults() []Result {
+	return []Result{
+		{
+			SchemaVersion: SchemaVersion, Framework: "gombit", FrameworkVersion: "v0.1.0",
+			Runtime: "go", RuntimeVersion: "go1.25.7", Benchmark: "crud-list",
+			Database: "postgresql", Concurrency: 100, Trial: 2, DurationSeconds: 30,
+			Requests: 123456, RequestsPerSecond: 4115.2,
+			LatencyMs: Latency{P50: 10.1, P95: 21.8, P99: 32.4},
+			Errors:    0, CPUPercent: 55.5, RSSBytes: 41943040,
+		},
+		{
+			SchemaVersion: SchemaVersion, Framework: "gin-gorm", FrameworkVersion: "v1.11.0",
+			Runtime: "go", RuntimeVersion: "go1.25.7", Benchmark: "crud-list",
+			Database: "postgresql", Concurrency: 100, Trial: 1, DurationSeconds: 30,
+			Requests: 200000, RequestsPerSecond: 6666.6,
+			LatencyMs: Latency{P50: 5, P95: 12, P99: 20},
+		},
+	}
+}
+
+func TestJSONRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, sampleResults()); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	got, err := ReadJSON(&buf)
+	if err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	want := sampleResults()
+	if len(got) != len(want) {
+		t.Fatalf("round trip len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("row %d round trip = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestJSONUsesSnakeCaseAndNestedLatency(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, sampleResults()[:1]); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	s := buf.String()
+	for _, want := range []string{
+		`"requests_per_second": 4115.2`,
+		`"latency_ms": {`,
+		`"p95": 21.8`,
+		`"schema_version": 1`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("json missing %q\n%s", want, s)
+		}
+	}
+}
+
+func TestWriteJSONEmptyIsArrayNotNull(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, nil); err != nil {
+		t.Fatalf("WriteJSON(nil): %v", err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "[]" {
+		t.Errorf("WriteJSON(nil) = %q, want []", got)
+	}
+}
+
+func TestWriteCSVHeaderAndSortOrder(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteCSV(&buf, sampleResults()); err != nil {
+		t.Fatalf("WriteCSV: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("csv has %d lines, want 3 (header + 2 rows)", len(lines))
+	}
+	if !strings.HasPrefix(lines[0], "schema_version,framework,") {
+		t.Errorf("csv header = %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "latency_p50_ms,latency_p95_ms,latency_p99_ms") {
+		t.Errorf("csv header missing flattened latency columns: %q", lines[0])
+	}
+	// Sorted by framework: gin-gorm before gombit, regardless of input order.
+	if !strings.HasPrefix(lines[1], "1,gin-gorm,") {
+		t.Errorf("first data row = %q, want gin-gorm first (deterministic sort)", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "1,gombit,") {
+		t.Errorf("second data row = %q, want gombit second", lines[2])
+	}
+}
+
+func TestFormatFloatNoTrailingZeroOrScientific(t *testing.T) {
+	cases := map[float64]string{
+		30:      "30",
+		4115.2:  "4115.2",
+		0:       "0",
+		0.00001: "0.00001",
+	}
+	for in, want := range cases {
+		if got := formatFloat(in); got != want {
+			t.Errorf("formatFloat(%v) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/benchmarks/internal/result/result_test.go
+++ b/benchmarks/internal/result/result_test.go
@@ -2,6 +2,7 @@ package result
 
 import (
 	"bytes"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -36,7 +37,9 @@ func TestJSONRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadJSON: %v", err)
 	}
-	want := sampleResults()
+	// WriteJSON emits rows in the canonical sorted order, so the round trip
+	// comes back sorted regardless of input order.
+	want := sortedCopy(sampleResults())
 	if len(got) != len(want) {
 		t.Fatalf("round trip len = %d, want %d", len(got), len(want))
 	}
@@ -75,27 +78,86 @@ func TestWriteJSONEmptyIsArrayNotNull(t *testing.T) {
 	}
 }
 
-func TestWriteCSVHeaderAndSortOrder(t *testing.T) {
+func TestWriteCSVHeader(t *testing.T) {
 	var buf bytes.Buffer
 	if err := WriteCSV(&buf, sampleResults()); err != nil {
 		t.Fatalf("WriteCSV: %v", err)
 	}
-	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-	if len(lines) != 3 {
-		t.Fatalf("csv has %d lines, want 3 (header + 2 rows)", len(lines))
+	header := strings.SplitN(strings.TrimSpace(buf.String()), "\n", 2)[0]
+	if !strings.HasPrefix(header, "schema_version,framework,") {
+		t.Errorf("csv header = %q", header)
 	}
-	if !strings.HasPrefix(lines[0], "schema_version,framework,") {
-		t.Errorf("csv header = %q", lines[0])
+	if !strings.Contains(header, "latency_p50_ms,latency_p95_ms,latency_p99_ms") {
+		t.Errorf("csv header missing flattened latency columns: %q", header)
 	}
-	if !strings.Contains(lines[0], "latency_p50_ms,latency_p95_ms,latency_p99_ms") {
-		t.Errorf("csv header missing flattened latency columns: %q", lines[0])
+}
+
+// sortFixture shares a framework and benchmark across rows and differs on the
+// later sort keys (benchmark, concurrency, trial), so the full comparator is
+// exercised — a comparator that only compared Framework would pass the old
+// two-row test but fail here.
+func sortFixture() []Result {
+	r := func(framework, benchmark string, concurrency, trial int) Result {
+		return Result{SchemaVersion: SchemaVersion, Framework: framework, Benchmark: benchmark, Concurrency: concurrency, Trial: trial}
 	}
-	// Sorted by framework: gin-gorm before gombit, regardless of input order.
-	if !strings.HasPrefix(lines[1], "1,gin-gorm,") {
-		t.Errorf("first data row = %q, want gin-gorm first (deterministic sort)", lines[1])
+	// Deliberately unsorted input.
+	return []Result{
+		r("gombit", "crud-list", 100, 2),
+		r("gombit", "crud-list", 100, 1),
+		r("gombit", "crud-list", 10, 1),
+		r("gombit", "auth", 100, 1),
+		r("gin-gorm", "crud-list", 10, 1),
 	}
-	if !strings.HasPrefix(lines[2], "1,gombit,") {
-		t.Errorf("second data row = %q, want gombit second", lines[2])
+}
+
+func wantSortedKeys() [][4]any {
+	return [][4]any{
+		{"gin-gorm", "crud-list", 10, 1},
+		{"gombit", "auth", 100, 1},
+		{"gombit", "crud-list", 10, 1},
+		{"gombit", "crud-list", 100, 1},
+		{"gombit", "crud-list", 100, 2},
+	}
+}
+
+func TestSortOrderIsFullKeyForBothEncoders(t *testing.T) {
+	want := wantSortedKeys()
+
+	// CSV rows, in order (skip the header).
+	var csvBuf bytes.Buffer
+	if err := WriteCSV(&csvBuf, sortFixture()); err != nil {
+		t.Fatalf("WriteCSV: %v", err)
+	}
+	rows := strings.Split(strings.TrimSpace(csvBuf.String()), "\n")[1:]
+	if len(rows) != len(want) {
+		t.Fatalf("csv rows = %d, want %d", len(rows), len(want))
+	}
+	for i, w := range want {
+		cols := strings.Split(rows[i], ",")
+		// framework(col 1), benchmark(col 5), concurrency(col 7), trial(col 8)
+		if cols[1] != w[0] || cols[5] != w[1] ||
+			cols[7] != strconv.Itoa(w[2].(int)) || cols[8] != strconv.Itoa(w[3].(int)) {
+			t.Errorf("csv row %d = %q, want key %v", i, rows[i], w)
+		}
+	}
+
+	// The canonical JSON must be sorted the same way, not collection order.
+	var jsonBuf bytes.Buffer
+	if err := WriteJSON(&jsonBuf, sortFixture()); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	got, err := ReadJSON(&jsonBuf)
+	if err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("json rows = %d, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].Framework != w[0] || got[i].Benchmark != w[1] ||
+			got[i].Concurrency != w[2] || got[i].Trial != w[3] {
+			t.Errorf("json row %d = %+v, want key %v", i, got[i], w)
+		}
 	}
 }
 

--- a/benchmarks/results/README.md
+++ b/benchmarks/results/README.md
@@ -1,0 +1,29 @@
+# benchmarks/results
+
+Generated benchmark output (issue #141 §9). **Nothing here is hand-edited** —
+Markdown is never the canonical data source; it is generated from the
+structured results.
+
+A full run writes a `latest/` snapshot:
+
+```text
+results/
+└── latest/
+    ├── metadata.json   reproducibility metadata (benchmarks/internal/metadata)
+    ├── raw/            per-trial raw load-generator output (k6 JSON, ...)
+    ├── results.json    the canonical structured results (benchmarks/internal/result)
+    ├── results.csv     flat CSV derived from results.json
+    └── summary.md      human-readable tables derived from results.json
+```
+
+`results.json` / `results.csv` are the machine-readable schema defined in
+[`benchmarks/internal/result`](../internal/result); `metadata.json` is the
+[`benchmarks/internal/metadata`](../internal/metadata) shape, collected by
+[`benchmarks/scripts/collect-host-info`](../scripts/collect-host-info).
+
+`latest/` is committed once the run pipeline exists (Phase 7 of
+[docs/plans/BENCH-1-benchmark-suite.md](../../docs/plans/BENCH-1-benchmark-suite.md)),
+so the published README performance tables are always regenerable from a
+committed snapshot. It does not exist yet — the schema, collector, and config
+pins land first (Phase 1 completion); the orchestration that fills `latest/`
+is the next slice.

--- a/benchmarks/scripts/collect-host-info/main.go
+++ b/benchmarks/scripts/collect-host-info/main.go
@@ -27,16 +27,26 @@ func main() {
 	warmup := flag.Float64("warmup-seconds", 0, "warm-up duration before measuring")
 	concurrency := flag.String("concurrency", "", "comma-separated concurrency levels, e.g. '1,10,100'")
 	trials := flag.Int("trials", 0, "number of trials per concurrency level")
+	frameworkVersions := flag.String("framework-versions", "", "comma-separated framework=version pairs, e.g. 'gombit=v0.1.0,gin-gorm=v1.11.0'")
+	runtimeVersions := flag.String("runtime-versions", "", "comma-separated runtime=version pairs, e.g. 'go=1.25.7,node=24'")
 	flag.Parse()
 
+	concurrencyLevels, err := parseIntList(*concurrency)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "collect-host-info: -concurrency: %v\n", err)
+		os.Exit(1)
+	}
+
 	m := metadata.Collect(context.Background(), metadata.Options{
-		PostgresVersion: *postgres,
-		BenchmarkTool:   *benchmarkTool,
-		ResourceLimits:  *resourceLimits,
-		DurationSeconds: *duration,
-		WarmupSeconds:   *warmup,
-		Concurrency:     parseIntList(*concurrency),
-		Trials:          *trials,
+		PostgresVersion:   *postgres,
+		FrameworkVersions: parseKeyVals(*frameworkVersions),
+		RuntimeVersions:   parseKeyVals(*runtimeVersions),
+		BenchmarkTool:     *benchmarkTool,
+		ResourceLimits:    *resourceLimits,
+		DurationSeconds:   *duration,
+		WarmupSeconds:     *warmup,
+		Concurrency:       concurrencyLevels,
+		Trials:            *trials,
 	})
 
 	if err := write(*out, m); err != nil {
@@ -64,17 +74,40 @@ func write(path string, m metadata.Metadata) error {
 	return f.Close()
 }
 
-func parseIntList(s string) []int {
+// parseIntList parses a comma-separated integer list. A malformed token is a
+// hard error, not a silently dropped element: this metadata records what a
+// benchmark run actually swept, so "1,10,abc,100" must fail rather than be
+// recorded as the different (and untrue) sweep "1,10,100".
+func parseIntList(s string) ([]int, error) {
 	if strings.TrimSpace(s) == "" {
-		return nil
+		return nil, nil
 	}
 	var out []int
 	for _, part := range strings.Split(s, ",") {
-		n, err := strconv.Atoi(strings.TrimSpace(part))
+		token := strings.TrimSpace(part)
+		n, err := strconv.Atoi(token)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("invalid integer %q", token)
 		}
 		out = append(out, n)
+	}
+	return out, nil
+}
+
+// parseKeyVals parses comma-separated key=value pairs into a map. Empty input
+// yields an empty (non-nil) map so downstream JSON is {} rather than null.
+func parseKeyVals(s string) map[string]string {
+	out := map[string]string{}
+	for _, part := range strings.Split(s, ",") {
+		token := strings.TrimSpace(part)
+		if token == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(token, "=")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(key)] = strings.TrimSpace(value)
 	}
 	return out
 }

--- a/benchmarks/scripts/collect-host-info/main.go
+++ b/benchmarks/scripts/collect-host-info/main.go
@@ -1,0 +1,80 @@
+// Command collect-host-info writes the reproducibility metadata for a
+// benchmark run (issue #141 "Reproducibility metadata") as JSON. The host and
+// toolchain fields are discovered automatically; the run-parameter fields
+// (durations, concurrency, trials, resource limits, tool versions) are passed
+// as flags by the orchestrator that knows them.
+//
+//	go run ./benchmarks/scripts/collect-host-info -out benchmarks/results/latest/metadata.json
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/gombit-dev/gombit/benchmarks/internal/metadata"
+)
+
+func main() {
+	out := flag.String("out", "", "output file for metadata.json (default: stdout)")
+	postgres := flag.String("postgres-version", "", "PostgreSQL version under test")
+	benchmarkTool := flag.String("benchmark-tool", "", "load generator name+version, e.g. 'k6 0.55.0'")
+	resourceLimits := flag.String("resource-limits", "", "documented resource limits for this run")
+	duration := flag.Float64("duration-seconds", 0, "per-trial measured duration")
+	warmup := flag.Float64("warmup-seconds", 0, "warm-up duration before measuring")
+	concurrency := flag.String("concurrency", "", "comma-separated concurrency levels, e.g. '1,10,100'")
+	trials := flag.Int("trials", 0, "number of trials per concurrency level")
+	flag.Parse()
+
+	m := metadata.Collect(context.Background(), metadata.Options{
+		PostgresVersion: *postgres,
+		BenchmarkTool:   *benchmarkTool,
+		ResourceLimits:  *resourceLimits,
+		DurationSeconds: *duration,
+		WarmupSeconds:   *warmup,
+		Concurrency:     parseIntList(*concurrency),
+		Trials:          *trials,
+	})
+
+	if err := write(*out, m); err != nil {
+		fmt.Fprintf(os.Stderr, "collect-host-info: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// write encodes m to path (or stdout when path is empty), checking the close
+// error on the output file so a full-disk / short-write failure is not lost.
+func write(path string, m metadata.Metadata) error {
+	if path == "" {
+		return metadata.WriteJSON(os.Stdout, m)
+	}
+	// path is the operator-supplied -out flag (a CLI writing its own output
+	// file), not untrusted input — G304 does not apply.
+	f, err := os.Create(path) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	if err := metadata.WriteJSON(f, m); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+func parseIntList(s string) []int {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var out []int
+	for _, part := range strings.Split(s, ",") {
+		n, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}

--- a/benchmarks/scripts/collect-host-info/main.go
+++ b/benchmarks/scripts/collect-host-info/main.go
@@ -33,14 +33,21 @@ func main() {
 
 	concurrencyLevels, err := parseIntList(*concurrency)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "collect-host-info: -concurrency: %v\n", err)
-		os.Exit(1)
+		fatalf("-concurrency: %v", err)
+	}
+	frameworks, err := parseKeyVals(*frameworkVersions)
+	if err != nil {
+		fatalf("-framework-versions: %v", err)
+	}
+	runtimes, err := parseKeyVals(*runtimeVersions)
+	if err != nil {
+		fatalf("-runtime-versions: %v", err)
 	}
 
 	m := metadata.Collect(context.Background(), metadata.Options{
 		PostgresVersion:   *postgres,
-		FrameworkVersions: parseKeyVals(*frameworkVersions),
-		RuntimeVersions:   parseKeyVals(*runtimeVersions),
+		FrameworkVersions: frameworks,
+		RuntimeVersions:   runtimes,
 		BenchmarkTool:     *benchmarkTool,
 		ResourceLimits:    *resourceLimits,
 		DurationSeconds:   *duration,
@@ -50,9 +57,13 @@ func main() {
 	})
 
 	if err := write(*out, m); err != nil {
-		fmt.Fprintf(os.Stderr, "collect-host-info: %v\n", err)
-		os.Exit(1)
+		fatalf("%v", err)
 	}
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "collect-host-info: "+format+"\n", args...)
+	os.Exit(1)
 }
 
 // write encodes m to path (or stdout when path is empty), checking the close
@@ -94,20 +105,36 @@ func parseIntList(s string) ([]int, error) {
 	return out, nil
 }
 
-// parseKeyVals parses comma-separated key=value pairs into a map. Empty input
-// yields an empty (non-nil) map so downstream JSON is {} rather than null.
-func parseKeyVals(s string) map[string]string {
+// parseKeyVals parses comma-separated key=value pairs into a map. Like
+// parseIntList, it fails closed: a token with no '=' (a bare 'django'), an
+// empty key, or a duplicate key is an error, not a silently dropped element —
+// these are the required framework_versions / runtime_versions this metadata
+// records, so a forgotten '=' must fail rather than omit the version that ran.
+// Empty input yields an empty (non-nil) map so downstream JSON is {} not null.
+func parseKeyVals(s string) (map[string]string, error) {
 	out := map[string]string{}
 	for _, part := range strings.Split(s, ",") {
 		token := strings.TrimSpace(part)
 		if token == "" {
-			continue
+			// A leading/trailing/doubled comma is malformed input for a
+			// record of exactly what ran, not a value to skip.
+			if strings.TrimSpace(s) == "" {
+				continue // wholly empty input -> empty map, no pairs
+			}
+			return nil, fmt.Errorf("empty key=value pair in %q", s)
 		}
 		key, value, ok := strings.Cut(token, "=")
 		if !ok {
-			continue
+			return nil, fmt.Errorf("missing '=' in %q", token)
 		}
-		out[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("empty key in %q", token)
+		}
+		if _, dup := out[key]; dup {
+			return nil, fmt.Errorf("duplicate key %q", key)
+		}
+		out[key] = strings.TrimSpace(value)
 	}
-	return out
+	return out, nil
 }

--- a/benchmarks/scripts/collect-host-info/main_test.go
+++ b/benchmarks/scripts/collect-host-info/main_test.go
@@ -33,19 +33,46 @@ func TestParseIntListValid(t *testing.T) {
 }
 
 func TestParseKeyValsEmptyIsNonNilMap(t *testing.T) {
-	m := parseKeyVals("")
+	m, err := parseKeyVals("")
+	if err != nil {
+		t.Fatalf("parseKeyVals(\"\"): %v", err)
+	}
 	if m == nil {
 		t.Fatal("parseKeyVals(\"\") = nil; want an empty (non-nil) map")
 	}
 	if len(m) != 0 {
 		t.Errorf("parseKeyVals(\"\") = %v, want empty", m)
 	}
+}
 
-	got := parseKeyVals("gombit=v0.1.0, gin-gorm=v1.11.0 ,malformed,go=1.25.7")
+func TestParseKeyValsValid(t *testing.T) {
+	got, err := parseKeyVals("gombit=v0.1.0, gin-gorm=v1.11.0 ,go=1.25.7,empty=")
+	if err != nil {
+		t.Fatalf("parseKeyVals: %v", err)
+	}
 	if got["gombit"] != "v0.1.0" || got["gin-gorm"] != "v1.11.0" || got["go"] != "1.25.7" {
 		t.Errorf("parseKeyVals = %v", got)
 	}
-	if _, ok := got["malformed"]; ok {
-		t.Errorf("parseKeyVals kept a token with no '=': %v", got)
+	// An explicit empty value (django=) is a recorded fact, kept; a missing
+	// '=' (django) is not — see TestParseKeyValsFailsClosed.
+	if v, ok := got["empty"]; !ok || v != "" {
+		t.Errorf("parseKeyVals should keep an explicit empty value: %v", got)
+	}
+}
+
+// The sibling of parseIntList must fail closed too: a token that can't be a
+// key=value pair is an error, never a silently dropped version. Otherwise the
+// document claims a framework/runtime set that isn't what ran.
+func TestParseKeyValsFailsClosed(t *testing.T) {
+	for _, in := range []string{
+		"gombit=v0.1.0,django",        // 'django' has no '='
+		"go=1.25.7,python",            // 'python' has no '='
+		"gombit=v0.1.0,",              // trailing comma
+		"=v0.1.0",                     // empty key
+		"gombit=v0.1.0,gombit=v0.2.0", // duplicate key
+	} {
+		if got, err := parseKeyVals(in); err == nil {
+			t.Errorf("parseKeyVals(%q) = %v, nil; want an error", in, got)
+		}
 	}
 }

--- a/benchmarks/scripts/collect-host-info/main_test.go
+++ b/benchmarks/scripts/collect-host-info/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+func TestParseIntListRejectsInvalidToken(t *testing.T) {
+	// A malformed token is an error, not a silently dropped element — the
+	// recorded sweep must equal the requested one or fail.
+	for _, in := range []string{"1,10,abc,100", "1,,10", "100o", "1, 2, x"} {
+		if got, err := parseIntList(in); err == nil {
+			t.Errorf("parseIntList(%q) = %v, nil; want an error", in, got)
+		}
+	}
+}
+
+func TestParseIntListValid(t *testing.T) {
+	got, err := parseIntList("1, 10 , 100,500,1000")
+	if err != nil {
+		t.Fatalf("parseIntList: %v", err)
+	}
+	want := []int{1, 10, 100, 500, 1000}
+	if len(got) != len(want) {
+		t.Fatalf("parseIntList len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("parseIntList[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+
+	if got, err := parseIntList(""); err != nil || got != nil {
+		t.Errorf("parseIntList(\"\") = %v, %v; want nil, nil", got, err)
+	}
+}
+
+func TestParseKeyValsEmptyIsNonNilMap(t *testing.T) {
+	m := parseKeyVals("")
+	if m == nil {
+		t.Fatal("parseKeyVals(\"\") = nil; want an empty (non-nil) map")
+	}
+	if len(m) != 0 {
+		t.Errorf("parseKeyVals(\"\") = %v, want empty", m)
+	}
+
+	got := parseKeyVals("gombit=v0.1.0, gin-gorm=v1.11.0 ,malformed,go=1.25.7")
+	if got["gombit"] != "v0.1.0" || got["gin-gorm"] != "v1.11.0" || got["go"] != "1.25.7" {
+		t.Errorf("parseKeyVals = %v", got)
+	}
+	if _, ok := got["malformed"]; ok {
+		t.Errorf("parseKeyVals kept a token with no '=': %v", got)
+	}
+}

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -181,14 +181,52 @@ SQLite/PostgreSQL/MySQL matrix green throughout (AGENTS.md §5.1).
   `metadata.json` (host discovery + run parameters passed as flags); verified
   end-to-end producing real metadata on the dev host.
 - Pin and document the load generator (k6) and PostgreSQL image (§4). —
-  **done** in `benchmarks/config/versions.env` (k6 version, `postgres:16.4-alpine`,
-  the 2 vCPU/2 GiB resource limits, `POOL_MAX_OPEN=20`, and the workload
-  concurrency/duration/warm-up/trial defaults), a single source of truth the
-  orchestrator will source and feed to the metadata collector.
+  **done** in `benchmarks/config/versions.env` (k6 version, `POSTGRES_IMAGE`,
+  the §7 resource limits — Postgres 2 vCPU/2 GiB, app 2 vCPU/**1 GiB** —
+  `POOL_MAX_OPEN=20`, and the workload concurrency (`1,10,100,500,1000`)/
+  duration/warm-up/trial defaults), a single source of truth the orchestrator
+  sources and feeds to the metadata collector. `benchmarks/compose.yml`
+  references `${POSTGRES_IMAGE}` so the image pin lives in exactly one place.
 - **AC:** `go build ./benchmarks/...` succeeds (it does, including the new
   packages, and `go test ./...` covers their unit tests); `docs/GOMBIT_BUILD_PLAN.md`
   has the new entry. Satisfied for the schema/collector/config; the
   `make benchmark-*` orchestration that consumes them is the next slice.
+
+**Post-landing correction (review on PR #183,
+github.com/gombit-dev/gombit/pull/183#pullrequestreview-5034253957):** five
+findings, all real — the row schema was right but the reproducibility contract
+fail-opened the very fields it exists to capture. All fixed and tested.
+
+- `GitDirty` was a plain `bool`, so a failed/missing `git status` recorded
+  `git_dirty: false` — a clean-tree claim for a check that never ran, even
+  when `rev-parse` had returned a SHA. Changed to `*bool`, set only when the
+  status check succeeds; a failure leaves it nil (JSON `null` = unknown).
+  Added a test where `rev-parse` succeeds and `status` errors, asserting
+  `git_dirty` is null, not false.
+- The CLI's `parseIntList` silently dropped invalid concurrency tokens
+  (`1,10,abc,100` → `[1,10,100]`, exit 0) — a recorder writing a different
+  sweep than it was given and calling it success. Now returns an error and the
+  CLI exits 1; tested (`main_test.go`).
+- `framework_versions`/`runtime_versions`/`concurrency` serialized as JSON
+  `null` at the CLI's default (no flags). `Collect` now initializes empty
+  maps/slice (`{}`/`[]`), the CLI gained `-framework-versions`/
+  `-runtime-versions` flags, and a wire-shape test (`json.go` previously had
+  none) fails if any of them encodes as null. Also gave `parseCPUModel` an
+  ARM/aarch64 fallback (`Model`/`Hardware`, since ARM `/proc/cpuinfo` has no
+  `model name`), tested.
+- `versions.env` had `APP_MEMORY=2g` (the issue's app budget is **1 GiB** —
+  the Postgres number had been copied onto the app), omitted `1000` from the
+  concurrency set the issue's minimum requires (a comment isn't a pin), and
+  duplicated the Postgres image already pinned in `compose.yml`. Corrected the
+  app memory, put `1000` in the data (the orchestrator attempts and, if
+  unsustainable, drops it from the *reported* set), and pointed `compose.yml`
+  at `${POSTGRES_IMAGE}` so the pin is single-sourced.
+- Deterministic sorting was applied to the derived CSV but not the canonical
+  `results.json` (the artifact Phase 7 commits), and the CSV sort test only
+  distinguished rows by `framework`. Extracted one `sortedCopy` used by both
+  encoders, and added a fixture that shares `framework` and differs on
+  benchmark/concurrency/trial so the full comparator is exercised for both
+  JSON and CSV.
 
 ### Phase 2 — Go abstraction-overhead microbenchmarks — **done**
 

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -162,18 +162,33 @@ SQLite/PostgreSQL/MySQL matrix green throughout (AGENTS.md §5.1).
 
 - Add the BENCH-1 backlog entry (§2). — **done**
 - Create the `benchmarks/` directory tree (§5); `micro/` landed in Phase 2,
-  the rest (`apps/`, `workloads/`, `scripts/`, `config/`, `results/`,
-  `docs/`) is still open.
+  `apps/` in Phase 3-4, and `internal/`, `scripts/`, `config/`, `results/`,
+  `docs/` now exist (`workloads/` and the `make benchmark-*` orchestration are
+  still open, next slice).
 - Implement the result schema + metadata collector in `benchmarks/internal/`
-  (Go structs matching the issue's `results.json` shape; a `metadata.json`
-  collector reading `git rev-parse`, `uname`, `go version`, `docker version`,
-  `docker compose version`, CPU/RAM). — not yet done.
-- Pin and document the load generator (k6) and PostgreSQL image (§4). — not
-  yet done.
-- **AC:** `go build ./benchmarks/...` succeeds; `docs/GOMBIT_BUILD_PLAN.md`
-  has the new entry. Partially satisfied — the backlog entry and `micro/`
-  build, but the result-schema/metadata-collector/load-generator work is
-  still open.
+  — **done.** `benchmarks/internal/result` is the `results.json` schema (issue
+  §9's recommended shape plus a `schema_version`), with JSON and CSV encoders
+  (the CSV flattens `latency_ms` and sorts deterministically so a regenerated
+  file diffs cleanly), unit-tested for round-trip, snake_case/nested-latency
+  wire shape, empty-is-`[]`-not-`null`, and sort order.
+  `benchmarks/internal/metadata` is the reproducibility-metadata struct and a
+  best-effort collector (git SHA + dirty, `uname`, `docker`/`compose`
+  versions via an **injectable** `Runner` so it's tested without those tools
+  installed; OS/arch/logical-CPU/Go-version from `runtime`; CPU model + RAM
+  parsed from `/proc` via pure, separately-tested functions). A missing tool
+  degrades to an empty field rather than failing the run.
+  `benchmarks/scripts/collect-host-info` is the thin CLI that writes
+  `metadata.json` (host discovery + run parameters passed as flags); verified
+  end-to-end producing real metadata on the dev host.
+- Pin and document the load generator (k6) and PostgreSQL image (§4). —
+  **done** in `benchmarks/config/versions.env` (k6 version, `postgres:16.4-alpine`,
+  the 2 vCPU/2 GiB resource limits, `POOL_MAX_OPEN=20`, and the workload
+  concurrency/duration/warm-up/trial defaults), a single source of truth the
+  orchestrator will source and feed to the metadata collector.
+- **AC:** `go build ./benchmarks/...` succeeds (it does, including the new
+  packages, and `go test ./...` covers their unit tests); `docs/GOMBIT_BUILD_PLAN.md`
+  has the new entry. Satisfied for the schema/collector/config; the
+  `make benchmark-*` orchestration that consumes them is the next slice.
 
 ### Phase 2 — Go abstraction-overhead microbenchmarks — **done**
 

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -192,7 +192,21 @@ SQLite/PostgreSQL/MySQL matrix green throughout (AGENTS.md §5.1).
   has the new entry. Satisfied for the schema/collector/config; the
   `make benchmark-*` orchestration that consumes them is the next slice.
 
-**Post-landing correction (review on PR #183,
+**Post-landing correction, round 2 (review on PR #183,
+github.com/gombit-dev/gombit/pull/183#pullrequestreview-5034497111):** the
+round-1 fix for finding 3 added `-framework-versions`/`-runtime-versions`
+flags parsed by a `parseKeyVals` that fail-*opened* — a token with no `=` (a
+bare `django`) was silently dropped, and the test pinned that drop as correct.
+That reintroduced, on the required version-map flags, the exact fail-open
+finding 2 had just forbidden for `-concurrency`. Reproduced live
+(`-framework-versions 'gombit=v0.1.0,django'` → `django` vanished, exit 0),
+then made `parseKeyVals` return `(map, error)` like `parseIntList`: a missing
+`=`, empty key, empty pair (trailing/doubled comma), or duplicate key is an
+error and the CLI exits 1; wholly-empty input still yields an empty non-nil
+map. Inverted the test to assert those inputs fail, and verified live that a
+malformed map now exits 1 while a valid one still records every pair.
+
+**Post-landing correction, round 1 (review on PR #183,
 github.com/gombit-dev/gombit/pull/183#pullrequestreview-5034253957):** five
 findings, all real — the row schema was right but the reproducibility contract
 fail-opened the very fields it exists to capture. All fixed and tested.


### PR DESCRIPTION
## Summary

The measurement foundation every remaining BENCH-1 phase writes to
(#141 §9 machine-readable results, §"Reproducibility metadata"). This
is the first slice of the run harness — the schema, collector, and
config pins that the `make benchmark-*` orchestration will consume;
**no app orchestration yet** (that's the next slice).

- **`benchmarks/internal/result`** — the `results.json` schema (§9's
  recommended shape + a `schema_version`) with JSON and CSV encoders.
  The CSV flattens `latency_ms` and sorts deterministically so a
  regenerated file diffs cleanly. Unit-tested (round-trip, wire shape,
  empty-is-`[]`, sort order, float formatting).
- **`benchmarks/internal/metadata`** — the reproducibility-metadata
  struct and a best-effort collector. Host/toolchain discovery
  (git SHA + dirty, `uname`, docker/compose versions) goes through an
  **injectable `Runner`** so it's unit-tested without those tools;
  `runtime` supplies OS/arch/CPU-count/Go-version; CPU model + RAM are
  parsed from `/proc` via pure, separately-tested functions. Missing
  tools degrade to empty fields rather than failing the run.
- **`benchmarks/scripts/collect-host-info`** — the CLI that writes
  `metadata.json` (verified end-to-end producing real host metadata).
- **`benchmarks/config/versions.env`** — one source of truth for the
  pinned k6 version, Postgres image, 2 vCPU/2 GiB limits,
  `POOL_MAX_OPEN=20`, and workload defaults.
- **`benchmarks/results/README.md`** — documents the generated
  `latest/` layout; Markdown is never the canonical source.

## Linked issue

#141 (Phase 1: result schema + metadata collector + load-generator pin)

## Scope notes

Deliberately scoped to the schema/collector/config foundation. The
`make benchmark-crud` orchestration (compose app services, k6 script,
seeding, resource capture) that fills `results/latest/` is the next
slice, as is extending `fairness_test.go` to all six apps.

## Validation commands

```sh
go build ./...
go test ./benchmarks/internal/...
golangci-lint run ./benchmarks/internal/... ./benchmarks/scripts/...
go run ./benchmarks/scripts/collect-host-info -postgres-version 16.4 \
  -benchmark-tool 'k6 0.55.0' -concurrency 1,10,100 -trials 5
```

## Working agreement checklist

- [x] New behavior has tests (result + metadata unit tests); no
      DB-touching change, so no SQLite/PG/MySQL matrix applies.
- [x] Docs updated (`benchmarks/README.md`, `benchmarks/results/README.md`,
      plan doc); the packages are the example usage.
- [ ] N/A — no `golang-rest-api-template` extraction.
- [ ] N/A — no Gombit API change; no OpenAPI/TS regeneration.
- [x] No secrets; config pins are public version strings.
- [x] Scope stays inside Phase 1 completion; no M6 battery pulled in.
- [x] Links its issue and states satisfied acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)