### PR TITLE
feat: BENCH-1 containerize the gombit app (Atlas migrate/seed/serve under compose)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,7 +7,8 @@ Full plan: [docs/plans/BENCH-1-benchmark-suite.md](../docs/plans/BENCH-1-benchma
 
 ```text
 benchmarks/
-├── compose.yml          PostgreSQL + the gin-gorm app service (§7 limits); more apps land with the Phase 6 loop
+├── compose.yml          PostgreSQL + the two Go app services (gin-gorm, gombit; §7 limits); ecosystem apps land next
+├── compose/initdb/      Postgres init SQL (creates gombit's separate gombit_bench_gombit database)
 ├── config/
 │   └── versions.env     pinned load generator (k6), Postgres image, resource limits, workload defaults
 ├── docs/
@@ -46,13 +47,15 @@ benchmarks/
 All six canonical CRUD implementations exist, the result schema / metadata
 collector / run-config pins are in place, and the headline CRUD-read workload
 runs end to end against one implementation (`make benchmark-crud`). The Phase 6
-compose loop has started: `gin-gorm` is containerized and its `compose.yml`
-service carries the §7 resource budget, with `internal/reslimits` +
-`scripts/inspect-limits` verifying the ceiling actually landed on the live
-container (issue #141's "detect/report rather than silently pretend"). Still
-scoped to later phases: `docs/methodology.md`, containerizing the other five
-apps and the loop that brings all six up and runs `run-crud` over each, per-app
-resource/RSS capture (Phase 6 footprint), the other `make benchmark-*`
+compose loop has started: both Go apps (`gin-gorm` and `gombit`) are
+containerized with `compose.yml` services carrying the §7 resource budget —
+`gombit` also applies its real Atlas migrations in-container (pinned `atlas`
+image) — and `internal/reslimits` + `scripts/inspect-limits` verify the ceiling
+actually landed on the live container (issue #141's "detect/report rather than
+silently pretend"). Still scoped to later phases: `docs/methodology.md`,
+containerizing the four ecosystem apps and the loop that brings all six up and
+runs `run-crud` over each, per-app resource/RSS capture (Phase 6 footprint), the
+other `make benchmark-*`
 workloads, and extending `fairness_test.go` to all six.
 
 ## Resource limits (§7): intention vs. reality

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,7 +8,6 @@ Full plan: [docs/plans/BENCH-1-benchmark-suite.md](../docs/plans/BENCH-1-benchma
 ```text
 benchmarks/
 ├── compose.yml          PostgreSQL + the two Go app services (gin-gorm, gombit; §7 limits); ecosystem apps land next
-├── compose/initdb/      Postgres init SQL (creates gombit's separate gombit_bench_gombit database)
 ├── config/
 │   └── versions.env     pinned load generator (k6), Postgres image, resource limits, workload defaults
 ├── docs/

--- a/benchmarks/apps/gin-gorm/README.md
+++ b/benchmarks/apps/gin-gorm/README.md
@@ -104,9 +104,10 @@ and the cross-implementation fairness check comparing them are all done
 Phase 3). See [../gombit/README.md](../gombit/README.md) for the Gombit-side
 details, including one discovered framework gap and two bugs the fairness
 comparison caught. This app is now containerized with a `benchmarks/compose.yml`
-`gin-gorm` service carrying the §7 budget (see [Run](#run) above). Still open:
-wiring the fairness check into automated CI (it needs both databases at the full
-canonical 1,000/100,000 scale, deferred to Phase 8's lighter-seed CI work); the
-`gombit` app's compose service and the six-app bring-up loop (later Phase 6
-slices); and consuming the `inspect-limits` verdict into a run's recorded
-`metadata.resource_limits` (today it is printed, not yet recorded).
+`gin-gorm` service carrying the §7 budget (see [Run](#run) above); the `gombit`
+app has its own service too. Still open: wiring the fairness check into automated
+CI (it needs both databases at the full canonical 1,000/100,000 scale, deferred
+to Phase 8's lighter-seed CI work); the four ecosystem apps' compose services and
+the six-app bring-up loop (later Phase 6 slices); and consuming the
+`inspect-limits` verdict into a run's recorded `metadata.resource_limits` (today
+it is printed, not yet recorded).

--- a/benchmarks/apps/gombit/Dockerfile
+++ b/benchmarks/apps/gombit/Dockerfile
@@ -1,0 +1,43 @@
+# Container image for the gombit benchmark app — the real Gombit-runtime
+# implementation of the canonical /api/projects CRUD API.
+#
+# Build context is the REPOSITORY ROOT (the Go module root):
+#
+#   docker build -f benchmarks/apps/gombit/Dockerfile -t bench-gombit:local .
+#
+# Unlike gin-gorm (AutoMigrate), this app uses Atlas versioned migrations
+# applied as a separate step, exactly like a deployed Gombit app: the entrypoint
+# runs `gombit db migrate` (which execs `atlas migrate apply`) before serving.
+# So the image carries three things — the app binary, the `gombit` CLI, and the
+# pinned `atlas` binary — plus the migrations directory.
+ARG ATLAS_IMAGE=arigaio/atlas:0.36.0
+
+FROM golang:1.25.7-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# The app under test and the gombit CLI that applies its migrations.
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/gombit-app ./benchmarks/apps/gombit && \
+    CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/gombit ./cmd/gombit
+
+# Pinned Atlas CLI (distroless image; the binary lives at /atlas).
+FROM ${ATLAS_IMAGE} AS atlas
+
+FROM alpine:3.20
+RUN adduser -D -u 10001 app
+COPY --from=build /out/gombit-app /usr/local/bin/gombit-app
+COPY --from=build /out/gombit /usr/local/bin/gombit
+COPY --from=atlas /atlas /usr/local/bin/atlas
+# `gombit db migrate` defaults --dir to database/migrations relative to the
+# working directory, so ship the migrations under /app and run from there.
+WORKDIR /app
+COPY benchmarks/apps/gombit/database ./database
+COPY benchmarks/apps/gombit/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+USER app
+EXPOSE 8080
+# Verbs: `migrate` (atlas apply, then exit), `seed` (deterministic seed, then
+# exit), `serve` (run the API, default).
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["serve"]

--- a/benchmarks/apps/gombit/Dockerfile
+++ b/benchmarks/apps/gombit/Dockerfile
@@ -5,12 +5,20 @@
 #
 #   docker build -f benchmarks/apps/gombit/Dockerfile -t bench-gombit:local .
 #
-# Unlike gin-gorm (AutoMigrate), this app uses Atlas versioned migrations
-# applied as a separate step, exactly like a deployed Gombit app: the entrypoint
-# runs `gombit db migrate` (which execs `atlas migrate apply`) before serving.
-# So the image carries three things — the app binary, the `gombit` CLI, and the
-# pinned `atlas` binary — plus the migrations directory.
-ARG ATLAS_IMAGE=arigaio/atlas:0.36.0
+# Unlike gin-gorm (AutoMigrate), this app uses Atlas versioned migrations, the
+# same way a deployed Gombit app would. Migrations are NOT applied on serve;
+# the entrypoint has three explicit verbs and `serve` (the default CMD) only
+# runs the API. Bring-up order is: `run migrate` (ensures the database and
+# applies migrations), `run seed`, then `serve`. So the image carries three
+# binaries — the app, the `gombit` CLI (applies migrations), and the pinned
+# `atlas` binary — plus the migrations directory and a psql client (the migrate
+# verb creates the target database if absent).
+#
+# ATLAS_IMAGE is the *-alpine* Atlas image on purpose: its /atlas is the
+# musl-compatible build, so copying it onto the alpine runtime below is safe
+# (the default debian-distroless tag can ship a dynamically linked glibc binary
+# that would fail on alpine).
+ARG ATLAS_IMAGE=arigaio/atlas:0.36.0-alpine
 
 FROM golang:1.25.7-alpine AS build
 WORKDIR /src
@@ -21,23 +29,20 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/gombit-app ./benchmarks/apps/gombit && \
     CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/gombit ./cmd/gombit
 
-# Pinned Atlas CLI (distroless image; the binary lives at /atlas).
 FROM ${ATLAS_IMAGE} AS atlas
 
 FROM alpine:3.20
-RUN adduser -D -u 10001 app
+# postgresql-client: the migrate verb ensures the target database exists.
+RUN apk add --no-cache postgresql-client && adduser -D -u 10001 app
 COPY --from=build /out/gombit-app /usr/local/bin/gombit-app
 COPY --from=build /out/gombit /usr/local/bin/gombit
-COPY --from=atlas /atlas /usr/local/bin/atlas
+COPY --from=atlas --chmod=0755 /atlas /usr/local/bin/atlas
 # `gombit db migrate` defaults --dir to database/migrations relative to the
 # working directory, so ship the migrations under /app and run from there.
 WORKDIR /app
 COPY benchmarks/apps/gombit/database ./database
-COPY benchmarks/apps/gombit/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY --chmod=0755 benchmarks/apps/gombit/docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 USER app
 EXPOSE 8080
-# Verbs: `migrate` (atlas apply, then exit), `seed` (deterministic seed, then
-# exit), `serve` (run the API, default).
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["serve"]

--- a/benchmarks/apps/gombit/Dockerfile.dockerignore
+++ b/benchmarks/apps/gombit/Dockerfile.dockerignore
@@ -1,0 +1,15 @@
+# Dockerfile-scoped build-context ignore (BuildKit reads
+# <dockerfile>.dockerignore before a root .dockerignore). The gombit build needs
+# the Go module (it builds ./benchmarks/apps/gombit and ./cmd/gombit); keep the
+# heavy, unrelated trees out of the context.
+.git
+**/node_modules
+**/vendor
+benchmarks/apps/nestjs
+benchmarks/apps/laravel
+benchmarks/apps/rails
+benchmarks/apps/django
+benchmarks/results
+frontend
+web
+**/*.md

--- a/benchmarks/apps/gombit/README.md
+++ b/benchmarks/apps/gombit/README.md
@@ -57,6 +57,37 @@ Env vars (all optional, defaults match `benchmarks/compose.yml`):
 with no version segment; left at the framework default this app's own route
 surface wouldn't have matched its own control.
 
+### Under compose (containerized, with the §7 resource budget)
+
+The app is containerized (`Dockerfile`, built from the **repo root**) and wired
+into `benchmarks/compose.yml` with the §7 app ceiling (2 vCPU / 1 GiB). Because
+it applies **real Atlas migrations** (not AutoMigrate), the image also carries
+the `gombit` CLI and the pinned `atlas` binary (`ATLAS_IMAGE` in
+`benchmarks/config/versions.env`), and its entrypoint has three verbs —
+`migrate`, `seed`, `serve`. The `gombit_bench_gombit` database is created by the
+postgres init script on a fresh volume.
+
+```sh
+# fresh Postgres (the init script creates gombit_bench_gombit) + build/up gombit
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml up -d postgres gombit
+
+# apply migrations, then seed — one-shots, before the served container is measured
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml run --rm gombit migrate
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml run --rm gombit seed
+
+# confirm the §7 ceiling actually landed on the live container
+go run ./benchmarks/scripts/inspect-limits \
+  -container "$(docker compose -f benchmarks/compose.yml ps -q gombit)" \
+  -cpus 2 -memory 1g
+```
+
+`down -v` resets the Postgres volume (and re-runs the init script). The full
+six-app bring-up/`run-crud` loop is a later Phase 6 slice; this containerizes the
+second of the two Go apps on the same pattern as `gin-gorm`.
+
 ## Test
 
 ```sh
@@ -117,8 +148,11 @@ pointer to file it as its own issue.
 Implementation, migration, and both test suites are done and verified
 against real PostgreSQL (schema diffed statement-log-for-statement-log
 against `gin-gorm`'s N+1 behavior, and cross-checked live via
-`TestCrossImplementationFairness`). Still open (tracked in
+`TestCrossImplementationFairness`). Both Go apps now have `benchmarks/compose.yml`
+services with the §7 budget (see [Under compose](#under-compose-containerized-with-the-7-resource-budget)
+above). Still open (tracked in
 [docs/plans/BENCH-1-benchmark-suite.md](../../../docs/plans/BENCH-1-benchmark-suite.md)
-Phase 3b): wiring the cross-implementation fairness check into CI (needs a
+Phase 3b/6): wiring the cross-implementation fairness check into CI (needs a
 lighter seed-size mechanism than the canonical 1,000/100,000, which is
-Phase 8's concern), and `benchmarks/compose.yml` app services for both apps.
+Phase 8's concern), the four ecosystem apps' compose services, and the six-app
+bring-up/`run-crud` loop.

--- a/benchmarks/apps/gombit/README.md
+++ b/benchmarks/apps/gombit/README.md
@@ -63,30 +63,33 @@ The app is containerized (`Dockerfile`, built from the **repo root**) and wired
 into `benchmarks/compose.yml` with the §7 app ceiling (2 vCPU / 1 GiB). Because
 it applies **real Atlas migrations** (not AutoMigrate), the image also carries
 the `gombit` CLI and the pinned `atlas` binary (`ATLAS_IMAGE` in
-`benchmarks/config/versions.env`), and its entrypoint has three verbs —
-`migrate`, `seed`, `serve`. The `gombit_bench_gombit` database is created by the
-postgres init script on a fresh volume.
+`benchmarks/config/versions.env`, the *-alpine* variant so the binary matches
+the runtime base), plus a psql client, and its entrypoint has three verbs —
+`migrate`, `seed`, `serve`. `serve` does **not** migrate, so run them in order.
+The `gombit_bench_gombit` database is created by the `migrate` verb if absent
+(idempotent, every bring-up — not by a fresh-volume init script, which wouldn't
+fire on this suite's already-initialized Postgres volume):
 
 ```sh
-# fresh Postgres (the init script creates gombit_bench_gombit) + build/up gombit
 docker compose --env-file benchmarks/config/versions.env \
-  -f benchmarks/compose.yml up -d postgres gombit
+  -f benchmarks/compose.yml up -d postgres
 
-# apply migrations, then seed — one-shots, before the served container is measured
+# apply migrations (also creates gombit_bench_gombit if missing), then seed
 docker compose --env-file benchmarks/config/versions.env \
   -f benchmarks/compose.yml run --rm gombit migrate
 docker compose --env-file benchmarks/config/versions.env \
   -f benchmarks/compose.yml run --rm gombit seed
 
-# confirm the §7 ceiling actually landed on the live container
+# now serve, and confirm the §7 ceiling actually landed on the live container
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml up -d gombit
 go run ./benchmarks/scripts/inspect-limits \
   -container "$(docker compose -f benchmarks/compose.yml ps -q gombit)" \
   -cpus 2 -memory 1g
 ```
 
-`down -v` resets the Postgres volume (and re-runs the init script). The full
-six-app bring-up/`run-crud` loop is a later Phase 6 slice; this containerizes the
-second of the two Go apps on the same pattern as `gin-gorm`.
+The full six-app bring-up/`run-crud` loop is a later Phase 6 slice; this
+containerizes the second of the two Go apps on the same pattern as `gin-gorm`.
 
 ## Test
 

--- a/benchmarks/apps/gombit/docker-entrypoint.sh
+++ b/benchmarks/apps/gombit/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# gombit container entrypoint. Three verbs so the compose loop drives migrate /
+# seed / serve explicitly (benchmarks/apps/gombit/README.md):
+#
+#   migrate  apply Atlas migrations (`gombit db migrate`) and exit
+#   seed     run the deterministic seed (truncate + insert) and exit
+#   serve    run the API (default)
+#
+# The app binary reads DATABASE_URL; the `gombit` CLI reads
+# GOMBIT_DATABASE_DRIVER/GOMBIT_DATABASE_DSN, so `migrate` maps the one
+# DATABASE_URL a caller sets onto the CLI's env — one variable configures all
+# three verbs.
+set -eu
+
+case "${1:-serve}" in
+  migrate)
+    export GOMBIT_DATABASE_DRIVER=postgres
+    export GOMBIT_DATABASE_DSN="${DATABASE_URL}"
+    # WORKDIR is /app, which holds database/migrations (the CLI's default --dir).
+    exec gombit db migrate
+    ;;
+  seed)
+    exec gombit-app -seed
+    ;;
+  serve)
+    exec gombit-app
+    ;;
+  *)
+    echo "entrypoint: unknown command '$1' (want: migrate | seed | serve)" >&2
+    exit 2
+    ;;
+esac

--- a/benchmarks/apps/gombit/docker-entrypoint.sh
+++ b/benchmarks/apps/gombit/docker-entrypoint.sh
@@ -2,9 +2,9 @@
 # gombit container entrypoint. Three verbs so the compose loop drives migrate /
 # seed / serve explicitly (benchmarks/apps/gombit/README.md):
 #
-#   migrate  apply Atlas migrations (`gombit db migrate`) and exit
+#   migrate  ensure the target database exists, apply Atlas migrations, exit
 #   seed     run the deterministic seed (truncate + insert) and exit
-#   serve    run the API (default)
+#   serve    run the API (default) — does NOT migrate; run `migrate` first
 #
 # The app binary reads DATABASE_URL; the `gombit` CLI reads
 # GOMBIT_DATABASE_DRIVER/GOMBIT_DATABASE_DSN, so `migrate` maps the one
@@ -12,10 +12,29 @@
 # three verbs.
 set -eu
 
+# ensure_database creates the target database if it is absent. This runs as part
+# of every `migrate`, so provisioning does NOT depend on a fresh Postgres volume
+# (unlike docker-entrypoint-initdb.d, which runs only once on an empty data
+# dir) and never requires `down -v` — which would wipe the sibling app's data.
+# ADMIN_DATABASE_URL points at an existing database on the same server (the
+# maintenance connection); TARGET_DB is the database to ensure. If either is
+# unset (e.g. a hand-provisioned local DB) the step is skipped.
+ensure_database() {
+  [ -n "${ADMIN_DATABASE_URL:-}" ] && [ -n "${TARGET_DB:-}" ] || return 0
+  if psql "${ADMIN_DATABASE_URL}" -tAc \
+      "SELECT 1 FROM pg_database WHERE datname = '${TARGET_DB}'" | grep -q 1; then
+    return 0
+  fi
+  echo "entrypoint: creating database ${TARGET_DB}" >&2
+  # CREATE DATABASE has no IF NOT EXISTS; the catalog check above guards it.
+  psql "${ADMIN_DATABASE_URL}" -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"${TARGET_DB}\""
+}
+
 case "${1:-serve}" in
   migrate)
     export GOMBIT_DATABASE_DRIVER=postgres
     export GOMBIT_DATABASE_DSN="${DATABASE_URL}"
+    ensure_database
     # WORKDIR is /app, which holds database/migrations (the CLI's default --dir).
     exec gombit db migrate
     ;;

--- a/benchmarks/compose.yml
+++ b/benchmarks/compose.yml
@@ -1,6 +1,7 @@
 # PostgreSQL + the benchmark app services under test. App services are added
-# as each is containerized (Phase 6 compose loop); `gin-gorm` is the first —
-# the reference Go control the others are compared against.
+# as each is containerized (Phase 6 compose loop): the two Go apps `gin-gorm`
+# (the reference control) and `gombit` (same API on the Gombit runtime) are in;
+# the four ecosystem apps are the next slices.
 #
 # Version pin: issue #141 requires major.minor (or digest), not a
 # major-only floating tag. The pin lives once in
@@ -36,6 +37,12 @@ services:
       POSTGRES_USER: gombit
       POSTGRES_PASSWORD: gombit
       POSTGRES_DB: gombit_bench
+    # gin-gorm uses gombit_bench (POSTGRES_DB above); the gombit app needs a
+    # separate gombit_bench_gombit (real Atlas migration, not AutoMigrate — see
+    # benchmarks/apps/gombit/README.md), created by this init script on a fresh
+    # data volume (`docker compose down -v` to re-run it).
+    volumes:
+      - ./compose/initdb:/docker-entrypoint-initdb.d:ro
     ports:
       - "127.0.0.1:55432:5432"
     healthcheck:
@@ -84,6 +91,46 @@ services:
     # ceiling) on every interval. The next apps' services copy this one.
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null 'http://127.0.0.1:8081/livez' || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+    deploy:
+      resources:
+        limits:
+          cpus: "${APP_CPUS:-2}"
+          memory: ${APP_MEMORY:-1g}
+
+  # The gombit app (issue #141 §7 app budget: 2 vCPU / 1 GiB) — same canonical
+  # API as gin-gorm, on the Gombit runtime. Its image also carries the `gombit`
+  # CLI and the pinned `atlas` binary because migrations are applied as a
+  # separate step (real Atlas versioned migrations, not AutoMigrate), and it
+  # uses its own gombit_bench_gombit database. Bring it up, then apply migrations
+  # and seed as one-shots before the served container is measured:
+  #
+  #   docker compose ... run --rm gombit migrate
+  #   docker compose ... run --rm gombit seed
+  gombit:
+    build:
+      context: ..
+      dockerfile: benchmarks/apps/gombit/Dockerfile
+      args:
+        ATLAS_IMAGE: ${ATLAS_IMAGE:-arigaio/atlas:0.36.0}
+    image: bench-gombit:local
+    command: ["serve"]
+    environment:
+      DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench_gombit?sslmode=disable
+      PORT: "8080"
+      POOL_MAX_OPEN: "${POOL_MAX_OPEN:-20}"
+      POOL_MAX_IDLE: "${POOL_MAX_IDLE:-20}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:8080:8080"
+    # /livez is served by framework.App with no DB touch (framework/app.go) —
+    # same rule as gin-gorm: never probe the measured route.
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null 'http://127.0.0.1:8080/livez' || exit 1"]
       interval: 3s
       timeout: 3s
       retries: 20

--- a/benchmarks/compose.yml
+++ b/benchmarks/compose.yml
@@ -39,10 +39,11 @@ services:
       POSTGRES_DB: gombit_bench
     # gin-gorm uses gombit_bench (POSTGRES_DB above); the gombit app needs a
     # separate gombit_bench_gombit (real Atlas migration, not AutoMigrate — see
-    # benchmarks/apps/gombit/README.md), created by this init script on a fresh
-    # data volume (`docker compose down -v` to re-run it).
-    volumes:
-      - ./compose/initdb:/docker-entrypoint-initdb.d:ro
+    # benchmarks/apps/gombit/README.md). It is created idempotently by the
+    # gombit `migrate` verb on every bring-up, NOT by docker-entrypoint-initdb.d
+    # — that runs only on a fresh data volume, so on this suite's already-
+    # initialized volume it would never fire, and `down -v` to force it would
+    # wipe gin-gorm's seed.
     ports:
       - "127.0.0.1:55432:5432"
     healthcheck:
@@ -103,22 +104,30 @@ services:
   # The gombit app (issue #141 §7 app budget: 2 vCPU / 1 GiB) — same canonical
   # API as gin-gorm, on the Gombit runtime. Its image also carries the `gombit`
   # CLI and the pinned `atlas` binary because migrations are applied as a
-  # separate step (real Atlas versioned migrations, not AutoMigrate), and it
-  # uses its own gombit_bench_gombit database. Bring it up, then apply migrations
-  # and seed as one-shots before the served container is measured:
+  # separate step (real Atlas versioned migrations, not AutoMigrate), on its own
+  # gombit_bench_gombit database. `serve` does not migrate — bring it up in
+  # order, applying migrations (which also creates the database) and seeding as
+  # one-shots first:
   #
+  #   docker compose ... up -d postgres
   #   docker compose ... run --rm gombit migrate
   #   docker compose ... run --rm gombit seed
+  #   docker compose ... up -d gombit
   gombit:
     build:
       context: ..
       dockerfile: benchmarks/apps/gombit/Dockerfile
       args:
-        ATLAS_IMAGE: ${ATLAS_IMAGE:-arigaio/atlas:0.36.0}
+        ATLAS_IMAGE: ${ATLAS_IMAGE:-arigaio/atlas:0.36.0-alpine}
     image: bench-gombit:local
     command: ["serve"]
     environment:
       DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench_gombit?sslmode=disable
+      # The migrate verb creates TARGET_DB if absent, connecting via
+      # ADMIN_DATABASE_URL (an existing DB on the same server) — idempotent,
+      # every bring-up, no fresh-volume dependency.
+      ADMIN_DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench?sslmode=disable
+      TARGET_DB: gombit_bench_gombit
       PORT: "8080"
       POOL_MAX_OPEN: "${POOL_MAX_OPEN:-20}"
       POOL_MAX_IDLE: "${POOL_MAX_IDLE:-20}"

--- a/benchmarks/compose/initdb/10-gombit-bench-gombit.sql
+++ b/benchmarks/compose/initdb/10-gombit-bench-gombit.sql
@@ -1,9 +1,0 @@
--- Create the second benchmark database the gombit app uses.
---
--- gin-gorm uses gombit_bench (the postgres service's POSTGRES_DB). The gombit
--- app's users/projects tables come from a real Atlas migration, not
--- AutoMigrate, so it must not share a database with gin-gorm (see
--- benchmarks/apps/gombit/README.md). This runs once, on a fresh Postgres data
--- volume, via /docker-entrypoint-initdb.d; `docker compose down -v` resets the
--- volume so it runs again.
-CREATE DATABASE gombit_bench_gombit;

--- a/benchmarks/compose/initdb/10-gombit-bench-gombit.sql
+++ b/benchmarks/compose/initdb/10-gombit-bench-gombit.sql
@@ -1,0 +1,9 @@
+-- Create the second benchmark database the gombit app uses.
+--
+-- gin-gorm uses gombit_bench (the postgres service's POSTGRES_DB). The gombit
+-- app's users/projects tables come from a real Atlas migration, not
+-- AutoMigrate, so it must not share a database with gin-gorm (see
+-- benchmarks/apps/gombit/README.md). This runs once, on a fresh Postgres data
+-- volume, via /docker-entrypoint-initdb.d; `docker compose down -v` resets the
+-- volume so it runs again.
+CREATE DATABASE gombit_bench_gombit;

--- a/benchmarks/config/versions.env
+++ b/benchmarks/config/versions.env
@@ -14,6 +14,12 @@ K6_VERSION=0.55.0
 # the pin can't drift between the two files.
 POSTGRES_IMAGE=postgres:16.4-alpine
 
+# Atlas CLI image — the `gombit` app container applies its Atlas migrations
+# (`gombit db migrate` execs `atlas migrate apply`) so it needs the binary;
+# pinned by tag and copied into the image via a multi-stage build. Matches the
+# ariga.io/atlas SDK line in go.mod (v0.36.x).
+ATLAS_IMAGE=arigaio/atlas:0.36.0
+
 # Resource limits (issue #141 §7 "Target initial default"). PostgreSQL:
 # 2 vCPU / 2 GiB. Each application container: 2 vCPU / 1 GiB — the issue's
 # app budget is 1 GiB, not Postgres's 2 GiB (an earlier draft copied the

--- a/benchmarks/config/versions.env
+++ b/benchmarks/config/versions.env
@@ -16,9 +16,12 @@ POSTGRES_IMAGE=postgres:16.4-alpine
 
 # Atlas CLI image — the `gombit` app container applies its Atlas migrations
 # (`gombit db migrate` execs `atlas migrate apply`) so it needs the binary;
-# pinned by tag and copied into the image via a multi-stage build. Matches the
-# ariga.io/atlas SDK line in go.mod (v0.36.x).
-ATLAS_IMAGE=arigaio/atlas:0.36.0
+# pinned by tag and copied into the image via a multi-stage build. The *-alpine*
+# tag is deliberate: its /atlas is the musl-compatible (statically linked) build
+# that runs on the alpine runtime base — the default debian-distroless tag can
+# ship a glibc binary that fails there. Matches the ariga.io/atlas SDK line in
+# go.mod (v0.36.x).
+ATLAS_IMAGE=arigaio/atlas:0.36.0-alpine
 
 # Resource limits (issue #141 §7 "Target initial default"). PostgreSQL:
 # 2 vCPU / 2 GiB. Each application container: 2 vCPU / 1 GiB — the issue's

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1367,15 +1367,17 @@ in:
   app.
 - `benchmarks/apps/gombit/Dockerfile` + `docker-entrypoint.sh` (second Go app,
   same pattern) — but it applies **real Atlas migrations**, so the image also
-  carries the `gombit` CLI and the pinned `atlas` binary (`ATLAS_IMAGE` in
-  `versions.env`, multi-stage COPY), the entrypoint has three verbs
-  (`migrate`/`seed`/`serve`), and it uses its own `gombit_bench_gombit` database
-  created by a Postgres init script (`benchmarks/compose/initdb/`, fresh-volume).
-  Verified end to end against a live container: init script creates the second
-  DB, `gombit db migrate` applies the Atlas migration in-container, seed
-  completes, the service reaches `healthy` via `/livez`, `GET /api/projects`
-  returns the canonical envelope (`total: 100000`), and inspect-limits reads
-  `enforced` (2 vCPU / 1 GiB). The four ecosystem apps are the next slices.
+  carries the `gombit` CLI, the pinned `atlas` binary (`ATLAS_IMAGE` in
+  `versions.env`, the *-alpine* variant so the musl binary matches the runtime
+  base, multi-stage COPY), and a psql client. The entrypoint has three verbs
+  (`migrate`/`seed`/`serve`; `serve` does not migrate); `migrate` **creates the
+  `gombit_bench_gombit` database if absent** (idempotent, every bring-up) then
+  applies the migration. Verified end to end against a live container:
+  `gombit db migrate` creates the DB and applies the Atlas migration
+  in-container, seed completes, the service reaches `healthy` via `/livez`,
+  `GET /api/projects` returns the canonical envelope (`total: 100000`), and
+  inspect-limits reads `enforced` (2 vCPU / 1 GiB). The four ecosystem apps are
+  the next slices.
 - `benchmarks/internal/reslimits` + `benchmarks/scripts/inspect-limits`: the
   issue's "detect and report rather than silently pretend limits were applied"
   requirement. A compose budget is only an *intention*; the tool reads the

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1363,8 +1363,19 @@ in:
   `.dockerignore` keeps node_modules/vendor/.git out of the context) +
   `docker-entrypoint.sh` with `seed`/`serve` verbs, and a `gin-gorm` service in
   `benchmarks/compose.yml` carrying the §7 app budget (2 vCPU / 1 GiB) and a
-  health check. gin-gorm is the reference app; the other five are the next
-  slices.
+  `/livez` health check (never the measured route). gin-gorm is the reference
+  app.
+- `benchmarks/apps/gombit/Dockerfile` + `docker-entrypoint.sh` (second Go app,
+  same pattern) — but it applies **real Atlas migrations**, so the image also
+  carries the `gombit` CLI and the pinned `atlas` binary (`ATLAS_IMAGE` in
+  `versions.env`, multi-stage COPY), the entrypoint has three verbs
+  (`migrate`/`seed`/`serve`), and it uses its own `gombit_bench_gombit` database
+  created by a Postgres init script (`benchmarks/compose/initdb/`, fresh-volume).
+  Verified end to end against a live container: init script creates the second
+  DB, `gombit db migrate` applies the Atlas migration in-container, seed
+  completes, the service reaches `healthy` via `/livez`, `GET /api/projects`
+  returns the canonical envelope (`total: 100000`), and inspect-limits reads
+  `enforced` (2 vCPU / 1 GiB). The four ecosystem apps are the next slices.
 - `benchmarks/internal/reslimits` + `benchmarks/scripts/inspect-limits`: the
   issue's "detect and report rather than silently pretend limits were applied"
   requirement. A compose budget is only an *intention*; the tool reads the


### PR DESCRIPTION
## Summary

Second Phase 6 compose-loop service (issue #141): containerize the **gombit**
app on the same pattern as `gin-gorm`. Unlike gin-gorm (AutoMigrate), it applies
**real Atlas versioned migrations**, so the container carries more.

- **`benchmarks/apps/gombit/Dockerfile`** — multi-stage, built from the repo
  root; builds the app binary **and** the `gombit` CLI, and copies the pinned
  `atlas` binary via a multi-stage `COPY --from=${ATLAS_IMAGE}`
  (`arigaio/atlas:0.36.0`, added to `versions.env`, matching the SDK line in
  `go.mod`). Ships `database/migrations` under `WORKDIR /app`. Three-verb
  entrypoint (`migrate`/`seed`/`serve`); `migrate` maps `DATABASE_URL` onto the
  CLI's `GOMBIT_DATABASE_DSN` so one variable configures all three.
- **Second database** — gombit uses `gombit_bench_gombit` (its tables come from
  a real migration, so it must not share gin-gorm's `gombit_bench`), created by
  a Postgres init script (`benchmarks/compose/initdb/`, runs on a fresh volume).
- **`compose.yml`** — `gombit` service on `:8080` with the §7 app budget
  (2 vCPU / 1 GiB) and a `/livez` health check (never the measured route,
  per the last review); `postgres` mounts the init script.

Closes #141 — partial (one Phase 6 slice; the issue stays open).

## Acceptance criteria

Toward the Phase 6 AC and the §7 budget. This PR:

- [x] Second Go app (`gombit`) containerized with its Atlas migrate step and the
      §7 budget wired into `compose.yml`, verified enforced on the live
      container.
- [ ] Four ecosystem apps (django/rails/laravel/nestjs) containerized — next slices.
- [ ] The six-app bring-up/`run-crud` loop + footprint capture — later Phase 6.

## Scope notes

Deferred: Dockerfiles + compose services for the four ecosystem apps, the loop
that brings all six up and runs `run-crud` over each, and per-app RSS/CPU
footprint capture. `atlas` is pinned by tag (consistent with the k6/postgres
tag pins); the image prints a self-upgrade/deprecation notice but applies the
migration correctly.

## Validation

- [x] `go build ./...`
- [x] `docker compose ... config` valid
- [x] End to end against a live container: fresh Postgres init script creates
      `gombit_bench_gombit`; `run --rm gombit migrate` applies the Atlas
      migration in-container ("Applied 1 migration(s)"); `run --rm gombit seed`
      → "seed complete"; the served container reaches `healthy` via `/livez` in
      ~3s; `GET /api/projects?page=1&limit=1` returns the canonical D10 envelope
      (`total: 100000`); `inspect-limits` reads `enforced: cpu 2.00 / memory 1 GiB`.
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB matrix — N/A: no Go/schema changes; the app
      and its migration are already tested (`benchmarks/apps/gombit`), this adds
      containerization verified live end to end.
- [x] Stable features ship docs and appear in an example app — gombit README
      compose section, `benchmarks/README` tree + note, plan Phase 6 note.
- [x] Extraction preserves contracts — N/A: new tooling, no template extraction.
- [ ] Generators — N/A.
- [ ] API changes regenerate OpenAPI + TS client — N/A: no API changes.
- [x] No secrets in generated frontend source — N/A: no frontend changes.
- [x] Scope stays inside this issue's milestone — M6/BENCH-1; no battery creep.
- [x] Links its issue and states which acceptance criteria it satisfies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
