### PR TITLE
feat: BENCH-1 containerize the django app (gunicorn, idempotent DB, /livez)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,7 +7,7 @@ Full plan: [docs/plans/BENCH-1-benchmark-suite.md](../docs/plans/BENCH-1-benchma
 
 ```text
 benchmarks/
-├── compose.yml          PostgreSQL + the two Go app services (gin-gorm, gombit; §7 limits); ecosystem apps land next
+├── compose.yml          PostgreSQL + app services (gin-gorm, gombit, django; §7 limits); rails/laravel/nestjs land next
 ├── config/
 │   └── versions.env     pinned load generator (k6), Postgres image, resource limits, workload defaults
 ├── docs/
@@ -46,15 +46,17 @@ benchmarks/
 All six canonical CRUD implementations exist, the result schema / metadata
 collector / run-config pins are in place, and the headline CRUD-read workload
 runs end to end against one implementation (`make benchmark-crud`). The Phase 6
-compose loop has started: both Go apps (`gin-gorm` and `gombit`) are
-containerized with `compose.yml` services carrying the §7 resource budget —
-`gombit` also applies its real Atlas migrations in-container (pinned `atlas`
-image) — and `internal/reslimits` + `scripts/inspect-limits` verify the ceiling
-actually landed on the live container (issue #141's "detect/report rather than
-silently pretend"). Still scoped to later phases: `docs/methodology.md`,
-containerizing the four ecosystem apps and the loop that brings all six up and
-runs `run-crud` over each, per-app resource/RSS capture (Phase 6 footprint), the
-other `make benchmark-*`
+compose loop has started: the two Go apps (`gin-gorm`, `gombit`) and the
+`django` ecosystem app are containerized with `compose.yml` services carrying
+the §7 resource budget — `gombit` also applies its real Atlas migrations
+in-container (pinned `atlas` image), and the migration-bearing apps create their
+own database idempotently on every bring-up — and `internal/reslimits` +
+`scripts/inspect-limits` verify the ceiling actually landed on the live
+container (issue #141's "detect/report rather than silently pretend"). Still
+scoped to later phases: `docs/methodology.md`, containerizing the remaining
+three ecosystem apps (rails/laravel/nestjs) and the loop that brings all six up
+and runs `run-crud` over each, per-app resource/RSS capture (Phase 6 footprint),
+the other `make benchmark-*`
 workloads, and extending `fairness_test.go` to all six.
 
 ## Resource limits (§7): intention vs. reality

--- a/benchmarks/apps/django/.dockerignore
+++ b/benchmarks/apps/django/.dockerignore
@@ -1,0 +1,6 @@
+# Build context is this directory; keep local dev cruft out of the image.
+.venv
+**/__pycache__
+*.pyc
+.pytest_cache
+db.sqlite3

--- a/benchmarks/apps/django/Dockerfile
+++ b/benchmarks/apps/django/Dockerfile
@@ -1,0 +1,27 @@
+# Container image for the django benchmark app.
+#
+# The app is self-contained (no Go module), so the build context is THIS
+# directory, not the repo root:
+#
+#   docker build -t bench-django:local benchmarks/apps/django
+#
+# benchmarks/compose.yml builds it with `context: apps/django`. Migrations are
+# applied as a separate step (like a deployed Django app); `serve` runs gunicorn
+# (WSGI, issue #141 §17), never `manage.py runserver`.
+FROM python:3.12-slim
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+WORKDIR /app
+# Install deps first so app-source edits don't re-run pip.
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+COPY . ./
+RUN useradd -u 10001 -m app
+USER app
+EXPOSE 8082
+# Verbs: migrate (ensure the database + apply migrations), seed, serve
+# (gunicorn, default). serve does NOT migrate — run migrate first.
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["serve"]

--- a/benchmarks/apps/django/README.md
+++ b/benchmarks/apps/django/README.md
@@ -189,13 +189,41 @@ wrapping transaction with the views doing nothing but a plain
 `Project.objects.create()`/`.save()` — the same shape as `gin-gorm`'s own
 handlers.
 
+### Under compose (containerized, with the §7 resource budget)
+
+The app is containerized (`Dockerfile`; self-contained, so the build context is
+this directory) and wired into `benchmarks/compose.yml` with the §7 app ceiling
+(2 vCPU / 1 GiB). The entrypoint has three verbs — `migrate`, `seed`, `serve`
+(gunicorn, never runserver). `serve` does **not** migrate, so run them in order.
+`migrate` creates the `gombit_bench_django` database if absent (idempotent,
+every bring-up, via `ensure_db.py` — not a fresh-volume init script):
+
+```sh
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml up -d postgres
+
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml run --rm django migrate
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml run --rm django seed
+
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml up -d django
+go run ./benchmarks/scripts/inspect-limits \
+  -container "$(docker compose -f benchmarks/compose.yml ps -q django)" \
+  -cpus 2 -memory 1g
+```
+
+`GUNICORN_WORKERS` (default 4) is passed to both `--workers` and the pool-split
+math in `settings.py`, so they stay in sync.
+
 ## Status
 
 Schema, seed, CRUD app, its own test suite, and CI (a Python 3.12 +
 `manage.py test` step in `.github/workflows/ci.yml`'s `database-postgres`
 job) are done (tracked in
 [docs/plans/BENCH-1-benchmark-suite.md](../../../docs/plans/BENCH-1-benchmark-suite.md)
-Phase 4). Still open: a `Dockerfile`/`benchmarks/compose.yml` service (the Go
-apps don't have one yet either — deferred to Phase 8's CI work), and
-extending the Go `benchmarks/apps/fairness_test.go` cross-implementation
-check to include this app as a third leg.
+Phase 4). This app now has a `Dockerfile` + `benchmarks/compose.yml` `django`
+service with the §7 budget (see [Under compose](#under-compose-containerized-with-the-7-resource-budget)).
+Still open: extending the Go `benchmarks/apps/fairness_test.go`
+cross-implementation check to include this app as a third leg.

--- a/benchmarks/apps/django/docker-entrypoint.sh
+++ b/benchmarks/apps/django/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# django container entrypoint. Three verbs so the compose loop drives migrate /
+# seed / serve explicitly (benchmarks/apps/django/README.md):
+#
+#   migrate  ensure the target database exists, apply Django migrations, exit
+#   seed     run the deterministic seed (truncate + insert) and exit
+#   serve    run gunicorn (WSGI, issue #141 §17) — does NOT migrate
+#
+# gunicorn is started with GUNICORN_WORKERS workers, the same value config/
+# settings.py divides POOL_MAX_OPEN by, so the per-worker pool math stays honest
+# (the two must match — see the app README's pooling note).
+set -eu
+
+case "${1:-serve}" in
+  migrate)
+    # ensure_db.py creates the target database if absent (idempotent, every
+    # bring-up), so provisioning does not depend on a fresh Postgres volume.
+    python ensure_db.py
+    exec python manage.py migrate
+    ;;
+  seed)
+    exec python manage.py seed
+    ;;
+  serve)
+    exec gunicorn config.wsgi:application \
+      --bind "0.0.0.0:${PORT:-8082}" \
+      --workers "${GUNICORN_WORKERS:-4}"
+    ;;
+  *)
+    echo "entrypoint: unknown command '$1' (want: migrate | seed | serve)" >&2
+    exit 2
+    ;;
+esac

--- a/benchmarks/apps/django/ensure_db.py
+++ b/benchmarks/apps/django/ensure_db.py
@@ -1,0 +1,41 @@
+"""Create the app's target database if it does not already exist.
+
+Django's ``manage.py migrate`` creates tables, not the database, and this app
+uses its own ``gombit_bench_django`` database (it must not share another app's
+schema). Provisioning it via docker-entrypoint-initdb.d would only run on a
+fresh Postgres volume — this suite's volume already exists — so instead the
+``migrate`` verb calls this on every bring-up: a guarded catalog check plus
+``CREATE DATABASE`` (which has no IF NOT EXISTS), idempotent and never
+requiring ``down -v``.
+
+ADMIN_DATABASE_URL is an existing database on the same server (the maintenance
+connection); TARGET_DB is the database to ensure. If either is unset (a
+hand-provisioned local DB), this is a no-op.
+"""
+
+import os
+import sys
+
+import psycopg
+from psycopg import sql
+
+
+def main() -> None:
+    admin = os.environ.get("ADMIN_DATABASE_URL")
+    target = os.environ.get("TARGET_DB")
+    if not admin or not target:
+        return
+
+    # autocommit: CREATE DATABASE cannot run inside a transaction block.
+    with psycopg.connect(admin, autocommit=True) as conn:
+        exists = conn.execute(
+            "SELECT 1 FROM pg_database WHERE datname = %s", (target,)
+        ).fetchone()
+        if exists:
+            return
+        print(f"ensure_db: creating database {target}", file=sys.stderr)
+        conn.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(target)))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/compose.yml
+++ b/benchmarks/compose.yml
@@ -1,7 +1,7 @@
 # PostgreSQL + the benchmark app services under test. App services are added
 # as each is containerized (Phase 6 compose loop): the two Go apps `gin-gorm`
-# (the reference control) and `gombit` (same API on the Gombit runtime) are in;
-# the four ecosystem apps are the next slices.
+# (the reference control) and `gombit` (same API on the Gombit runtime) plus the
+# `django` ecosystem app are in; rails / laravel / nestjs are the next slices.
 #
 # Version pin: issue #141 requires major.minor (or digest), not a
 # major-only floating tag. The pin lives once in
@@ -140,6 +140,47 @@ services:
     # same rule as gin-gorm: never probe the measured route.
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null 'http://127.0.0.1:8080/livez' || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+    deploy:
+      resources:
+        limits:
+          cpus: "${APP_CPUS:-2}"
+          memory: ${APP_MEMORY:-1g}
+
+  # The django app (issue #141 §7 app budget: 2 vCPU / 1 GiB) — Python/DRF
+  # ecosystem context, not a framework-tax control. Self-contained, so the build
+  # context is the app dir. Same three-verb bring-up as gombit; `migrate` ensures
+  # its own gombit_bench_django database. gunicorn (WSGI, §17) with
+  # GUNICORN_WORKERS workers, the value settings.py divides POOL_MAX_OPEN by:
+  #
+  #   docker compose ... up -d postgres
+  #   docker compose ... run --rm django migrate
+  #   docker compose ... run --rm django seed
+  #   docker compose ... up -d django
+  django:
+    build:
+      context: apps/django
+    image: bench-django:local
+    command: ["serve"]
+    environment:
+      DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench_django?sslmode=disable
+      ADMIN_DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench?sslmode=disable
+      TARGET_DB: gombit_bench_django
+      PORT: "8082"
+      GUNICORN_WORKERS: "4"
+      POOL_MAX_OPEN: "${POOL_MAX_OPEN:-20}"
+      DJANGO_ALLOWED_HOSTS: "127.0.0.1,localhost"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:8082:8082"
+    # /livez returns 200 with no DB touch (config/urls.py) — never the measured
+    # route. The slim image has no wget/curl, so probe with python's urllib.
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request as u,sys; sys.exit(0 if u.urlopen('http://127.0.0.1:8082/livez').status==200 else 1)\""]
       interval: 3s
       timeout: 3s
       retries: 20

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1376,8 +1376,19 @@ in:
   `gombit db migrate` creates the DB and applies the Atlas migration
   in-container, seed completes, the service reaches `healthy` via `/livez`,
   `GET /api/projects` returns the canonical envelope (`total: 100000`), and
-  inspect-limits reads `enforced` (2 vCPU / 1 GiB). The four ecosystem apps are
-  the next slices.
+  inspect-limits reads `enforced` (2 vCPU / 1 GiB).
+- `benchmarks/apps/django/Dockerfile` + `docker-entrypoint.sh` + `ensure_db.py`
+  (first ecosystem app). Self-contained, so the build context is the app dir
+  (`python:3.12-slim`, no repo-root context). Three verbs
+  (`migrate`/`seed`/`serve`); `serve` is gunicorn (WSGI, §17) with
+  `GUNICORN_WORKERS` workers — the same value `settings.py` divides
+  `POOL_MAX_OPEN` by, kept in sync by the entrypoint. `migrate` creates
+  `gombit_bench_django` idempotently via `ensure_db.py` (psycopg, guarded
+  `CREATE DATABASE`, every bring-up — the #187 provisioning lesson, reused).
+  Verified end to end against a live container on an existing volume: migrate
+  creates the DB and applies migrations (a second migrate is a no-op), seed
+  completes, `healthy` via `/livez`, canonical envelope (`total: 100000`),
+  inspect-limits `enforced`. rails / laravel / nestjs are the next slices.
 - `benchmarks/internal/reslimits` + `benchmarks/scripts/inspect-limits`: the
   issue's "detect and report rather than silently pretend limits were applied"
   requirement. A compose budget is only an *intention*; the tool reads the


### PR DESCRIPTION
## Summary

First ecosystem-app compose service (issue #141 Phase 6): the **Django + DRF**
app, on the same three-verb pattern as the Go apps.

- **`benchmarks/apps/django/Dockerfile`** — the app is self-contained (no Go
  module), so the build context is the app dir (`python:3.12-slim`). Installs the
  pinned `requirements.txt`; runs non-root.
- **`docker-entrypoint.sh`** — `migrate` / `seed` / `serve`. `serve` is gunicorn
  (WSGI, §17, never `runserver`) with `GUNICORN_WORKERS` workers — the same value
  `settings.py` divides `POOL_MAX_OPEN` by, so the per-worker pool math stays
  honest (20 ÷ 4 = 5/worker, 20 total).
- **`ensure_db.py`** — creates `gombit_bench_django` if absent (psycopg, guarded
  `CREATE DATABASE`, autocommit) on every `migrate`. This reuses the #187
  idempotent-provisioning lesson: no `docker-entrypoint-initdb.d`, no fresh-volume
  or `down -v` dependency.
- **`compose.yml`** — `django` service on `:8082` with the §7 budget and a
  `/livez` health check (python `urllib`, since the slim image has no wget/curl),
  never the measured route.

Closes #141 — partial (one Phase 6 slice; the issue stays open).

## Acceptance criteria

- [x] First ecosystem app (`django`) containerized with its migrate step and the
      §7 budget, verified enforced on the live container.
- [ ] rails / laravel / nestjs containerized — next slices.
- [ ] The six-app bring-up/`run-crud` loop + footprint capture — later Phase 6.

## Scope notes

Deferred: Dockerfiles + compose services for rails/laravel/nestjs, the six-app
`run-crud` loop, and per-app RSS/CPU footprint capture. `ensure_db.py` uses
psycopg (already a dependency) rather than adding a `psql` client to the image.

## Validation

- [x] `go build ./...` (no Go changed; sanity)
- [x] `docker compose ... config` valid
- [x] End to end against a live container on an **existing** volume: `run --rm
      django migrate` creates `gombit_bench_django` and applies migrations
      ("ensure_db: creating database gombit_bench_django"); a second migrate is a
      no-op (exit 0); `run --rm django seed` → "seed complete"; the served
      container reaches `healthy` via `/livez` in ~3s; `GET /api/projects`
      returns the canonical D10 envelope (`total: 100000`); `inspect-limits`
      reads `enforced: cpu 2.00 / memory 1 GiB`.
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB matrix — N/A: no Go/schema changes; the app and
      its migration/seed are already tested (`manage.py test` in CI); this adds
      containerization verified live end to end.
- [x] Stable features ship docs and appear in an example app — django README
      compose section + Status, `benchmarks/README` tree + note, plan Phase 6 note.
- [x] Extraction preserves contracts — N/A: new tooling, no template extraction.
- [ ] Generators — N/A.
- [ ] API changes regenerate OpenAPI + TS client — N/A: no API changes.
- [x] No secrets in generated frontend source — N/A: no frontend changes.
- [x] Scope stays inside this issue's milestone — M6/BENCH-1; no battery creep.
- [x] Links its issue and states which acceptance criteria it satisfies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
