### PR TITLE
feat: BENCH-1 headline CRUD-read workload + make benchmark-crud (Phase 5 engine)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ TARGET_URL ?=
 # Where the snapshot is written.
 OUT_DIR ?= benchmarks/results/latest
 
-RESOURCE_LIMITS ?= app $(APP_CPUS)cpu/$(APP_MEMORY); postgres $(POSTGRES_CPUS)cpu/$(POSTGRES_MEMORY)
+# The pinned intended limits (issue #141 §7). run-crud does NOT apply these —
+# it starts nothing — so it records an honest "not applied" string instead;
+# these are only surfaced by benchmark-metadata, labelled as intended. The
+# compose loop (next slice) is what will actually enforce and record them.
+INTENDED_LIMITS ?= intended (not yet enforced): app $(APP_CPUS)cpu/$(APP_MEMORY); postgres $(POSTGRES_CPUS)cpu/$(POSTGRES_MEMORY)
 
 .PHONY: benchmark-crud benchmark-metadata
 
@@ -42,8 +46,10 @@ benchmark-crud:
 		-duration "$(DURATION_SECONDS)s" -warmup "$(WARMUP_SECONDS)s" -trials "$(TRIALS)" \
 		-k6-image "grafana/k6:$(K6_VERSION)" \
 		-out-dir "$(OUT_DIR)" \
-		-postgres-version "$(POSTGRES_IMAGE)" \
-		-resource-limits "$(RESOURCE_LIMITS)"
+		-postgres-version "$(POSTGRES_IMAGE)"
+	@# resource-limits deliberately omitted: run-crud does not start or
+	@# constrain the app, so it records its honest "not applied" default
+	@# rather than the intended pins this target never enforces.
 
 ## benchmark-metadata: write just the reproducibility metadata for the current
 ## host and pinned run configuration to OUT_DIR/metadata.json.
@@ -56,4 +62,4 @@ benchmark-metadata:
 		-concurrency "$(CONCURRENCY)" \
 		-duration-seconds "$(DURATION_SECONDS)" -warmup-seconds "$(WARMUP_SECONDS)" \
 		-trials "$(TRIALS)" \
-		-resource-limits "$(RESOURCE_LIMITS)"
+		-resource-limits "$(INTENDED_LIMITS)"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+# Benchmark developer UX (issue #141 §10). More targets (benchmark-micro,
+# -auth, -techempower, -footprint, -report, and the all-in-one benchmark) land
+# with their phases; this file starts with the pieces that exist.
+#
+# Run configuration is sourced from benchmarks/config/versions.env (the single
+# source of truth for the pinned k6 version, resource limits, and workload
+# defaults); any variable can be overridden on the command line.
+
+BENCH_CONFIG ?= benchmarks/config/versions.env
+include $(BENCH_CONFIG)
+
+# Identity of the implementation under test, for the recorded result rows.
+FRAMEWORK ?=
+FRAMEWORK_VERSION ?=
+RUNTIME ?=
+RUNTIME_VERSION ?=
+# The already-running, already-seeded app's list endpoint.
+TARGET_URL ?=
+# Where the snapshot is written.
+OUT_DIR ?= benchmarks/results/latest
+
+RESOURCE_LIMITS ?= app $(APP_CPUS)cpu/$(APP_MEMORY); postgres $(POSTGRES_CPUS)cpu/$(POSTGRES_MEMORY)
+
+.PHONY: benchmark-crud benchmark-metadata
+
+## benchmark-crud: run the headline CRUD-read workload against one running,
+## seeded implementation and write results.json/results.csv/metadata.json.
+## Requires the app to be up and seeded (see benchmarks/apps/<name>/README.md);
+## the full "bring up all six under compose" loop is a later slice.
+##
+##   make benchmark-crud FRAMEWORK=gin-gorm FRAMEWORK_VERSION=v1.11.0 \
+##     RUNTIME=go RUNTIME_VERSION=go1.25.7 \
+##     TARGET_URL='http://127.0.0.1:8081/api/projects?page=1&limit=20'
+benchmark-crud:
+	@test -n "$(TARGET_URL)" || { echo "error: set TARGET_URL=<app list endpoint>"; exit 1; }
+	@test -n "$(FRAMEWORK)" || { echo "error: set FRAMEWORK=<name>"; exit 1; }
+	go run ./benchmarks/scripts/run-crud \
+		-target-url "$(TARGET_URL)" \
+		-framework "$(FRAMEWORK)" -framework-version "$(FRAMEWORK_VERSION)" \
+		-runtime "$(RUNTIME)" -runtime-version "$(RUNTIME_VERSION)" \
+		-concurrency "$(CONCURRENCY)" \
+		-duration "$(DURATION_SECONDS)s" -warmup "$(WARMUP_SECONDS)s" -trials "$(TRIALS)" \
+		-k6-image "grafana/k6:$(K6_VERSION)" \
+		-out-dir "$(OUT_DIR)" \
+		-postgres-version "$(POSTGRES_IMAGE)" \
+		-resource-limits "$(RESOURCE_LIMITS)"
+
+## benchmark-metadata: write just the reproducibility metadata for the current
+## host and pinned run configuration to OUT_DIR/metadata.json.
+benchmark-metadata:
+	@mkdir -p "$(OUT_DIR)"
+	go run ./benchmarks/scripts/collect-host-info \
+		-out "$(OUT_DIR)/metadata.json" \
+		-benchmark-tool "grafana/k6:$(K6_VERSION)" \
+		-postgres-version "$(POSTGRES_IMAGE)" \
+		-concurrency "$(CONCURRENCY)" \
+		-duration-seconds "$(DURATION_SECONDS)" -warmup-seconds "$(WARMUP_SECONDS)" \
+		-trials "$(TRIALS)" \
+		-resource-limits "$(RESOURCE_LIMITS)"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -14,9 +14,13 @@ benchmarks/
 │   └── schema.md        canonical schema/API/envelope every benchmarks/apps/ implementation targets
 ├── internal/            machine-readable output plumbing (Phase 1)
 │   ├── result/           results.json/results.csv schema + encoders (issue §9)
-│   └── metadata/         reproducibility metadata struct + host/toolchain collector
+│   ├── metadata/         reproducibility metadata struct + host/toolchain collector
+│   └── k6/               parses a crud-list.js summary into result rows (+ Validate)
+├── workloads/
+│   └── crud-list.js      the headline GET /api/projects read workload (k6)
 ├── scripts/
-│   └── collect-host-info/ CLI over internal/metadata: writes metadata.json for a run
+│   ├── collect-host-info/ CLI over internal/metadata: writes metadata.json for a run
+│   └── run-crud/          runs crud-list.js (via the pinned k6 image) against one app → results snapshot
 ├── micro/                Go abstraction-overhead microbenchmarks (Phase 2)
 │   ├── scenario/          shared resource types, Huma route registration, correctness assertions
 │   ├── nethttp/           net/http row (no router, no framework)
@@ -35,13 +39,13 @@ benchmarks/
 └── results/             generated output (issue §9); results/README.md documents the layout
 ```
 
-All six canonical CRUD implementations now exist (the Go control, the real
-Gombit app, and the four ecosystem apps), and the result schema, metadata
-collector, and run-config pins are in place. Everything else in the suite's
-target layout (`workloads/`, the `make benchmark-*` orchestration that fills
-`results/latest/`, `docs/methodology.md`, per-app `compose.yml` services, and
-the extension of `fairness_test.go` to all six) is scoped to later phases of
-the plan above and doesn't exist yet.
+All six canonical CRUD implementations exist, the result schema / metadata
+collector / run-config pins are in place, and the headline CRUD-read workload
+runs end to end against one implementation (`make benchmark-crud`). Still
+scoped to later phases: `docs/methodology.md`, per-app `compose.yml` services
+and the loop that brings all six up and runs `run-crud` over each, per-app
+resource/RSS capture (Phase 6 footprint), the other `make benchmark-*`
+workloads, and extending `fairness_test.go` to all six.
 
 ## Result schema and run metadata
 
@@ -53,6 +57,31 @@ canonical results shape lives in
 Markdown report is always generated from that, never the other way around.
 Pinned versions and limits are in
 [`benchmarks/config/versions.env`](config/versions.env).
+
+## Running the CRUD-read workload
+
+The headline workload is `GET /api/projects?page=1&limit=20`
+([`workloads/crud-list.js`](workloads/crud-list.js)), driven by the pinned k6
+image (the load generator runs in its own container, off the application
+host). Against **one already-running, already-seeded** implementation:
+
+```sh
+# start + seed the app per its own README, e.g. benchmarks/apps/gin-gorm, then:
+make benchmark-crud FRAMEWORK=gin-gorm FRAMEWORK_VERSION=v1.11.0 \
+  RUNTIME=go RUNTIME_VERSION=go1.25.7 \
+  TARGET_URL='http://127.0.0.1:8081/api/projects?page=1&limit=20'
+```
+
+It warms up (a discarded run), measures `TRIALS` times at each concurrency
+level in `benchmarks/config/versions.env`, and writes
+`benchmarks/results/latest/{results.json,results.csv,metadata.json}` plus the
+raw k6 summaries under `raw/`. A trial that sends no traffic, has any HTTP
+error, or fails a content check (a 200 with the wrong page shape) fails the
+command loudly rather than recording a bogus row — the read workload against a
+healthy app must be error-free (`benchmarks/internal/k6`'s `Summary.Validate`).
+`cpu_percent`/`rss_bytes` stay 0 for now; per-app footprint capture is Phase 6.
+The loop that brings all six apps up under compose and runs this over each is
+the next slice.
 
 ## Running the framework-tax matrix
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -62,8 +62,21 @@ Pinned versions and limits are in
 
 The headline workload is `GET /api/projects?page=1&limit=20`
 ([`workloads/crud-list.js`](workloads/crud-list.js)), driven by the pinned k6
-image (the load generator runs in its own container, off the application
-host). Against **one already-running, already-seeded** implementation:
+image. **Load model and topology (read before citing any number):** the
+workload uses a closed-loop `constant-vus` executor — `VUS` concurrent clients
+for the measured window — because the issue's concurrency sweep
+(1/10/100/500/1000) is a client-count axis. Closed-loop load is subject to
+**coordinated omission**: when the app slows, a client waits before its next
+request, so the reported tail latency understates true client-observed wait.
+This is the issue's "constant-rate *or* document the limitation" path, taken
+by documenting it. `gracefulStop` is `0s`, so the measured window is exactly
+the requested duration and `duration_seconds` records the *actual* elapsed run
+time (from k6's state), not the flag. The k6 container runs on the host
+network on the **same machine** as the app (the issue's "another container on
+the same host"), so at high concurrency k6 contends for CPU with the app —
+this is the recorded topology, not a separate load-generation host.
+
+Against **one already-running, already-seeded** implementation:
 
 ```sh
 # start + seed the app per its own README, e.g. benchmarks/apps/gin-gorm, then:
@@ -73,15 +86,18 @@ make benchmark-crud FRAMEWORK=gin-gorm FRAMEWORK_VERSION=v1.11.0 \
 ```
 
 It warms up (a discarded run), measures `TRIALS` times at each concurrency
-level in `benchmarks/config/versions.env`, and writes
-`benchmarks/results/latest/{results.json,results.csv,metadata.json}` plus the
-raw k6 summaries under `raw/`. A trial that sends no traffic, has any HTTP
-error, or fails a content check (a 200 with the wrong page shape) fails the
-command loudly rather than recording a bogus row — the read workload against a
-healthy app must be error-free (`benchmarks/internal/k6`'s `Summary.Validate`).
-`cpu_percent`/`rss_bytes` stay 0 for now; per-app footprint capture is Phase 6.
-The loop that brings all six apps up under compose and runs this over each is
-the next slice.
+level in `benchmarks/config/versions.env`, and **merges** its rows into
+`benchmarks/results/latest/{results.json,results.csv,metadata.json}` (raw k6
+summaries under `raw/`) — re-running one framework replaces that framework's
+rows while other frameworks are kept, so running each in turn accumulates all
+six. A trial that sends no traffic, has any HTTP error, or fails a content
+check (a 200 with the wrong page shape) fails the command loudly **with
+nothing written** rather than recording a bogus row — the read workload
+against a healthy app must be error-free (`benchmarks/internal/k6`'s
+`Summary.Validate`). `run-crud` does not start or resource-constrain the app,
+so `metadata.resource_limits` says so honestly; the compose loop that enforces
+the §7 limits and captures `cpu_percent`/`rss_bytes` (Phase 6) is the next
+slice.
 
 ## Running the framework-tax matrix
 

--- a/benchmarks/internal/k6/summary.go
+++ b/benchmarks/internal/k6/summary.go
@@ -1,0 +1,70 @@
+// Package k6 parses the machine-readable summary that benchmarks/workloads/
+// crud-list.js writes (via k6's handleSummary) into the load-generator-derived
+// fields of a benchmark result. Keeping this a pure decode step — no k6
+// process, no HTTP — lets the mapping be unit-tested against a captured
+// summary fixture.
+package k6
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/gombit-dev/gombit/benchmarks/internal/result"
+)
+
+// Summary is the shape crud-list.js's handleSummary emits: only the fields a
+// load generator can measure (throughput, tail latency, errors). The
+// orchestrator fills in the identity/config fields (framework, concurrency,
+// trial, ...) around it.
+type Summary struct {
+	Requests          int64          `json:"requests"`
+	RequestsPerSecond float64        `json:"requests_per_second"`
+	LatencyMs         result.Latency `json:"latency_ms"`
+	Errors            int64          `json:"errors"`
+	ChecksFailed      int64          `json:"checks_failed"`
+}
+
+// ParseSummary decodes one crud-list.js summary. Decoding only — validity is
+// Validate's job, so a caller can inspect a failed run's numbers before
+// rejecting it.
+func ParseSummary(r io.Reader) (Summary, error) {
+	var s Summary
+	if err := json.NewDecoder(r).Decode(&s); err != nil {
+		return Summary{}, fmt.Errorf("decode k6 summary: %w", err)
+	}
+	return s, nil
+}
+
+// Validate rejects a trial that isn't a clean measurement: no traffic at all
+// (target unreachable / workload misconfigured), any HTTP error (the target
+// erroring or unreachable — every request failing still yields requests > 0),
+// or any failed content check (a 200 with the wrong page shape). The headline
+// read workload against a healthy, seeded app must be error-free; the
+// orchestrator turns a Validate failure into a loud benchmark failure rather
+// than recording a bogus row (issue #141 §10 "a failed implementation must
+// make the benchmark command fail clearly", §7 "instead of publishing bogus
+// data").
+func (s Summary) Validate() error {
+	switch {
+	case s.Requests <= 0:
+		return fmt.Errorf("no traffic: %d requests (target unreachable or workload misconfigured)", s.Requests)
+	case s.Errors > 0:
+		return fmt.Errorf("%d of %d requests failed (target erroring or unreachable)", s.Errors, s.Requests)
+	case s.ChecksFailed > 0:
+		return fmt.Errorf("%d content checks failed (target returned a wrong or malformed page)", s.ChecksFailed)
+	default:
+		return nil
+	}
+}
+
+// Merge copies the load-generator-measured fields of s onto base (which
+// carries the identity/config fields the orchestrator set) and returns the
+// completed result row.
+func (s Summary) Merge(base result.Result) result.Result {
+	base.Requests = s.Requests
+	base.RequestsPerSecond = s.RequestsPerSecond
+	base.LatencyMs = s.LatencyMs
+	base.Errors = s.Errors
+	return base
+}

--- a/benchmarks/internal/k6/summary.go
+++ b/benchmarks/internal/k6/summary.go
@@ -1,8 +1,10 @@
-// Package k6 parses the machine-readable summary that benchmarks/workloads/
-// crud-list.js writes (via k6's handleSummary) into the load-generator-derived
-// fields of a benchmark result. Keeping this a pure decode step — no k6
-// process, no HTTP — lets the mapping be unit-tested against a captured
-// summary fixture.
+// Package k6 parses the raw k6 summary that benchmarks/workloads/crud-list.js
+// dumps (via handleSummary) into the load-generator-derived fields of a
+// benchmark result. The workload does no interpretation — it forwards k6's own
+// metrics and state — so every mapping that used to be a footgun in
+// JavaScript (the http_req_failed Rate whose FAILED count is `passes` not
+// `fails`, the percentile keys, the elapsed run time) lives here and is
+// unit-tested against captured k6 goldens (testdata/).
 package k6
 
 import (
@@ -13,27 +15,75 @@ import (
 	"github.com/gombit-dev/gombit/benchmarks/internal/result"
 )
 
-// Summary is the shape crud-list.js's handleSummary emits: only the fields a
-// load generator can measure (throughput, tail latency, errors). The
-// orchestrator fills in the identity/config fields (framework, concurrency,
-// trial, ...) around it.
-type Summary struct {
-	Requests          int64          `json:"requests"`
-	RequestsPerSecond float64        `json:"requests_per_second"`
-	LatencyMs         result.Latency `json:"latency_ms"`
-	Errors            int64          `json:"errors"`
-	ChecksFailed      int64          `json:"checks_failed"`
+// rawSummary is the shape of k6's `{metrics, state}` dump. Only the fields the
+// benchmark records are declared; k6's numbers are JSON floats.
+type rawSummary struct {
+	Metrics struct {
+		HTTPReqs struct {
+			Values struct {
+				Count float64 `json:"count"`
+				Rate  float64 `json:"rate"`
+			} `json:"values"`
+		} `json:"http_reqs"`
+		HTTPReqDuration struct {
+			Values map[string]float64 `json:"values"`
+		} `json:"http_req_duration"`
+		// http_req_failed is a Rate: a request is "added" as true when it
+		// failed, so `passes` is the count of FAILED requests and `fails` the
+		// count of successful ones (verified against testdata: an all-200 run
+		// has passes:0, an all-refused run has passes==count).
+		HTTPReqFailed struct {
+			Values struct {
+				Passes float64 `json:"passes"`
+			} `json:"values"`
+		} `json:"http_req_failed"`
+		// checks is a Rate over individual check evaluations: `fails` is the
+		// count of FAILED checks (a 200 with the wrong page shape).
+		Checks struct {
+			Values struct {
+				Fails float64 `json:"fails"`
+			} `json:"values"`
+		} `json:"checks"`
+	} `json:"metrics"`
+	State struct {
+		TestRunDurationMs float64 `json:"testRunDurationMs"`
+	} `json:"state"`
 }
 
-// ParseSummary decodes one crud-list.js summary. Decoding only — validity is
-// Validate's job, so a caller can inspect a failed run's numbers before
-// rejecting it.
+// Summary is the interpreted, load-generator-measured half of a result row.
+// The orchestrator fills in the identity/config fields (framework,
+// concurrency, trial, ...) around it via Merge. DurationSeconds is the ACTUAL
+// elapsed measured window (from k6's state), not the requested flag.
+type Summary struct {
+	Requests          int64
+	RequestsPerSecond float64
+	LatencyMs         result.Latency
+	Errors            int64
+	ChecksFailed      int64
+	DurationSeconds   float64
+}
+
+// ParseSummary decodes and interprets one raw k6 summary. Decoding/mapping
+// only — validity is Validate's job, so a caller can inspect a failed run's
+// numbers before rejecting it.
 func ParseSummary(r io.Reader) (Summary, error) {
-	var s Summary
-	if err := json.NewDecoder(r).Decode(&s); err != nil {
+	var raw rawSummary
+	if err := json.NewDecoder(r).Decode(&raw); err != nil {
 		return Summary{}, fmt.Errorf("decode k6 summary: %w", err)
 	}
-	return s, nil
+	d := raw.Metrics.HTTPReqDuration.Values
+	return Summary{
+		Requests:          int64(raw.Metrics.HTTPReqs.Values.Count),
+		RequestsPerSecond: raw.Metrics.HTTPReqs.Values.Rate,
+		LatencyMs: result.Latency{
+			P50: d["p(50)"],
+			P95: d["p(95)"],
+			P99: d["p(99)"],
+		},
+		Errors:          int64(raw.Metrics.HTTPReqFailed.Values.Passes),
+		ChecksFailed:    int64(raw.Metrics.Checks.Values.Fails),
+		DurationSeconds: raw.State.TestRunDurationMs / 1000,
+	}, nil
 }
 
 // Validate rejects a trial that isn't a clean measurement: no traffic at all
@@ -59,12 +109,13 @@ func (s Summary) Validate() error {
 }
 
 // Merge copies the load-generator-measured fields of s onto base (which
-// carries the identity/config fields the orchestrator set) and returns the
-// completed result row.
+// carries the identity/config fields the orchestrator set), including the
+// actual measured DurationSeconds, and returns the completed result row.
 func (s Summary) Merge(base result.Result) result.Result {
 	base.Requests = s.Requests
 	base.RequestsPerSecond = s.RequestsPerSecond
 	base.LatencyMs = s.LatencyMs
 	base.Errors = s.Errors
+	base.DurationSeconds = s.DurationSeconds
 	return base
 }

--- a/benchmarks/internal/k6/summary_test.go
+++ b/benchmarks/internal/k6/summary_test.go
@@ -1,33 +1,69 @@
 package k6
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/gombit-dev/gombit/benchmarks/internal/result"
 )
 
-// A real crud-list.js summary (captured shape).
-const sampleSummary = `{
-  "requests": 123456,
-  "requests_per_second": 4115.2,
-  "latency_ms": {"p50": 10.1, "p95": 21.8, "p99": 32.4},
-  "errors": 0
-}`
-
-func TestParseSummary(t *testing.T) {
-	s, err := ParseSummary(strings.NewReader(sampleSummary))
+func parseGolden(t *testing.T, name string) Summary {
+	t.Helper()
+	f, err := os.Open("testdata/" + name) //nolint:gosec // fixed testdata golden name
 	if err != nil {
-		t.Fatalf("ParseSummary: %v", err)
+		t.Fatalf("open golden: %v", err)
 	}
-	if s.Requests != 123456 || s.RequestsPerSecond != 4115.2 {
-		t.Errorf("throughput = %d / %v", s.Requests, s.RequestsPerSecond)
+	defer func() { _ = f.Close() }()
+	s, err := ParseSummary(f)
+	if err != nil {
+		t.Fatalf("ParseSummary(%s): %v", name, err)
 	}
-	if s.LatencyMs != (result.Latency{P50: 10.1, P95: 21.8, P99: 32.4}) {
-		t.Errorf("latency = %+v", s.LatencyMs)
+	return s
+}
+
+// summary_ok.json is a real k6 dump from a clean 3s/10-VU run against
+// gin-gorm: 1253 requests, http_req_failed passes:0 (none failed), checks
+// fails:0, state.testRunDurationMs ~3001.
+func TestParseCleanGolden(t *testing.T) {
+	s := parseGolden(t, "summary_ok.json")
+
+	if s.Requests != 1253 {
+		t.Errorf("Requests = %d, want 1253", s.Requests)
 	}
 	if s.Errors != 0 {
-		t.Errorf("errors = %d", s.Errors)
+		t.Errorf("Errors = %d, want 0 (an all-200 run has http_req_failed passes:0)", s.Errors)
+	}
+	if s.ChecksFailed != 0 {
+		t.Errorf("ChecksFailed = %d, want 0", s.ChecksFailed)
+	}
+	if s.LatencyMs.P50 <= 0 || s.LatencyMs.P95 < s.LatencyMs.P50 || s.LatencyMs.P99 < s.LatencyMs.P95 {
+		t.Errorf("latency percentiles not monotone/positive: %+v", s.LatencyMs)
+	}
+	// gracefulStop:0s -> elapsed is the ~3s window, not 0 and not the drain.
+	if s.DurationSeconds < 2.9 || s.DurationSeconds > 3.2 {
+		t.Errorf("DurationSeconds = %v, want ~3 (actual elapsed from state)", s.DurationSeconds)
+	}
+	if err := s.Validate(); err != nil {
+		t.Errorf("Validate(clean golden) = %v, want nil", err)
+	}
+}
+
+// summary_all_failed.json is a real k6 dump against an unreachable port: every
+// request failed. This is the golden that pins the http_req_failed inversion —
+// the FAILED count is `passes` (12279), not `fails` (0). A one-token change to
+// read `fails` would make Errors 0 here and this test would catch it.
+func TestParseAllFailedGolden(t *testing.T) {
+	s := parseGolden(t, "summary_all_failed.json")
+
+	if s.Requests <= 0 {
+		t.Fatalf("Requests = %d, want > 0 (failed requests still count)", s.Requests)
+	}
+	if s.Errors != s.Requests {
+		t.Errorf("Errors = %d, want %d (every request failed -> http_req_failed passes == count)", s.Errors, s.Requests)
+	}
+	if err := s.Validate(); err == nil {
+		t.Error("Validate(all-failed golden) = nil; want a rejection")
 	}
 }
 
@@ -38,41 +74,41 @@ func TestParseSummaryRejectsGarbage(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	valid := Summary{Requests: 1000, RequestsPerSecond: 100, Errors: 0, ChecksFailed: 0}
+	valid := Summary{Requests: 1000, RequestsPerSecond: 100}
 	if err := valid.Validate(); err != nil {
-		t.Errorf("Validate(clean run) = %v, want nil", err)
+		t.Errorf("Validate(clean) = %v, want nil", err)
 	}
-
 	cases := map[string]Summary{
-		"no traffic (unreachable)":                   {Requests: 0},
-		"all requests failed":                        {Requests: 11379, Errors: 11379},
-		"some requests failed":                       {Requests: 1000, Errors: 3},
-		"content checks failed (200 but wrong page)": {Requests: 1000, Errors: 0, ChecksFailed: 5},
+		"no traffic (unreachable)": {Requests: 0},
+		"all requests failed":      {Requests: 11379, Errors: 11379},
+		"some requests failed":     {Requests: 1000, Errors: 3},
+		"content checks failed":    {Requests: 1000, ChecksFailed: 5},
 	}
 	for name, s := range cases {
 		if err := s.Validate(); err == nil {
-			t.Errorf("Validate(%s) = nil error; want a rejection", name)
+			t.Errorf("Validate(%s) = nil; want a rejection", name)
 		}
 	}
 }
 
-func TestMergeKeepsIdentityFieldsAndSetsMeasured(t *testing.T) {
+func TestMergeKeepsIdentitySetsMeasuredAndElapsedDuration(t *testing.T) {
 	base := result.Result{
 		SchemaVersion: result.SchemaVersion, Framework: "gin-gorm", FrameworkVersion: "v1.11.0",
 		Runtime: "go", Benchmark: "crud-list", Database: "postgresql",
-		Concurrency: 100, Trial: 2, DurationSeconds: 30,
+		Concurrency: 100, Trial: 2, DurationSeconds: 30, // the flag; Merge overwrites with elapsed
 	}
-	s := Summary{Requests: 999, RequestsPerSecond: 33.3, LatencyMs: result.Latency{P50: 1, P95: 2, P99: 3}, Errors: 4}
+	s := Summary{Requests: 999, RequestsPerSecond: 33.3, LatencyMs: result.Latency{P50: 1, P95: 2, P99: 3}, Errors: 0, DurationSeconds: 30.05}
 
 	got := s.Merge(base)
 
-	// Identity/config fields survive.
-	if got.Framework != "gin-gorm" || got.Concurrency != 100 || got.Trial != 2 || got.DurationSeconds != 30 {
+	if got.Framework != "gin-gorm" || got.Concurrency != 100 || got.Trial != 2 {
 		t.Errorf("Merge clobbered identity fields: %+v", got)
 	}
-	// Measured fields come from the summary.
-	if got.Requests != 999 || got.RequestsPerSecond != 33.3 || got.Errors != 4 ||
-		got.LatencyMs != (result.Latency{P50: 1, P95: 2, P99: 3}) {
+	if got.Requests != 999 || got.RequestsPerSecond != 33.3 || got.LatencyMs.P99 != 3 {
 		t.Errorf("Merge did not set measured fields: %+v", got)
+	}
+	// duration_seconds becomes the actual elapsed window, not the 30 flag.
+	if got.DurationSeconds != 30.05 {
+		t.Errorf("DurationSeconds = %v, want the measured 30.05, not the flag", got.DurationSeconds)
 	}
 }

--- a/benchmarks/internal/k6/summary_test.go
+++ b/benchmarks/internal/k6/summary_test.go
@@ -1,0 +1,78 @@
+package k6
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gombit-dev/gombit/benchmarks/internal/result"
+)
+
+// A real crud-list.js summary (captured shape).
+const sampleSummary = `{
+  "requests": 123456,
+  "requests_per_second": 4115.2,
+  "latency_ms": {"p50": 10.1, "p95": 21.8, "p99": 32.4},
+  "errors": 0
+}`
+
+func TestParseSummary(t *testing.T) {
+	s, err := ParseSummary(strings.NewReader(sampleSummary))
+	if err != nil {
+		t.Fatalf("ParseSummary: %v", err)
+	}
+	if s.Requests != 123456 || s.RequestsPerSecond != 4115.2 {
+		t.Errorf("throughput = %d / %v", s.Requests, s.RequestsPerSecond)
+	}
+	if s.LatencyMs != (result.Latency{P50: 10.1, P95: 21.8, P99: 32.4}) {
+		t.Errorf("latency = %+v", s.LatencyMs)
+	}
+	if s.Errors != 0 {
+		t.Errorf("errors = %d", s.Errors)
+	}
+}
+
+func TestParseSummaryRejectsGarbage(t *testing.T) {
+	if _, err := ParseSummary(strings.NewReader("not json")); err == nil {
+		t.Error("ParseSummary(garbage) = nil error; want a decode error")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	valid := Summary{Requests: 1000, RequestsPerSecond: 100, Errors: 0, ChecksFailed: 0}
+	if err := valid.Validate(); err != nil {
+		t.Errorf("Validate(clean run) = %v, want nil", err)
+	}
+
+	cases := map[string]Summary{
+		"no traffic (unreachable)":                   {Requests: 0},
+		"all requests failed":                        {Requests: 11379, Errors: 11379},
+		"some requests failed":                       {Requests: 1000, Errors: 3},
+		"content checks failed (200 but wrong page)": {Requests: 1000, Errors: 0, ChecksFailed: 5},
+	}
+	for name, s := range cases {
+		if err := s.Validate(); err == nil {
+			t.Errorf("Validate(%s) = nil error; want a rejection", name)
+		}
+	}
+}
+
+func TestMergeKeepsIdentityFieldsAndSetsMeasured(t *testing.T) {
+	base := result.Result{
+		SchemaVersion: result.SchemaVersion, Framework: "gin-gorm", FrameworkVersion: "v1.11.0",
+		Runtime: "go", Benchmark: "crud-list", Database: "postgresql",
+		Concurrency: 100, Trial: 2, DurationSeconds: 30,
+	}
+	s := Summary{Requests: 999, RequestsPerSecond: 33.3, LatencyMs: result.Latency{P50: 1, P95: 2, P99: 3}, Errors: 4}
+
+	got := s.Merge(base)
+
+	// Identity/config fields survive.
+	if got.Framework != "gin-gorm" || got.Concurrency != 100 || got.Trial != 2 || got.DurationSeconds != 30 {
+		t.Errorf("Merge clobbered identity fields: %+v", got)
+	}
+	// Measured fields come from the summary.
+	if got.Requests != 999 || got.RequestsPerSecond != 33.3 || got.Errors != 4 ||
+		got.LatencyMs != (result.Latency{P50: 1, P95: 2, P99: 3}) {
+		t.Errorf("Merge did not set measured fields: %+v", got)
+	}
+}

--- a/benchmarks/internal/k6/testdata/summary_all_failed.json
+++ b/benchmarks/internal/k6/testdata/summary_all_failed.json
@@ -1,0 +1,149 @@
+{
+  "metrics": {
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 12279,
+        "fails": 0
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 24558
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "value": 2,
+        "min": 2,
+        "max": 2
+      },
+      "type": "gauge"
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 2,
+        "max": 2,
+        "value": 2
+      }
+    },
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "count": 0,
+        "rate": 0
+      },
+      "type": "counter"
+    },
+    "http_req_waiting": {
+      "contains": "time",
+      "values": {
+        "p(99)": 0,
+        "p(50)": 0,
+        "p(95)": 0
+      },
+      "type": "trend"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0.295508,
+        "p(95)": 0.5524936,
+        "p(99)": 0.8145596799999999
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 12279,
+        "rate": 6138.761009810879
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 12279,
+        "rate": 6138.761009810879
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0,
+        "p(50)": 0,
+        "p(95)": 0
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 0,
+        "rate": 0
+      }
+    }
+  },
+  "state": {
+    "testRunDurationMs": 2000.240762,
+    "isStdOutTTY": false,
+    "isStdErrTTY": false
+  }
+}

--- a/benchmarks/internal/k6/testdata/summary_ok.json
+++ b/benchmarks/internal/k6/testdata/summary_ok.json
@@ -1,0 +1,158 @@
+{
+  "metrics": {
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "iteration_duration": {
+      "values": {
+        "p(50)": 6.928879,
+        "p(95)": 81.3787712,
+        "p(99)": 86.49168312
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1253,
+        "rate": 417.4580107164603
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 6.502428,
+        "p(95)": 80.79765359999999,
+        "p(99)": 86.04171156000001
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 6.576768,
+        "p(95)": 80.899579,
+        "p(99)": 86.12335332
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 10,
+        "max": 10,
+        "value": 10
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 45445.28531026979,
+        "count": 136404
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 1928656.0095100466,
+        "count": 5788860
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0.04937,
+        "p(95)": 0.1698597999999999,
+        "p(99)": 0.4646979600000002
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1253
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 86.12335332,
+        "p(50)": 6.576768,
+        "p(95)": 80.899579
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0.008088,
+        "p(95)": 0.02666739999999997,
+        "p(99)": 0.37218396000000004
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1253,
+        "rate": 417.4580107164603
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0.002758,
+        "p(95)": 0.005287399999999981,
+        "p(99)": 0.04926844000000009
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(50)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 2506,
+        "fails": 0,
+        "rate": 1
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 10,
+        "min": 10,
+        "max": 10
+      }
+    }
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 3001.499475
+  }
+}

--- a/benchmarks/scripts/run-crud/main.go
+++ b/benchmarks/scripts/run-crud/main.go
@@ -1,0 +1,235 @@
+// Command run-crud runs the headline CRUD-read workload
+// (benchmarks/workloads/crud-list.js) against one already-running,
+// already-seeded implementation and appends its rows to a results snapshot.
+//
+// It drives the pinned k6 image (the load generator runs in its own
+// container, off the application host — issue #141 requirement), warms up
+// with a discarded run, then measures TRIALS times at each concurrency level,
+// parses each summary, and writes results.json/results.csv plus metadata.json.
+// A failed k6 run or an empty summary fails the command loudly rather than
+// recording a silent zero (issue #141 §10).
+//
+// The full make benchmark-crud that brings up all six apps under compose and
+// loops this over them is the next slice; this is the per-implementation
+// engine, verified end-to-end against benchmarks/apps/gin-gorm.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gombit-dev/gombit/benchmarks/internal/k6"
+	"github.com/gombit-dev/gombit/benchmarks/internal/metadata"
+	"github.com/gombit-dev/gombit/benchmarks/internal/result"
+)
+
+func main() {
+	var (
+		targetURL       = flag.String("target-url", "", "the app's GET list endpoint, e.g. http://127.0.0.1:8081/api/projects?page=1&limit=20")
+		framework       = flag.String("framework", "", "framework name for the result rows, e.g. gin-gorm")
+		frameworkVer    = flag.String("framework-version", "", "framework version")
+		runtimeName     = flag.String("runtime", "", "runtime, e.g. go")
+		runtimeVer      = flag.String("runtime-version", "", "runtime version")
+		concurrency     = flag.String("concurrency", "1,10,100", "comma-separated concurrency levels (VUs)")
+		duration        = flag.String("duration", "30s", "measured per-trial duration (k6 duration string)")
+		warmup          = flag.String("warmup", "10s", "warm-up duration, discarded")
+		trials          = flag.Int("trials", 5, "measured trials per concurrency level")
+		outDir          = flag.String("out-dir", "benchmarks/results/latest", "output directory for results.json/results.csv/metadata.json")
+		k6Image         = flag.String("k6-image", "grafana/k6:0.55.0", "pinned k6 image (the load generator)")
+		workload        = flag.String("workload", "benchmarks/workloads/crud-list.js", "k6 workload script")
+		postgresVersion = flag.String("postgres-version", "", "PostgreSQL version, for metadata")
+		resourceLimits  = flag.String("resource-limits", "", "documented resource limits, for metadata")
+	)
+	flag.Parse()
+
+	if *targetURL == "" || *framework == "" {
+		fatalf("-target-url and -framework are required")
+	}
+	levels, err := parseIntList(*concurrency)
+	if err != nil {
+		fatalf("-concurrency: %v", err)
+	}
+	if len(levels) == 0 {
+		fatalf("-concurrency must list at least one level")
+	}
+
+	workloadAbs, err := filepath.Abs(*workload)
+	if err != nil {
+		fatalf("resolve workload path: %v", err)
+	}
+	outAbs, err := filepath.Abs(*outDir)
+	if err != nil {
+		fatalf("resolve out dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(outAbs, "raw"), 0o750); err != nil {
+		fatalf("create out dir: %v", err)
+	}
+
+	ctx := context.Background()
+	base := result.Result{
+		SchemaVersion:    result.SchemaVersion,
+		Framework:        *framework,
+		FrameworkVersion: *frameworkVer,
+		Runtime:          *runtimeName,
+		RuntimeVersion:   *runtimeVer,
+		Benchmark:        "crud-list",
+		Database:         "postgresql",
+		DurationSeconds:  durationSeconds(*duration),
+	}
+
+	var rows []result.Result
+	for _, vus := range levels {
+		// One discarded warm-up per concurrency level before its measured
+		// trials, so the app is at steady state.
+		if err := runK6(ctx, *k6Image, workloadAbs, *targetURL, vus, *warmup, ""); err != nil {
+			fatalf("warm-up (vus=%d): %v", vus, err)
+		}
+		for trial := 1; trial <= *trials; trial++ {
+			summaryPath := filepath.Join(outAbs, "raw", fmt.Sprintf("%s_c%d_t%d.json", *framework, vus, trial))
+			if err := runK6(ctx, *k6Image, workloadAbs, *targetURL, vus, *duration, summaryPath); err != nil {
+				fatalf("k6 run (vus=%d trial=%d): %v", vus, trial, err)
+			}
+			summary, err := parseSummaryFile(summaryPath)
+			if err != nil {
+				fatalf("parse summary (vus=%d trial=%d): %v", vus, trial, err)
+			}
+			if err := summary.Validate(); err != nil {
+				fatalf("%s vus=%d trial=%d: %v", *framework, vus, trial, err)
+			}
+			row := base
+			row.Concurrency = vus
+			row.Trial = trial
+			rows = append(rows, summary.Merge(row))
+			fmt.Fprintf(os.Stderr, "run-crud: %s vus=%d trial=%d -> %.0f rps, p95=%.1fms, errors=%d\n",
+				*framework, vus, trial, summary.RequestsPerSecond, summary.LatencyMs.P95, summary.Errors)
+		}
+	}
+
+	if err := writeOutputs(outAbs, rows, metadata.Collect(ctx, metadata.Options{
+		PostgresVersion:   *postgresVersion,
+		FrameworkVersions: map[string]string{*framework: *frameworkVer},
+		RuntimeVersions:   map[string]string{*runtimeName: *runtimeVer},
+		BenchmarkTool:     *k6Image,
+		ResourceLimits:    *resourceLimits,
+		DurationSeconds:   durationSeconds(*duration),
+		WarmupSeconds:     durationSeconds(*warmup),
+		Concurrency:       levels,
+		Trials:            *trials,
+	})); err != nil {
+		fatalf("write outputs: %v", err)
+	}
+	fmt.Fprintf(os.Stderr, "run-crud: wrote %d rows to %s\n", len(rows), outAbs)
+}
+
+// runK6 runs the pinned k6 image against targetURL at vus concurrency for
+// duration. When summaryPath is non-empty the workload writes its summary
+// there (mounted into the container); an empty summaryPath is a warm-up whose
+// output is discarded. --network host lets the containerized load generator
+// reach an app listening on the host.
+func runK6(ctx context.Context, image, workloadAbs, targetURL string, vus int, duration, summaryPath string) error {
+	args := []string{
+		"run", "--rm", "--network", "host",
+		// Run k6 as the current user so the summary it writes into the
+		// mounted output dir is owned by (and writable for) us — the k6
+		// image's own non-root user otherwise can't write a host dir we own.
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+		"-e", "TARGET_URL=" + targetURL,
+		"-e", "VUS=" + strconv.Itoa(vus),
+		"-e", "DURATION=" + duration,
+		"-v", workloadAbs + ":/workload/crud-list.js:ro",
+	}
+	if summaryPath != "" {
+		args = append(args,
+			"-e", "SUMMARY_OUT=/out/summary.json",
+			"-v", filepath.Dir(summaryPath)+":/out",
+		)
+	}
+	args = append(args, image, "run", "--quiet", "/workload/crud-list.js")
+
+	cmd := exec.CommandContext(ctx, "docker", args...) //nolint:gosec // fixed argv, operator-supplied target only
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	if summaryPath != "" {
+		// k6 wrote /out/summary.json; move it to the trial-specific name.
+		if err := os.Rename(filepath.Join(filepath.Dir(summaryPath), "summary.json"), summaryPath); err != nil {
+			return fmt.Errorf("k6 produced no summary: %w", err)
+		}
+	}
+	return nil
+}
+
+func parseSummaryFile(path string) (k6.Summary, error) {
+	f, err := os.Open(path) //nolint:gosec // path is composed from the operator-supplied out-dir
+	if err != nil {
+		return k6.Summary{}, err
+	}
+	defer func() { _ = f.Close() }()
+	return k6.ParseSummary(f)
+}
+
+func writeOutputs(outDir string, rows []result.Result, meta metadata.Metadata) error {
+	if err := writeFile(filepath.Join(outDir, "results.json"), func(f *os.File) error {
+		return result.WriteJSON(f, rows)
+	}); err != nil {
+		return err
+	}
+	if err := writeFile(filepath.Join(outDir, "results.csv"), func(f *os.File) error {
+		return result.WriteCSV(f, rows)
+	}); err != nil {
+		return err
+	}
+	return writeFile(filepath.Join(outDir, "metadata.json"), func(f *os.File) error {
+		return metadata.WriteJSON(f, meta)
+	})
+}
+
+func writeFile(path string, encode func(*os.File) error) error {
+	f, err := os.Create(path) //nolint:gosec // path composed from operator-supplied out-dir
+	if err != nil {
+		return err
+	}
+	if err := encode(f); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// durationSeconds converts a k6 duration string ("30s", "1m30s") to seconds
+// for the metadata / result duration_seconds field; unparseable input is 0.
+func durationSeconds(s string) float64 {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0
+	}
+	return d.Seconds()
+}
+
+func parseIntList(s string) ([]int, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, nil
+	}
+	var out []int
+	for _, part := range strings.Split(s, ",") {
+		n, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil {
+			return nil, fmt.Errorf("invalid integer %q", strings.TrimSpace(part))
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "run-crud: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/benchmarks/scripts/run-crud/main.go
+++ b/benchmarks/scripts/run-crud/main.go
@@ -50,6 +50,7 @@ type runConfig struct {
 	outDir           string
 	postgresVersion  string
 	resourceLimits   string
+	k6Image          string
 }
 
 // k6Runner runs the workload once at vus concurrency for duration; a non-empty
@@ -61,10 +62,10 @@ type k6Runner func(vus int, duration, summaryPath string) error
 func main() {
 	var (
 		cfg      runConfig
-		k6Image  = flag.String("k6-image", "grafana/k6:0.55.0", "pinned k6 image (the load generator)")
 		workload = flag.String("workload", "benchmarks/workloads/crud-list.js", "k6 workload script")
 		conc     = flag.String("concurrency", "1,10,100", "comma-separated concurrency levels (VUs)")
 	)
+	flag.StringVar(&cfg.k6Image, "k6-image", "grafana/k6:0.55.0", "pinned k6 image (the load generator); recorded as benchmark_tool")
 	flag.StringVar(&cfg.targetURL, "target-url", "", "the app's GET list endpoint, e.g. http://127.0.0.1:8081/api/projects?page=1&limit=20")
 	flag.StringVar(&cfg.framework, "framework", "", "framework name for the result rows, e.g. gin-gorm")
 	flag.StringVar(&cfg.frameworkVersion, "framework-version", "", "framework version")
@@ -100,7 +101,7 @@ func main() {
 		fatalf("resolve out dir: %v", err)
 	}
 
-	if err := run(cfg, dockerK6Runner(*k6Image, workloadAbs, cfg.targetURL)); err != nil {
+	if err := run(cfg, dockerK6Runner(cfg.k6Image, workloadAbs, cfg.targetURL)); err != nil {
 		fatalf("%v", err)
 	}
 }
@@ -155,12 +156,15 @@ func run(cfg runConfig, k6run k6Runner) error {
 		PostgresVersion:   cfg.postgresVersion,
 		FrameworkVersions: map[string]string{cfg.framework: cfg.frameworkVersion},
 		RuntimeVersions:   map[string]string{cfg.runtimeName: cfg.runtimeVersion},
-		BenchmarkTool:     "k6",
-		ResourceLimits:    cfg.resourceLimits,
-		DurationSeconds:   durationSeconds(cfg.duration),
-		WarmupSeconds:     durationSeconds(cfg.warmup),
-		Concurrency:       cfg.concurrency,
-		Trials:            cfg.trials,
+		// The actual load-generator image that ran, not a bare "k6" token —
+		// issue #141's reproducibility metadata requires the benchmark-tool
+		// version, and overriding -k6-image must be reflected here.
+		BenchmarkTool:   cfg.k6Image,
+		ResourceLimits:  cfg.resourceLimits,
+		DurationSeconds: durationSeconds(cfg.duration),
+		WarmupSeconds:   durationSeconds(cfg.warmup),
+		Concurrency:     cfg.concurrency,
+		Trials:          cfg.trials,
 	})
 	if err := writeOutputs(cfg.outDir, cfg.framework, rows, meta); err != nil {
 		return err

--- a/benchmarks/scripts/run-crud/main.go
+++ b/benchmarks/scripts/run-crud/main.go
@@ -1,21 +1,26 @@
 // Command run-crud runs the headline CRUD-read workload
 // (benchmarks/workloads/crud-list.js) against one already-running,
-// already-seeded implementation and appends its rows to a results snapshot.
+// already-seeded implementation and merges its rows into a results snapshot.
 //
-// It drives the pinned k6 image (the load generator runs in its own
-// container, off the application host — issue #141 requirement), warms up
-// with a discarded run, then measures TRIALS times at each concurrency level,
-// parses each summary, and writes results.json/results.csv plus metadata.json.
-// A failed k6 run or an empty summary fails the command loudly rather than
-// recording a silent zero (issue #141 §10).
+// It drives the pinned k6 image (the load generator runs in a container on the
+// host network, on the SAME machine as the app — the issue's "another
+// container on the same host" topology, recorded as such), warms up with a
+// discarded run, then measures TRIALS times at each concurrency level, parses
+// and validates each summary, and writes results.json/results.csv plus
+// metadata.json. A failed k6 run or an invalid summary (no traffic, HTTP
+// errors, failed content checks) fails the command loudly with nothing written
+// (issue #141 §10).
 //
-// The full make benchmark-crud that brings up all six apps under compose and
-// loops this over them is the next slice; this is the per-implementation
-// engine, verified end-to-end against benchmarks/apps/gin-gorm.
+// It does NOT start or resource-constrain the app; the recorded
+// resource_limits therefore says so honestly. The full make benchmark-crud
+// that brings all six apps up under compose with the §7 limits and loops this
+// over them is the next slice; this is the per-implementation engine, verified
+// end-to-end against benchmarks/apps/gin-gorm.
 package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -30,145 +35,178 @@ import (
 	"github.com/gombit-dev/gombit/benchmarks/internal/result"
 )
 
+const resourceLimitsNotApplied = "not applied (run-crud does not start or constrain the app; app runs outside compose)"
+
+type runConfig struct {
+	targetURL        string
+	framework        string
+	frameworkVersion string
+	runtimeName      string
+	runtimeVersion   string
+	concurrency      []int
+	duration         string
+	warmup           string
+	trials           int
+	outDir           string
+	postgresVersion  string
+	resourceLimits   string
+}
+
+// k6Runner runs the workload once at vus concurrency for duration; a non-empty
+// summaryPath is where the run's summary must be written (an empty one is a
+// warm-up whose output is discarded). Injectable so run() is testable without
+// docker or a live app.
+type k6Runner func(vus int, duration, summaryPath string) error
+
 func main() {
 	var (
-		targetURL       = flag.String("target-url", "", "the app's GET list endpoint, e.g. http://127.0.0.1:8081/api/projects?page=1&limit=20")
-		framework       = flag.String("framework", "", "framework name for the result rows, e.g. gin-gorm")
-		frameworkVer    = flag.String("framework-version", "", "framework version")
-		runtimeName     = flag.String("runtime", "", "runtime, e.g. go")
-		runtimeVer      = flag.String("runtime-version", "", "runtime version")
-		concurrency     = flag.String("concurrency", "1,10,100", "comma-separated concurrency levels (VUs)")
-		duration        = flag.String("duration", "30s", "measured per-trial duration (k6 duration string)")
-		warmup          = flag.String("warmup", "10s", "warm-up duration, discarded")
-		trials          = flag.Int("trials", 5, "measured trials per concurrency level")
-		outDir          = flag.String("out-dir", "benchmarks/results/latest", "output directory for results.json/results.csv/metadata.json")
-		k6Image         = flag.String("k6-image", "grafana/k6:0.55.0", "pinned k6 image (the load generator)")
-		workload        = flag.String("workload", "benchmarks/workloads/crud-list.js", "k6 workload script")
-		postgresVersion = flag.String("postgres-version", "", "PostgreSQL version, for metadata")
-		resourceLimits  = flag.String("resource-limits", "", "documented resource limits, for metadata")
+		cfg      runConfig
+		k6Image  = flag.String("k6-image", "grafana/k6:0.55.0", "pinned k6 image (the load generator)")
+		workload = flag.String("workload", "benchmarks/workloads/crud-list.js", "k6 workload script")
+		conc     = flag.String("concurrency", "1,10,100", "comma-separated concurrency levels (VUs)")
 	)
+	flag.StringVar(&cfg.targetURL, "target-url", "", "the app's GET list endpoint, e.g. http://127.0.0.1:8081/api/projects?page=1&limit=20")
+	flag.StringVar(&cfg.framework, "framework", "", "framework name for the result rows, e.g. gin-gorm")
+	flag.StringVar(&cfg.frameworkVersion, "framework-version", "", "framework version")
+	flag.StringVar(&cfg.runtimeName, "runtime", "", "runtime, e.g. go")
+	flag.StringVar(&cfg.runtimeVersion, "runtime-version", "", "runtime version")
+	flag.StringVar(&cfg.duration, "duration", "30s", "measured per-trial duration (k6 duration string)")
+	flag.StringVar(&cfg.warmup, "warmup", "10s", "warm-up duration, discarded")
+	flag.IntVar(&cfg.trials, "trials", 5, "measured trials per concurrency level")
+	flag.StringVar(&cfg.outDir, "out-dir", "benchmarks/results/latest", "output directory")
+	flag.StringVar(&cfg.postgresVersion, "postgres-version", "", "PostgreSQL version, for metadata")
+	flag.StringVar(&cfg.resourceLimits, "resource-limits", resourceLimitsNotApplied,
+		"resource limits string recorded in metadata; defaults to an honest 'not applied' since this command does not constrain the app")
 	flag.Parse()
 
-	if *targetURL == "" || *framework == "" {
+	if cfg.targetURL == "" || cfg.framework == "" {
 		fatalf("-target-url and -framework are required")
 	}
-	levels, err := parseIntList(*concurrency)
+	levels, err := parseIntList(*conc)
 	if err != nil {
 		fatalf("-concurrency: %v", err)
 	}
 	if len(levels) == 0 {
 		fatalf("-concurrency must list at least one level")
 	}
+	cfg.concurrency = levels
 
 	workloadAbs, err := filepath.Abs(*workload)
 	if err != nil {
 		fatalf("resolve workload path: %v", err)
 	}
-	outAbs, err := filepath.Abs(*outDir)
+	cfg.outDir, err = filepath.Abs(cfg.outDir)
 	if err != nil {
 		fatalf("resolve out dir: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(outAbs, "raw"), 0o750); err != nil {
-		fatalf("create out dir: %v", err)
+
+	if err := run(cfg, dockerK6Runner(*k6Image, workloadAbs, cfg.targetURL)); err != nil {
+		fatalf("%v", err)
+	}
+}
+
+// run executes the sweep and, only if every trial is a clean measurement,
+// merges the rows into the snapshot. On any failure it returns an error with
+// nothing written — a failed implementation must not leave a partial or bogus
+// snapshot behind.
+func run(cfg runConfig, k6run k6Runner) error {
+	rawDir := filepath.Join(cfg.outDir, "raw")
+	if err := os.MkdirAll(rawDir, 0o750); err != nil {
+		return fmt.Errorf("create out dir: %w", err)
 	}
 
-	ctx := context.Background()
 	base := result.Result{
 		SchemaVersion:    result.SchemaVersion,
-		Framework:        *framework,
-		FrameworkVersion: *frameworkVer,
-		Runtime:          *runtimeName,
-		RuntimeVersion:   *runtimeVer,
+		Framework:        cfg.framework,
+		FrameworkVersion: cfg.frameworkVersion,
+		Runtime:          cfg.runtimeName,
+		RuntimeVersion:   cfg.runtimeVersion,
 		Benchmark:        "crud-list",
 		Database:         "postgresql",
-		DurationSeconds:  durationSeconds(*duration),
 	}
 
 	var rows []result.Result
-	for _, vus := range levels {
-		// One discarded warm-up per concurrency level before its measured
-		// trials, so the app is at steady state.
-		if err := runK6(ctx, *k6Image, workloadAbs, *targetURL, vus, *warmup, ""); err != nil {
-			fatalf("warm-up (vus=%d): %v", vus, err)
+	for _, vus := range cfg.concurrency {
+		if err := k6run(vus, cfg.warmup, ""); err != nil {
+			return fmt.Errorf("warm-up (vus=%d): %w", vus, err)
 		}
-		for trial := 1; trial <= *trials; trial++ {
-			summaryPath := filepath.Join(outAbs, "raw", fmt.Sprintf("%s_c%d_t%d.json", *framework, vus, trial))
-			if err := runK6(ctx, *k6Image, workloadAbs, *targetURL, vus, *duration, summaryPath); err != nil {
-				fatalf("k6 run (vus=%d trial=%d): %v", vus, trial, err)
+		for trial := 1; trial <= cfg.trials; trial++ {
+			summaryPath := filepath.Join(rawDir, fmt.Sprintf("%s_c%d_t%d.json", cfg.framework, vus, trial))
+			if err := k6run(vus, cfg.duration, summaryPath); err != nil {
+				return fmt.Errorf("k6 run (vus=%d trial=%d): %w", vus, trial, err)
 			}
 			summary, err := parseSummaryFile(summaryPath)
 			if err != nil {
-				fatalf("parse summary (vus=%d trial=%d): %v", vus, trial, err)
+				return fmt.Errorf("parse summary (vus=%d trial=%d): %w", vus, trial, err)
 			}
 			if err := summary.Validate(); err != nil {
-				fatalf("%s vus=%d trial=%d: %v", *framework, vus, trial, err)
+				return fmt.Errorf("%s vus=%d trial=%d: %w", cfg.framework, vus, trial, err)
 			}
 			row := base
 			row.Concurrency = vus
 			row.Trial = trial
 			rows = append(rows, summary.Merge(row))
 			fmt.Fprintf(os.Stderr, "run-crud: %s vus=%d trial=%d -> %.0f rps, p95=%.1fms, errors=%d\n",
-				*framework, vus, trial, summary.RequestsPerSecond, summary.LatencyMs.P95, summary.Errors)
+				cfg.framework, vus, trial, summary.RequestsPerSecond, summary.LatencyMs.P95, summary.Errors)
 		}
 	}
 
-	if err := writeOutputs(outAbs, rows, metadata.Collect(ctx, metadata.Options{
-		PostgresVersion:   *postgresVersion,
-		FrameworkVersions: map[string]string{*framework: *frameworkVer},
-		RuntimeVersions:   map[string]string{*runtimeName: *runtimeVer},
-		BenchmarkTool:     *k6Image,
-		ResourceLimits:    *resourceLimits,
-		DurationSeconds:   durationSeconds(*duration),
-		WarmupSeconds:     durationSeconds(*warmup),
-		Concurrency:       levels,
-		Trials:            *trials,
-	})); err != nil {
-		fatalf("write outputs: %v", err)
-	}
-	fmt.Fprintf(os.Stderr, "run-crud: wrote %d rows to %s\n", len(rows), outAbs)
-}
-
-// runK6 runs the pinned k6 image against targetURL at vus concurrency for
-// duration. When summaryPath is non-empty the workload writes its summary
-// there (mounted into the container); an empty summaryPath is a warm-up whose
-// output is discarded. --network host lets the containerized load generator
-// reach an app listening on the host.
-func runK6(ctx context.Context, image, workloadAbs, targetURL string, vus int, duration, summaryPath string) error {
-	args := []string{
-		"run", "--rm", "--network", "host",
-		// Run k6 as the current user so the summary it writes into the
-		// mounted output dir is owned by (and writable for) us — the k6
-		// image's own non-root user otherwise can't write a host dir we own.
-		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
-		"-e", "TARGET_URL=" + targetURL,
-		"-e", "VUS=" + strconv.Itoa(vus),
-		"-e", "DURATION=" + duration,
-		"-v", workloadAbs + ":/workload/crud-list.js:ro",
-	}
-	if summaryPath != "" {
-		args = append(args,
-			"-e", "SUMMARY_OUT=/out/summary.json",
-			"-v", filepath.Dir(summaryPath)+":/out",
-		)
-	}
-	args = append(args, image, "run", "--quiet", "/workload/crud-list.js")
-
-	cmd := exec.CommandContext(ctx, "docker", args...) //nolint:gosec // fixed argv, operator-supplied target only
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	meta := metadata.Collect(context.Background(), metadata.Options{
+		PostgresVersion:   cfg.postgresVersion,
+		FrameworkVersions: map[string]string{cfg.framework: cfg.frameworkVersion},
+		RuntimeVersions:   map[string]string{cfg.runtimeName: cfg.runtimeVersion},
+		BenchmarkTool:     "k6",
+		ResourceLimits:    cfg.resourceLimits,
+		DurationSeconds:   durationSeconds(cfg.duration),
+		WarmupSeconds:     durationSeconds(cfg.warmup),
+		Concurrency:       cfg.concurrency,
+		Trials:            cfg.trials,
+	})
+	if err := writeOutputs(cfg.outDir, cfg.framework, rows, meta); err != nil {
 		return err
 	}
-	if summaryPath != "" {
-		// k6 wrote /out/summary.json; move it to the trial-specific name.
-		if err := os.Rename(filepath.Join(filepath.Dir(summaryPath), "summary.json"), summaryPath); err != nil {
-			return fmt.Errorf("k6 produced no summary: %w", err)
-		}
-	}
+	fmt.Fprintf(os.Stderr, "run-crud: merged %d %s rows into %s\n", len(rows), cfg.framework, cfg.outDir)
 	return nil
 }
 
+// dockerK6Runner returns a k6Runner that runs the pinned k6 image against
+// targetURL. --network host lets the containerized load generator reach an app
+// listening on the host; --user runs k6 as the invoking uid so the summary it
+// writes into the mounted output dir is ours.
+func dockerK6Runner(image, workloadAbs, targetURL string) k6Runner {
+	return func(vus int, duration, summaryPath string) error {
+		args := []string{
+			"run", "--rm", "--network", "host",
+			"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+			"-e", "TARGET_URL=" + targetURL,
+			"-e", "VUS=" + strconv.Itoa(vus),
+			"-e", "DURATION=" + duration,
+			"-v", workloadAbs + ":/workload/crud-list.js:ro",
+		}
+		if summaryPath != "" {
+			args = append(args,
+				"-e", "SUMMARY_OUT=/out/summary.json",
+				"-v", filepath.Dir(summaryPath)+":/out",
+			)
+		}
+		args = append(args, image, "run", "--quiet", "/workload/crud-list.js")
+
+		cmd := exec.CommandContext(context.Background(), "docker", args...) //nolint:gosec // fixed argv, operator-supplied target only
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+		if summaryPath != "" {
+			if err := os.Rename(filepath.Join(filepath.Dir(summaryPath), "summary.json"), summaryPath); err != nil {
+				return fmt.Errorf("k6 produced no summary: %w", err)
+			}
+		}
+		return nil
+	}
+}
+
 func parseSummaryFile(path string) (k6.Summary, error) {
-	f, err := os.Open(path) //nolint:gosec // path is composed from the operator-supplied out-dir
+	f, err := os.Open(path) //nolint:gosec // path composed from the operator-supplied out-dir
 	if err != nil {
 		return k6.Summary{}, err
 	}
@@ -176,7 +214,18 @@ func parseSummaryFile(path string) (k6.Summary, error) {
 	return k6.ParseSummary(f)
 }
 
-func writeOutputs(outDir string, rows []result.Result, meta metadata.Metadata) error {
+// writeOutputs merges this run's rows into any existing snapshot rather than
+// truncating it: re-running one framework replaces that framework's rows,
+// while running each framework in turn accumulates all six. metadata's version
+// maps are unioned the same way so a multi-framework snapshot records every
+// implementation that contributed.
+func writeOutputs(outDir, framework string, newRows []result.Result, meta metadata.Metadata) error {
+	rows, err := mergedResults(filepath.Join(outDir, "results.json"), newRows, framework)
+	if err != nil {
+		return err
+	}
+	meta = mergedMetadata(filepath.Join(outDir, "metadata.json"), meta)
+
 	if err := writeFile(filepath.Join(outDir, "results.json"), func(f *os.File) error {
 		return result.WriteJSON(f, rows)
 	}); err != nil {
@@ -192,6 +241,63 @@ func writeOutputs(outDir string, rows []result.Result, meta metadata.Metadata) e
 	})
 }
 
+func mergedResults(path string, newRows []result.Result, framework string) ([]result.Result, error) {
+	existing, err := readResults(path)
+	if err != nil {
+		return nil, err
+	}
+	return mergeRows(existing, newRows, framework), nil
+}
+
+// mergeRows drops any existing rows for framework (a re-run replaces them) and
+// appends the new ones; rows for other frameworks are kept.
+func mergeRows(existing, newRows []result.Result, framework string) []result.Result {
+	merged := make([]result.Result, 0, len(existing)+len(newRows))
+	for _, r := range existing {
+		if r.Framework != framework {
+			merged = append(merged, r)
+		}
+	}
+	return append(merged, newRows...)
+}
+
+func readResults(path string) ([]result.Result, error) {
+	f, err := os.Open(path) //nolint:gosec // path composed from the operator-supplied out-dir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return result.ReadJSON(f)
+}
+
+func mergedMetadata(path string, meta metadata.Metadata) metadata.Metadata {
+	data, err := os.ReadFile(path) //nolint:gosec // path composed from the operator-supplied out-dir
+	if err != nil {
+		return meta
+	}
+	var existing metadata.Metadata
+	if err := json.Unmarshal(data, &existing); err != nil {
+		return meta
+	}
+	meta.FrameworkVersions = union(existing.FrameworkVersions, meta.FrameworkVersions)
+	meta.RuntimeVersions = union(existing.RuntimeVersions, meta.RuntimeVersions)
+	return meta
+}
+
+func union(a, b map[string]string) map[string]string {
+	out := map[string]string{}
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
+}
+
 func writeFile(path string, encode func(*os.File) error) error {
 	f, err := os.Create(path) //nolint:gosec // path composed from operator-supplied out-dir
 	if err != nil {
@@ -205,7 +311,7 @@ func writeFile(path string, encode func(*os.File) error) error {
 }
 
 // durationSeconds converts a k6 duration string ("30s", "1m30s") to seconds
-// for the metadata / result duration_seconds field; unparseable input is 0.
+// for the metadata fields; unparseable input is 0.
 func durationSeconds(s string) float64 {
 	d, err := time.ParseDuration(s)
 	if err != nil {

--- a/benchmarks/scripts/run-crud/main_test.go
+++ b/benchmarks/scripts/run-crud/main_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gombit-dev/gombit/benchmarks/internal/result"
+)
+
+func TestParseIntListRejectsInvalidToken(t *testing.T) {
+	for _, in := range []string{"1,10,abc,100", "1,,10", "100o"} {
+		if got, err := parseIntList(in); err == nil {
+			t.Errorf("parseIntList(%q) = %v, nil; want an error", in, got)
+		}
+	}
+}
+
+func TestMergeRowsReplacesSameFrameworkKeepsOthers(t *testing.T) {
+	existing := []result.Result{
+		{Framework: "gin-gorm", Concurrency: 10, Trial: 1},
+		{Framework: "gombit", Concurrency: 10, Trial: 1},    // other framework, kept
+		{Framework: "gin-gorm", Concurrency: 100, Trial: 1}, // old gin-gorm rows, replaced
+	}
+	newRows := []result.Result{
+		{Framework: "gin-gorm", Concurrency: 10, Trial: 1, Requests: 42},
+	}
+
+	merged := mergeRows(existing, newRows, "gin-gorm")
+
+	var ginGorm, gombit int
+	for _, r := range merged {
+		switch r.Framework {
+		case "gin-gorm":
+			ginGorm++
+			if r.Requests != 42 {
+				t.Errorf("gin-gorm row not the new one: %+v", r)
+			}
+		case "gombit":
+			gombit++
+		}
+	}
+	if ginGorm != 1 {
+		t.Errorf("gin-gorm rows = %d, want 1 (old ones replaced)", ginGorm)
+	}
+	if gombit != 1 {
+		t.Errorf("gombit rows = %d, want 1 (other framework kept)", gombit)
+	}
+}
+
+// A trial that fails Validate (here the real all-failed k6 golden) must make
+// run() return an error AND leave no results.json — a failed implementation
+// must not write a partial or bogus snapshot (issue #141 §10).
+func TestRunFailsAndWritesNothingOnValidateFailure(t *testing.T) {
+	dir := t.TempDir()
+	allFailed, err := os.ReadFile(filepath.Join("..", "..", "internal", "k6", "testdata", "summary_all_failed.json")) //nolint:gosec // fixed testdata golden path
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+
+	// Injected k6: warm-up (empty summaryPath) is a no-op; the measured run
+	// writes the all-failed golden.
+	k6run := func(_ int, _ string, summaryPath string) error {
+		if summaryPath == "" {
+			return nil
+		}
+		return os.WriteFile(summaryPath, allFailed, 0o600) //nolint:gosec // summaryPath is under t.TempDir()
+	}
+
+	cfg := runConfig{
+		targetURL: "http://unused", framework: "x",
+		concurrency: []int{1}, duration: "1s", warmup: "1s", trials: 1,
+		outDir: dir,
+	}
+
+	if err := run(cfg, k6run); err == nil {
+		t.Fatal("run() = nil, want an error for an all-failed trial")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "results.json")); !os.IsNotExist(statErr) {
+		t.Errorf("results.json exists after a failed run; want nothing written (stat err: %v)", statErr)
+	}
+}
+
+// A clean injected run writes the snapshot, and a second framework's run merges
+// rather than truncating.
+func TestRunWritesAndAccumulatesAcrossFrameworks(t *testing.T) {
+	dir := t.TempDir()
+	ok, err := os.ReadFile(filepath.Join("..", "..", "internal", "k6", "testdata", "summary_ok.json")) //nolint:gosec // fixed testdata golden path
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	k6run := func(_ int, _ string, summaryPath string) error {
+		if summaryPath == "" {
+			return nil
+		}
+		return os.WriteFile(summaryPath, ok, 0o600) //nolint:gosec // summaryPath is under t.TempDir()
+	}
+
+	for _, fw := range []string{"gin-gorm", "gombit"} {
+		cfg := runConfig{
+			targetURL: "http://unused", framework: fw, concurrency: []int{10},
+			duration: "1s", warmup: "1s", trials: 1, outDir: dir,
+		}
+		if err := run(cfg, k6run); err != nil {
+			t.Fatalf("run(%s) = %v", fw, err)
+		}
+	}
+
+	f, err := os.Open(filepath.Join(dir, "results.json")) //nolint:gosec // dir is t.TempDir()
+	if err != nil {
+		t.Fatalf("open results.json: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	rows, err := result.ReadJSON(f)
+	if err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	frameworks := map[string]bool{}
+	for _, r := range rows {
+		frameworks[r.Framework] = true
+	}
+	if !frameworks["gin-gorm"] || !frameworks["gombit"] {
+		t.Errorf("second run truncated the first: frameworks = %v", frameworks)
+	}
+}

--- a/benchmarks/scripts/run-crud/main_test.go
+++ b/benchmarks/scripts/run-crud/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gombit-dev/gombit/benchmarks/internal/result"
@@ -98,8 +99,9 @@ func TestRunWritesAndAccumulatesAcrossFrameworks(t *testing.T) {
 
 	for _, fw := range []string{"gin-gorm", "gombit"} {
 		cfg := runConfig{
-			targetURL: "http://unused", framework: fw, concurrency: []int{10},
-			duration: "1s", warmup: "1s", trials: 1, outDir: dir,
+			targetURL: "http://unused", framework: fw, frameworkVersion: "v" + fw,
+			concurrency: []int{10}, duration: "1s", warmup: "1s", trials: 1,
+			outDir: dir, k6Image: "grafana/k6:0.55.0",
 		}
 		if err := run(cfg, k6run); err != nil {
 			t.Fatalf("run(%s) = %v", fw, err)
@@ -121,5 +123,19 @@ func TestRunWritesAndAccumulatesAcrossFrameworks(t *testing.T) {
 	}
 	if !frameworks["gin-gorm"] || !frameworks["gombit"] {
 		t.Errorf("second run truncated the first: frameworks = %v", frameworks)
+	}
+
+	// metadata records the ACTUAL k6 image that ran (not a bare "k6"), and the
+	// version maps accumulate both frameworks across the two runs.
+	meta, err := os.ReadFile(filepath.Join(dir, "metadata.json")) //nolint:gosec // dir is t.TempDir()
+	if err != nil {
+		t.Fatalf("read metadata.json: %v", err)
+	}
+	s := string(meta)
+	if !strings.Contains(s, `"benchmark_tool": "grafana/k6:0.55.0"`) {
+		t.Errorf("metadata benchmark_tool is not the k6 image that ran:\n%s", s)
+	}
+	if !strings.Contains(s, `"gin-gorm": "vgin-gorm"`) || !strings.Contains(s, `"gombit": "vgombit"`) {
+		t.Errorf("metadata framework_versions did not accumulate both runs:\n%s", s)
 	}
 }

--- a/benchmarks/workloads/crud-list.js
+++ b/benchmarks/workloads/crud-list.js
@@ -1,31 +1,56 @@
 // Headline BENCH-1 read workload (issue #141 §"Required headline workload"):
 // GET /api/projects?page=1&limit=20 against a seeded database. The same script
 // runs against every implementation; the orchestrator sets TARGET_URL, VUS
-// (concurrency), and DURATION, and reads the machine-readable summary this
-// writes via handleSummary.
+// (concurrency), and DURATION.
 //
-// This is the *measured* run only — a constant VUs load for DURATION. Warm-up
-// is a separate short invocation of this same script whose summary the
-// orchestrator discards, so no warm-up traffic pollutes the reported metrics.
+// Load model — closed-loop constant VUs. The issue's concurrency-and-tail-
+// latency axis is "N concurrent clients" (1/10/100/500/1000), which is a
+// closed-loop VU concept, so this uses an explicit constant-vus executor at
+// VUS concurrent clients for DURATION. Closed-loop load is subject to
+// COORDINATED OMISSION: when the app slows, a VU waits before issuing its next
+// request, so fewer requests go out and the reported tail latency understates
+// true client-observed wait. Issue #141 §7 allows either constant-rate load or
+// documenting this limitation; the concurrency-sweep framing makes VUs the
+// natural executor, so the limitation is documented here and in
+// benchmarks/README.md / methodology rather than hidden. gracefulStop is 0s so
+// the measured window is exactly DURATION (no up-to-30s default drain in which
+// a slow implementation would get a longer experiment than a fast one); the
+// orchestrator records the *actual* elapsed run time from state, not the flag.
+//
+// Topology — the k6 container runs on the host network on the SAME machine as
+// the app under test (issue's "another container on the same host"), not a
+// separate load-generation host. At high VUs k6 contends for CPU with the app;
+// this is the pinned topology, recorded as such, not hidden.
+//
+// This is the measured run only; warm-up is a separate short invocation whose
+// output the orchestrator discards.
+//
+// handleSummary dumps k6's RAW metrics and state — no interpretation here. All
+// mapping (throughput, percentiles, the http_req_failed Rate whose FAILED
+// count is `passes` not `fails`, elapsed duration) happens in the Go parser
+// (benchmarks/internal/k6), where it is unit-tested against a captured golden,
+// instead of living untested in JavaScript.
 import http from 'k6/http';
 import { check } from 'k6';
 
 const target = __ENV.TARGET_URL;
 
 export const options = {
-  vus: Number(__ENV.VUS || 10),
-  duration: __ENV.DURATION || '30s',
-  // Percentiles the result schema records (issue §9 latency_ms).
+  scenarios: {
+    crud_list: {
+      executor: 'constant-vus',
+      vus: Number(__ENV.VUS || 10),
+      duration: __ENV.DURATION || '30s',
+      gracefulStop: '0s',
+    },
+  },
   summaryTrendStats: ['p(50)', 'p(95)', 'p(99)'],
-  // The load generator itself must not be the thing that fails the run on a
-  // slow tail; thresholds are evaluated but not abort-on-fail here.
-  discardResponseBodies: false,
 };
 
 export default function () {
   const res = http.get(target);
-  // A response that isn't 200 with a full 20-row page is a real error, not a
-  // slow success — count it so errors surfaces in the summary.
+  // A 200 with a full 20-row page; a wrong status or row count is a real
+  // error (counted via http_req_failed / checks), not a slow success.
   check(res, {
     'status is 200': (r) => r.status === 200,
     'has 20 rows': (r) => {
@@ -39,35 +64,6 @@ export default function () {
 }
 
 export function handleSummary(data) {
-  const duration = data.metrics.http_req_duration.values;
-  const reqs = data.metrics.http_reqs.values;
-  // http_req_failed is a Rate metric where a request is "added" as true when
-  // it failed (non-2xx/3xx). In k6's summary a Rate's `passes` is the count of
-  // true adds and `fails` the count of false adds — so the number of FAILED
-  // requests is `passes`, not `fails` (verified against a live all-200 run:
-  // passes=0, fails=<total>). Using `fails` here would report every
-  // successful request as an error.
-  const failed = data.metrics.http_req_failed
-    ? data.metrics.http_req_failed.values
-    : { passes: 0 };
-
-  // Failed content checks (a 200 with the wrong row count) don't show up in
-  // http_req_failed, so surface them separately — the orchestrator fails the
-  // run on either, so a silently-wrong app can't be recorded as valid.
-  const checks = data.metrics.checks ? data.metrics.checks.values : { fails: 0 };
-
-  const summary = {
-    requests: reqs.count,
-    requests_per_second: reqs.rate,
-    latency_ms: {
-      p50: duration['p(50)'],
-      p95: duration['p(95)'],
-      p99: duration['p(99)'],
-    },
-    errors: failed.passes || 0,
-    checks_failed: checks.fails || 0,
-  };
-
   const out = __ENV.SUMMARY_OUT || 'stdout';
-  return { [out]: JSON.stringify(summary) + '\n' };
+  return { [out]: JSON.stringify({ metrics: data.metrics, state: data.state }) + '\n' };
 }

--- a/benchmarks/workloads/crud-list.js
+++ b/benchmarks/workloads/crud-list.js
@@ -1,0 +1,73 @@
+// Headline BENCH-1 read workload (issue #141 §"Required headline workload"):
+// GET /api/projects?page=1&limit=20 against a seeded database. The same script
+// runs against every implementation; the orchestrator sets TARGET_URL, VUS
+// (concurrency), and DURATION, and reads the machine-readable summary this
+// writes via handleSummary.
+//
+// This is the *measured* run only — a constant VUs load for DURATION. Warm-up
+// is a separate short invocation of this same script whose summary the
+// orchestrator discards, so no warm-up traffic pollutes the reported metrics.
+import http from 'k6/http';
+import { check } from 'k6';
+
+const target = __ENV.TARGET_URL;
+
+export const options = {
+  vus: Number(__ENV.VUS || 10),
+  duration: __ENV.DURATION || '30s',
+  // Percentiles the result schema records (issue §9 latency_ms).
+  summaryTrendStats: ['p(50)', 'p(95)', 'p(99)'],
+  // The load generator itself must not be the thing that fails the run on a
+  // slow tail; thresholds are evaluated but not abort-on-fail here.
+  discardResponseBodies: false,
+};
+
+export default function () {
+  const res = http.get(target);
+  // A response that isn't 200 with a full 20-row page is a real error, not a
+  // slow success — count it so errors surfaces in the summary.
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'has 20 rows': (r) => {
+      try {
+        return JSON.parse(r.body).data.length === 20;
+      } catch {
+        return false;
+      }
+    },
+  });
+}
+
+export function handleSummary(data) {
+  const duration = data.metrics.http_req_duration.values;
+  const reqs = data.metrics.http_reqs.values;
+  // http_req_failed is a Rate metric where a request is "added" as true when
+  // it failed (non-2xx/3xx). In k6's summary a Rate's `passes` is the count of
+  // true adds and `fails` the count of false adds — so the number of FAILED
+  // requests is `passes`, not `fails` (verified against a live all-200 run:
+  // passes=0, fails=<total>). Using `fails` here would report every
+  // successful request as an error.
+  const failed = data.metrics.http_req_failed
+    ? data.metrics.http_req_failed.values
+    : { passes: 0 };
+
+  // Failed content checks (a 200 with the wrong row count) don't show up in
+  // http_req_failed, so surface them separately — the orchestrator fails the
+  // run on either, so a silently-wrong app can't be recorded as valid.
+  const checks = data.metrics.checks ? data.metrics.checks.values : { fails: 0 };
+
+  const summary = {
+    requests: reqs.count,
+    requests_per_second: reqs.rate,
+    latency_ms: {
+      p50: duration['p(50)'],
+      p95: duration['p(95)'],
+      p99: duration['p(99)'],
+    },
+    errors: failed.passes || 0,
+    checks_failed: checks.fails || 0,
+  };
+
+  const out = __ENV.SUMMARY_OUT || 'stdout';
+  return { [out]: JSON.stringify(summary) + '\n' };
+}

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -99,7 +99,7 @@ The issue deliberately leaves these open ("pick one and document why"). Recommen
 
 | Decision | Recommendation | Rationale |
 | --- | --- | --- |
-| Load generator | **k6** | Only one of {k6, wrk2, oha} with a built-in constant-arrival-rate executor (`ramping-arrival-rate`), so the coordinated-omission requirement (issue §"Load generator") is met natively instead of documented as a gap. JS scripting lets one workload script parametrize all 6 targets. Ships JSON summary export natively (`--summary-export`), feeding `results.json` directly. |
+| Load generator | **k6** | JS scripting lets one workload script parametrize all 6 targets, and it dumps its raw metrics natively (via `handleSummary`), feeding `results.json` through a tested Go parser. k6 also has a built-in constant-arrival-rate executor available for rate-based workloads. **Coordinated omission (revised on PR #184 review):** the *headline concurrency sweep* (issue §7) is an "N concurrent clients" axis — a closed-loop VU concept — so `benchmarks/workloads/crud-list.js` uses the `constant-vus` executor and the coordinated-omission limitation is documented (the issue's "constant-rate OR document" escape hatch), in the workload comment and `benchmarks/README.md`, rather than claimed away. A rate-based workload that wants CO-resistance natively can use k6's arrival-rate executor. Topology is a k6 container on the host network, on the same machine as the app (issue's "another container on the same host"), recorded as such. |
 | PostgreSQL pin | `postgres:16.4-alpine`, digest captured into `metadata.json` at run time via `docker inspect` | Repo's existing CI convention is `postgres:16-alpine` (major-only); issue requires major.minor or digest. Bump precision without diverging from the CI convention's major version. |
 | Go microbenchmark location | `benchmarks/micro/{nethttp,gin,huma,gombit}`, one package per row, sharing types/route registration/assertions via `benchmarks/micro/scenario`; `internal/contractspike`'s M0-2 spike stays untouched as a historical, standalone artifact, cross-linked but not extended | Matches the issue's own suggested tree and keeps one discoverable home for all benchmark code. "Reuse, not reimplement" is satisfied by cross-linking the spike's result, not by physically colocating new code in `internal/`; the spike's widget routes were never going to be literally extended anyway. One package per row also gets Huma's `contract.Install` process-isolation requirement (the Gombit row mutates process-global `huma.NewError`) for free from `go test`'s one-process-per-package model, instead of needing a special-cased package boundary for just that row. |
 | Gombit/Gin+GORM benchmark *server* apps (real HTTP, not in-process) | Live in `benchmarks/apps/gombit` and `benchmarks/apps/gin-gorm` as `package main` inside the **root Go module** | They only need deps already in `go.sum` (Gin, Huma, GORM, `pgx`/`lib/pq`). Matches the existing precedent of `examples/` living in the root module and being covered by `go build ./...` in CI — no nested `go.mod` needed. |
@@ -1228,6 +1228,44 @@ the next slices.**
   TechEmpower-inspired, and concurrency-sweep workloads below; and the
   benchstat/CoV summarization the AC's "trial variance recorded" needs.
 
+**Post-landing correction (review on PR #184,
+github.com/gombit-dev/gombit/pull/184#pullrequestreview-5035211655):** the
+measurement engine described one experiment and executed another; four
+findings, all real, fixed.
+
+- The workload used k6's `vus`+`duration` shortcut (default `gracefulStop`
+  30s, so a "30s trial" was up to 60s of wall clock, and a slower app got a
+  longer experiment), and `duration_seconds` recorded the *flag*, not elapsed.
+  Switched to an explicit `constant-vus` scenario with `gracefulStop: 0s`, and
+  the parser now records the actual elapsed window from k6's
+  `state.testRunDurationMs` (verified: a 3s run records `duration_seconds ≈
+  3.001`). Documented that this is closed-loop load subject to coordinated
+  omission (the issue's "constant-rate OR document" path — the concurrency
+  sweep is a client-count axis, so VUs are the right executor), corrected the
+  §4 plan claim that arrival-rate met CO natively, fixed the "off the
+  application host" comments to the honest "same machine, host network"
+  topology, and removed a comment about thresholds that didn't exist.
+- The interpretation the PR exists to get right — including the
+  `http_req_failed` Rate whose *failed* count is `passes` not `fails` — lived
+  in untested JavaScript; a one-token change to `fails` would have passed
+  every Go test. Moved all mapping into the Go parser (`benchmarks/internal/k6`):
+  the workload now dumps k6's raw `{metrics, state}`, and the parser is
+  unit-tested against two **real captured k6 goldens** (`testdata/`), one
+  all-200 and one all-refused — the all-refused golden (`http_req_failed
+  passes == count`) is what pins the inversion.
+- `run-crud`'s "appends" was `os.Create` (truncate): a second framework's run
+  against the same out-dir erased the first, so the planned six-app loop would
+  keep only the last. Now merges by framework key (re-running one framework
+  replaces its rows, other frameworks kept), with the metadata version maps
+  unioned; both the merge and "a `Validate` failure writes nothing" are unit
+  tested via an injected k6 seam and the captured goldens.
+- `metadata.resource_limits` recorded the pinned `app 2cpu/1g; postgres
+  2cpu/2g` budget that this engine never applies (it starts nothing) — the
+  `git_dirty: false` fail-open on a different field. `run-crud` now records an
+  honest "not applied (run-crud does not start or constrain the app)"; the
+  compose loop that actually enforces and observes the §7 limits is the next
+  slice.
+
 - Gombit-only auth-overhead benchmark: no-auth / JWT / cookie-session /
   cookie+CSRF variants of `GET /api/me` and `POST /api/projects`
   (`make benchmark-auth`). No cross-framework auth comparison (excluded by
@@ -1305,10 +1343,12 @@ they must not touch `ci.yml`'s existing database/migrations/conformance jobs.
 
 ## 8. Open questions to confirm before Phase 1
 
-1. **k6 as the load generator** — confirms native constant-arrival-rate
-   support satisfies the coordinated-omission requirement; alternative is
-   wrk2 (simpler, but text-output-only and no native arrival-rate control
-   for the concurrency sweep).
+1. **k6 as the load generator** — chosen for JS parametrization of one script
+   across all 6 targets and native raw-metrics dump; alternative is wrk2
+   (simpler, but text-output-only). The headline concurrency sweep uses
+   closed-loop `constant-vus` (the issue's client-count axis) with coordinated
+   omission documented, not k6's arrival-rate executor (revised on PR #184
+   review — see the load-generator row in §4).
 2. **Seed size** (1,000 users / 100,000 projects as specified, vs. a smaller
    documented size) — depends on how slow local/CI seeding turns out to be;
    decide empirically in Phase 3, not up front.

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1193,6 +1193,41 @@ real MAJOR findings, all confirmed and fixed.
 
 ### Phase 5 — Workload depth: auth overhead, TechEmpower-inspired, concurrency sweep
 
+**Headline CRUD-read workload + `make benchmark-crud` — the per-implementation
+measurement engine — done; the all-six compose loop and footprint capture are
+the next slices.**
+
+- `benchmarks/workloads/crud-list.js`: the headline `GET /api/projects?page=1&limit=20`
+  workload (issue §"Required headline workload"), run by the pinned k6 image
+  (`grafana/k6:0.55.0` — the load generator runs in its own container, off the
+  application host, satisfying issue §"Load generator"). It is the *measured*
+  run only (constant VUs for the duration); warm-up is a separate short
+  invocation whose summary the orchestrator discards, so no warm-up traffic
+  pollutes the metrics. `handleSummary` writes a compact machine-readable
+  summary (throughput, p50/p95/p99, HTTP errors, failed content checks).
+- `benchmarks/internal/k6`: parses that summary into the load-generator-derived
+  fields of a `result.Result` (`Merge` keeps the identity/config fields the
+  orchestrator set), plus `Summary.Validate` — a trial with no traffic (target
+  unreachable), any HTTP error, or any failed content check is a failed
+  measurement, not a valid row. Unit-tested, including that k6's
+  `http_req_failed` Rate reports the *failed* count as `passes` not `fails`
+  (found by running it live — an all-200 run reported `passes:0, fails:<total>`,
+  so an earlier draft recorded every success as an error).
+- `benchmarks/scripts/run-crud` + `make benchmark-crud`: against one
+  already-running, already-seeded implementation, warms up, measures `TRIALS`
+  times at each concurrency level from `versions.env`, validates every trial,
+  and writes `results/latest/{results.json,results.csv,metadata.json}` + the
+  raw k6 summaries. Verified end to end against `benchmarks/apps/gin-gorm`: a
+  clean run records `errors:0` rows; an unreachable target fails the command
+  (exit 1, "N of N requests failed") with no results written, rather than
+  recording a bogus 100%-error row. The k6 container runs as the invoking uid
+  so the mounted summary file is writable. `cpu_percent`/`rss_bytes` stay 0 —
+  per-app footprint is Phase 6, and this engine doesn't manage the app process.
+- **Still open in Phase 5:** the loop that brings all six apps up under compose
+  (with the §7 resource limits) and runs `run-crud` over each; the auth,
+  TechEmpower-inspired, and concurrency-sweep workloads below; and the
+  benchstat/CoV summarization the AC's "trial variance recorded" needs.
+
 - Gombit-only auth-overhead benchmark: no-auth / JWT / cookie-session /
   cookie+CSRF variants of `GET /api/me` and `POST /api/projects`
   (`make benchmark-auth`). No cross-framework auth comparison (excluded by

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1199,30 +1199,37 @@ the next slices.**
 
 - `benchmarks/workloads/crud-list.js`: the headline `GET /api/projects?page=1&limit=20`
   workload (issue §"Required headline workload"), run by the pinned k6 image
-  (`grafana/k6:0.55.0` — the load generator runs in its own container, off the
-  application host, satisfying issue §"Load generator"). It is the *measured*
-  run only (constant VUs for the duration); warm-up is a separate short
-  invocation whose summary the orchestrator discards, so no warm-up traffic
-  pollutes the metrics. `handleSummary` writes a compact machine-readable
-  summary (throughput, p50/p95/p99, HTTP errors, failed content checks).
-- `benchmarks/internal/k6`: parses that summary into the load-generator-derived
-  fields of a `result.Result` (`Merge` keeps the identity/config fields the
-  orchestrator set), plus `Summary.Validate` — a trial with no traffic (target
-  unreachable), any HTTP error, or any failed content check is a failed
-  measurement, not a valid row. Unit-tested, including that k6's
-  `http_req_failed` Rate reports the *failed* count as `passes` not `fails`
-  (found by running it live — an all-200 run reported `passes:0, fails:<total>`,
-  so an earlier draft recorded every success as an error).
+  (`grafana/k6:0.55.0`) in a container on the host network, on the **same
+  machine** as the app (the issue's "another container on the same host"). It
+  uses an explicit closed-loop `constant-vus` executor (`gracefulStop: 0s`) at
+  the concurrency level — the concurrency sweep is a client-count axis — with
+  the resulting **coordinated omission** documented (the issue's constant-rate
+  OR document path), not hidden. Measured run only; warm-up is a separate short
+  invocation the orchestrator discards. `handleSummary` dumps k6's **raw**
+  `{metrics, state}` — no interpretation in JavaScript.
+- `benchmarks/internal/k6`: parses that raw summary into the
+  load-generator-derived fields of a `result.Result` — including `DurationSeconds`
+  from the actual elapsed `state.testRunDurationMs` (not the flag), the
+  percentiles, and the `http_req_failed` Rate whose *failed* count is `passes`
+  not `fails` — with `Merge` keeping the orchestrator's identity/config fields,
+  and `Summary.Validate` rejecting any trial with no traffic, HTTP errors, or
+  failed content checks. Unit-tested against two **real captured k6 goldens**
+  (`testdata/`, all-200 and all-refused); the all-refused golden (`passes ==
+  count`) is what pins the inversion a one-token change would otherwise break.
 - `benchmarks/scripts/run-crud` + `make benchmark-crud`: against one
   already-running, already-seeded implementation, warms up, measures `TRIALS`
   times at each concurrency level from `versions.env`, validates every trial,
-  and writes `results/latest/{results.json,results.csv,metadata.json}` + the
-  raw k6 summaries. Verified end to end against `benchmarks/apps/gin-gorm`: a
-  clean run records `errors:0` rows; an unreachable target fails the command
-  (exit 1, "N of N requests failed") with no results written, rather than
-  recording a bogus 100%-error row. The k6 container runs as the invoking uid
-  so the mounted summary file is writable. `cpu_percent`/`rss_bytes` stay 0 —
-  per-app footprint is Phase 6, and this engine doesn't manage the app process.
+  and **merges** the rows into `results/latest/{results.json,results.csv,metadata.json}`
+  (+ raw k6 summaries) by framework key — re-running one framework replaces its
+  rows, others kept, so the six-app loop accumulates. `metadata.benchmark_tool`
+  records the actual k6 image that ran, and `metadata.resource_limits` honestly
+  says "not applied" (this engine starts/constrains nothing). Verified end to
+  end against `benchmarks/apps/gin-gorm`: a clean run records `errors:0` rows
+  and `duration_seconds ≈ 3.001` for a 3s run; an unreachable target fails the
+  command (exit 1, "N of N requests failed") with **nothing written**. The k6
+  container runs as the invoking uid so the mounted summary file is writable.
+  `cpu_percent`/`rss_bytes` stay 0 — per-app footprint (and enforcing/observing
+  the §7 limits) is the compose loop / Phase 6, not this engine.
 - **Still open in Phase 5:** the loop that brings all six apps up under compose
   (with the §7 resource limits) and runs `run-crud` over each; the auth,
   TechEmpower-inspired, and concurrency-sweep workloads below; and the
@@ -1265,6 +1272,20 @@ findings, all real, fixed.
   honest "not applied (run-crud does not start or constrain the app)"; the
   compose loop that actually enforces and observes the §7 limits is the next
   slice.
+
+**Post-landing correction, round 2 (review on PR #184,
+github.com/gombit-dev/gombit/pull/184#pullrequestreview-5035408343):** two
+metadata-path gaps, both fixed. (1) `run()` recorded `benchmark_tool: "k6"` — a
+bare token, not the image it exec'd — so overriding `-k6-image` left the
+reproducibility file describing the wrong tool version. Put the image on
+`runConfig` and record it; a test asserts `metadata.json`'s `benchmark_tool` is
+the actual image and that the version maps accumulate across two framework
+runs. (2) The Phase 5 "done" bullets above still described the first-commit
+engine ("off the application host", an interpreted `handleSummary`); rewritten
+to match the code (same-machine topology, `constant-vus` + documented CO, raw
+`{metrics,state}` dump, merge-by-framework, honest `benchmark_tool`/
+`resource_limits`) so the prose someone copies into methodology is accurate on
+its own, not only in the correction below it.
 
 - Gombit-only auth-overhead benchmark: no-auth / JWT / cookie-session /
   cookie+CSRF variants of `GET /api/me` and `POST /api/projects`


### PR DESCRIPTION
## Summary

The per-implementation measurement engine that turns the Phase 1 result
schema into real numbers (#141 §"Required headline workload", §9, §10).
Runs the headline `GET /api/projects?page=1&limit=20` workload against
one running, seeded app and writes a `results/latest/` snapshot. The
loop that brings all six apps up under compose and runs this over each
is the deliberately-next slice.

- **`benchmarks/workloads/crud-list.js`** — the headline read workload,
  driven by the pinned k6 image (`grafana/k6:0.55.0`, running in its own
  container off the app host). Measured run only; warm-up is a separate
  discarded invocation. `handleSummary` emits throughput, p50/p95/p99,
  HTTP errors, and failed content checks.
- **`benchmarks/internal/k6`** — parses that summary into a
  `result.Result` (`Merge` keeps the orchestrator's identity/config
  fields), plus `Summary.Validate`: no traffic, any HTTP error, or any
  failed content check is a failed measurement, not a valid row.
  Unit-tested — including that k6's `http_req_failed` Rate reports the
  *failed* count as `passes`, not `fails` (found by running it live).
- **`benchmarks/scripts/run-crud` + `make benchmark-crud`** — warms up,
  measures `TRIALS` times per concurrency level from `versions.env`,
  validates every trial, and writes
  `results/latest/{results.json,results.csv,metadata.json}` + raw k6
  summaries. The k6 container runs as the invoking uid so the mounted
  summary file is writable. `cpu_percent`/`rss_bytes` stay 0 (Phase 6).
- **`Makefile`** — `benchmark-crud` and `benchmark-metadata`, sourcing
  the pinned run config from `benchmarks/config/versions.env`.

## Linked issue

#141 (Phase 5 headline CRUD workload + §10 `make benchmark-crud`)

## Scope notes

The full `make benchmark-crud` that brings up all six apps under compose
with §7 resource limits and loops `run-crud` over each — plus per-app
RSS/CPU capture (Phase 6) and the other `make benchmark-*` workloads —
is layered on next. This slice is the verified engine those build on.

## Validation commands

```sh
# start + seed benchmarks/apps/gin-gorm, then:
make benchmark-crud FRAMEWORK=gin-gorm FRAMEWORK_VERSION=v1.11.0 \
  RUNTIME=go RUNTIME_VERSION=go1.25.7 \
  TARGET_URL='http://127.0.0.1:8081/api/projects?page=1&limit=20'
go test ./benchmarks/internal/k6/...
golangci-lint run ./benchmarks/internal/k6/... ./benchmarks/scripts/run-crud/...
```

Verified end to end against gin-gorm: a clean run records `errors:0`
rows; an unreachable target fails the command (exit 1, no results),
rather than recording a bogus 100%-error row.

## Working agreement checklist

- [x] New behavior has tests (`internal/k6` parse/validate/merge); the
      k6-invocation glue is verified end-to-end (a runner over tested
      packages), documented in the PR.
- [x] Docs updated (`benchmarks/README.md` "Running the CRUD-read
      workload", plan Phase 5); the Makefile is the runnable example.
- [ ] N/A — no `golang-rest-api-template` extraction.
- [ ] N/A — no Gombit API change; no OpenAPI/TS regeneration.
- [x] No secrets; no generated artifacts committed (results/latest/ is
      Phase 7).
- [x] Scope stays inside the Phase 5 CRUD-workload engine; no M6 battery.
- [x] Links its issue and states satisfied acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)