### PR TITLE
feat: BENCH-1 containerize the rails app (Puma clustered, idempotent DB, /livez)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,7 +7,7 @@ Full plan: [docs/plans/BENCH-1-benchmark-suite.md](../docs/plans/BENCH-1-benchma
 
 ```text
 benchmarks/
-├── compose.yml          PostgreSQL + app services (gin-gorm, gombit, django; §7 limits); rails/laravel/nestjs land next
+├── compose.yml          PostgreSQL + app services (gin-gorm, gombit, django, rails; §7 limits); laravel/nestjs land next
 ├── config/
 │   └── versions.env     pinned load generator (k6), Postgres image, resource limits, workload defaults
 ├── docs/
@@ -47,16 +47,17 @@ All six canonical CRUD implementations exist, the result schema / metadata
 collector / run-config pins are in place, and the headline CRUD-read workload
 runs end to end against one implementation (`make benchmark-crud`). The Phase 6
 compose loop has started: the two Go apps (`gin-gorm`, `gombit`) and the
-`django` ecosystem app are containerized with `compose.yml` services carrying
-the §7 resource budget — `gombit` also applies its real Atlas migrations
-in-container (pinned `atlas` image), and the migration-bearing apps create their
-own database idempotently on every bring-up — and `internal/reslimits` +
-`scripts/inspect-limits` verify the ceiling actually landed on the live
-container (issue #141's "detect/report rather than silently pretend"). Still
-scoped to later phases: `docs/methodology.md`, containerizing the remaining
-three ecosystem apps (rails/laravel/nestjs) and the loop that brings all six up
-and runs `run-crud` over each, per-app resource/RSS capture (Phase 6 footprint),
-the other `make benchmark-*`
+`django` and `rails` ecosystem apps are containerized with `compose.yml`
+services carrying the §7 resource budget — `gombit` also applies its real Atlas
+migrations in-container (pinned `atlas` image), and every migration-bearing app
+creates its own database idempotently on every bring-up (no fresh-volume init
+scripts) — and `internal/reslimits` + `scripts/inspect-limits` verify the
+ceiling actually landed on the live container (issue #141's "detect/report
+rather than silently pretend"). Still scoped to later phases:
+`docs/methodology.md`, containerizing the remaining two ecosystem apps
+(laravel/nestjs) and the loop that brings all six up and runs `run-crud` over
+each, per-app resource/RSS capture (Phase 6 footprint), the other
+`make benchmark-*`
 workloads, and extending `fairness_test.go` to all six.
 
 ## Resource limits (§7): intention vs. reality

--- a/benchmarks/apps/rails/.dockerignore
+++ b/benchmarks/apps/rails/.dockerignore
@@ -1,0 +1,9 @@
+# Build context is this directory; keep local dev/runtime cruft out of the image
+# (tmp/ and log/ are recreated at runtime; .bundle/vendor would shadow the
+# image's gems).
+.git
+tmp
+log
+.bundle
+vendor/bundle
+*.log

--- a/benchmarks/apps/rails/Dockerfile
+++ b/benchmarks/apps/rails/Dockerfile
@@ -1,0 +1,44 @@
+# Container image for the rails benchmark app.
+#
+# Self-contained (no Go module), so the build context is THIS directory:
+#
+#   docker build -t bench-rails:local benchmarks/apps/rails
+#
+# benchmarks/compose.yml builds it with `context: apps/rails`. Migrations are
+# applied as a separate step; `serve` runs Puma in RAILS_ENV=production
+# (clustered, per config/puma.rb), never `bin/rails server` in development mode.
+FROM ruby:3.3.12-slim AS build
+ENV BUNDLE_WITHOUT="development:test" \
+    BUNDLE_FROZEN="1" \
+    BUNDLE_JOBS="4"
+# Build deps for native gems (pg needs libpq-dev + a compiler).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential libpq-dev git pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+COPY . ./
+
+FROM ruby:3.3.12-slim
+ENV BUNDLE_WITHOUT="development:test" \
+    BUNDLE_FROZEN="1" \
+    RAILS_ENV="production"
+# libpq5 is the pg gem's runtime dependency.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libpq5 && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -u 10001 -m app
+WORKDIR /app
+COPY --from=build /usr/local/bundle /usr/local/bundle
+COPY --from=build --chown=app:app /app /app
+# tmp/ and log/ are excluded from the build context (dev cruft); Puma/Rails
+# create files under them at boot, so make them and hand /app to the app user
+# (WORKDIR created the /app dir itself as root).
+RUN mkdir -p tmp/pids log && chown -R app:app /app
+USER app
+EXPOSE 8083
+# Verbs: migrate (create the database if needed + migrate), seed, serve
+# (Puma, default). serve does NOT migrate — run migrate first.
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["serve"]

--- a/benchmarks/apps/rails/README.md
+++ b/benchmarks/apps/rails/README.md
@@ -248,13 +248,42 @@ found several:
   `test_rejects_null_description_on_{create,update}`, which fail on the
   pre-fix commit (create 201, update 500).
 
+### Under compose (containerized, with the §7 resource budget)
+
+The app is containerized (`Dockerfile`; self-contained, so the build context is
+this directory) and wired into `benchmarks/compose.yml` with the §7 app ceiling
+(2 vCPU / 1 GiB). The entrypoint has three verbs — `migrate`, `seed`, `serve`
+(Puma clustered in `RAILS_ENV=production`, never dev mode). `serve` does **not**
+migrate, so run them in order. `migrate` runs `db:create` (idempotent) so it
+provisions `gombit_bench_rails` on every bring-up; `SECRET_KEY_BASE` is generated
+per boot by the entrypoint (no committed secret):
+
+```sh
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml up -d postgres
+
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml run --rm rails migrate
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml run --rm rails seed
+
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml up -d rails
+go run ./benchmarks/scripts/inspect-limits \
+  -container "$(docker compose -f benchmarks/compose.yml ps -q rails)" \
+  -cpus 2 -memory 1g
+```
+
+`WEB_CONCURRENCY` (2) and `RAILS_MAX_THREADS` (3) drive Puma; the pool is
+`POOL_MAX_OPEN / WEB_CONCURRENCY` per worker (`config/database.yml`).
+
 ## Status
 
 Schema, seed, CRUD app, its own test suite, and CI (a Ruby 3.3.12 +
 `bin/rails test` step in `.github/workflows/ci.yml`'s `database-postgres`
 job) are done (tracked in
 [docs/plans/BENCH-1-benchmark-suite.md](../../../docs/plans/BENCH-1-benchmark-suite.md)
-Phase 4). Still open, matching the Phase 3a/3b/4a precedent: a
-`Dockerfile`/`benchmarks/compose.yml` service, and extending the Go
-`benchmarks/apps/fairness_test.go` cross-implementation check to include
-this app as a fourth leg.
+Phase 4). This app now has a `Dockerfile` + `benchmarks/compose.yml` `rails`
+service with the §7 budget (see [Under compose](#under-compose-containerized-with-the-7-resource-budget)).
+Still open: extending the Go `benchmarks/apps/fairness_test.go`
+cross-implementation check to include this app as a fourth leg.

--- a/benchmarks/apps/rails/docker-entrypoint.sh
+++ b/benchmarks/apps/rails/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# rails container entrypoint. Three verbs so the compose loop drives migrate /
+# seed / serve explicitly (benchmarks/apps/rails/README.md):
+#
+#   migrate  create the database if absent, apply migrations, exit
+#   seed     run the deterministic seed (truncate + insert) and exit
+#   serve    run Puma in production (clustered, config/puma.rb) — does NOT migrate
+#
+# All verbs boot Rails in production, which refuses to start without
+# SECRET_KEY_BASE. This app commits no throwaway secret (unlike ../django's
+# placeholder), so one is generated per boot — a benchmark keeps no sessions
+# across restarts, so an ephemeral key is fine and nothing insecure is shipped.
+set -eu
+
+export RAILS_ENV=production
+: "${SECRET_KEY_BASE:=$(ruby -rsecurerandom -e 'print SecureRandom.hex(64)')}"
+export SECRET_KEY_BASE
+
+case "${1:-serve}" in
+  migrate)
+    # db:create is idempotent (prints "already exists" and exits 0), so this
+    # provisions the database on every bring-up without a fresh-volume init
+    # script or `down -v` — Rails creates it via the DATABASE_URL credentials.
+    exec bin/rails db:create db:migrate
+    ;;
+  seed)
+    exec bin/rails db:seed
+    ;;
+  serve)
+    exec bin/rails server -b 0.0.0.0 -p "${PORT:-8083}"
+    ;;
+  *)
+    echo "entrypoint: unknown command '$1' (want: migrate | seed | serve)" >&2
+    exit 2
+    ;;
+esac

--- a/benchmarks/compose.yml
+++ b/benchmarks/compose.yml
@@ -1,7 +1,7 @@
 # PostgreSQL + the benchmark app services under test. App services are added
 # as each is containerized (Phase 6 compose loop): the two Go apps `gin-gorm`
 # (the reference control) and `gombit` (same API on the Gombit runtime) plus the
-# `django` ecosystem app are in; rails / laravel / nestjs are the next slices.
+# `django` and `rails` ecosystem apps are in; laravel / nestjs are the next slices.
 #
 # Version pin: issue #141 requires major.minor (or digest), not a
 # major-only floating tag. The pin lives once in
@@ -181,6 +181,48 @@ services:
     # route. The slim image has no wget/curl, so probe with python's urllib.
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request as u,sys; sys.exit(0 if u.urlopen('http://127.0.0.1:8082/livez').status==200 else 1)\""]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+    deploy:
+      resources:
+        limits:
+          cpus: "${APP_CPUS:-2}"
+          memory: ${APP_MEMORY:-1g}
+
+  # The rails app (issue #141 §7 app budget: 2 vCPU / 1 GiB) — Ruby/ActiveRecord
+  # ecosystem context. Self-contained build context. Puma clustered in
+  # production (WEB_CONCURRENCY workers x RAILS_MAX_THREADS threads, config/
+  # puma.rb), pool split across workers. `migrate` runs `db:create` (idempotent)
+  # so it provisions gombit_bench_rails on every bring-up; SECRET_KEY_BASE is
+  # generated per boot by the entrypoint (no committed secret):
+  #
+  #   docker compose ... up -d postgres
+  #   docker compose ... run --rm rails migrate
+  #   docker compose ... run --rm rails seed
+  #   docker compose ... up -d rails
+  rails:
+    build:
+      context: apps/rails
+    image: bench-rails:local
+    command: ["serve"]
+    environment:
+      DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench_rails?sslmode=disable
+      PORT: "8083"
+      WEB_CONCURRENCY: "2"
+      RAILS_MAX_THREADS: "3"
+      POOL_MAX_OPEN: "${POOL_MAX_OPEN:-20}"
+      RAILS_ALLOWED_HOSTS: "127.0.0.1,localhost"
+      RAILS_LOG_LEVEL: "warn"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:8083:8083"
+    # /livez -> Rails' built-in health controller (200, no DB) and silenced in
+    # logs — never the measured route. The slim image has ruby but no wget/curl.
+    healthcheck:
+      test: ["CMD-SHELL", "ruby -rnet/http -e \"exit(Net::HTTP.get_response(URI('http://127.0.0.1:8083/livez')).code == '200' ? 0 : 1)\""]
       interval: 3s
       timeout: 3s
       retries: 20

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1388,7 +1388,19 @@ in:
   Verified end to end against a live container on an existing volume: migrate
   creates the DB and applies migrations (a second migrate is a no-op), seed
   completes, `healthy` via `/livez`, canonical envelope (`total: 100000`),
-  inspect-limits `enforced`. rails / laravel / nestjs are the next slices.
+  inspect-limits `enforced`.
+- `benchmarks/apps/rails/Dockerfile` + `docker-entrypoint.sh` (Ruby/Rails
+  ecosystem app). Multi-stage `ruby:3.3.12-slim` (native `pg` gem compiled in
+  the build stage, `libpq5` at runtime); self-contained context. Three verbs;
+  `serve` is Puma clustered in `RAILS_ENV=production` (`WEB_CONCURRENCY` workers
+  × `RAILS_MAX_THREADS` threads, pool split per worker). `migrate` uses
+  `db:create` (idempotent) so it provisions `gombit_bench_rails` every bring-up;
+  `SECRET_KEY_BASE` is generated per boot (no committed secret). The runtime
+  stage creates `tmp/`/`log/` and chowns `/app` so the non-root user can boot
+  Puma. Verified end to end against a live container: db:create + migrate
+  (second run a no-op), seed, `healthy` via `/livez`, Puma comes up in cluster
+  mode with 2 workers on `0.0.0.0:8083`, canonical envelope, inspect-limits
+  `enforced`. laravel / nestjs are the next slices.
 - `benchmarks/internal/reslimits` + `benchmarks/scripts/inspect-limits`: the
   issue's "detect and report rather than silently pretend limits were applied"
   requirement. A compose budget is only an *intention*; the tool reads the


### PR DESCRIPTION
## Summary

Second ecosystem-app compose service (issue #141 Phase 6): the **Ruby on Rails +
ActiveRecord** app.

- **`benchmarks/apps/rails/Dockerfile`** — multi-stage `ruby:3.3.12-slim` (the
  native `pg` gem is compiled in the build stage, `libpq5` at runtime);
  self-contained build context. The runtime stage creates `tmp/` and `log/`
  (excluded from context) and chowns `/app` so the non-root user can boot Puma.
- **`docker-entrypoint.sh`** — `migrate` / `seed` / `serve`, all in
  `RAILS_ENV=production`. `serve` is Puma **clustered** (`config/puma.rb`:
  `WEB_CONCURRENCY` workers × `RAILS_MAX_THREADS` threads, pool split per worker).
  `migrate` uses `db:create` (idempotent) to provision `gombit_bench_rails` on
  every bring-up — no fresh-volume init script (the #187 lesson; Rails' own
  tooling makes it a one-liner here). `SECRET_KEY_BASE` is generated per boot —
  Rails refuses production without one, and this app deliberately commits no
  throwaway secret, so an ephemeral key is generated rather than baked in.
- **`compose.yml`** — `rails` service on `:8083` with the §7 budget and a
  `/livez` health check (ruby `net/http`, since the slim image has no wget/curl),
  never the measured route.

Closes #141 — partial (one Phase 6 slice; the issue stays open).

## Acceptance criteria

- [x] Rails ecosystem app containerized with its migrate step and the §7 budget,
      verified enforced on the live container.
- [ ] laravel / nestjs containerized — next slices.
- [ ] The six-app bring-up/`run-crud` loop + footprint capture — later Phase 6.

## Scope notes

Deferred: Dockerfiles + compose services for laravel/nestjs, the six-app
`run-crud` loop, and per-app RSS/CPU footprint capture. `db:create` replaces a
psql/`ensure_db` step because Rails provisions the database from `DATABASE_URL`
itself.

## Validation

- [x] `go build ./...` (no Go changed; sanity)
- [x] `docker compose ... config` valid
- [x] End to end against a live container: `run --rm rails migrate` →
      "Created database 'gombit_bench_rails'" + migrations; a second migrate is a
      no-op (exit 0); `run --rm rails seed` → "seed complete"; the served
      container reaches `healthy` via `/livez` in ~3s; the log shows Puma
      "cluster mode ... Workers: 2 ... Listening on http://0.0.0.0:8083"; `GET
      /api/projects` returns the canonical D10 envelope (`total: 100000`);
      `inspect-limits` reads `enforced: cpu 2.00 / memory 1 GiB`.
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB matrix — N/A: no Go/schema changes; the app and
      its migration/seed are already tested (`bin/rails test` in CI); this adds
      containerization verified live end to end.
- [x] Stable features ship docs and appear in an example app — rails README
      compose section + Status, `benchmarks/README` tree + note, plan Phase 6 note.
- [x] Extraction preserves contracts — N/A: new tooling, no template extraction.
- [ ] Generators — N/A.
- [ ] API changes regenerate OpenAPI + TS client — N/A: no API changes.
- [x] No secrets in generated frontend source — N/A: no frontend; SECRET_KEY_BASE
      is generated per boot, never committed.
- [x] Scope stays inside this issue's milestone — M6/BENCH-1; no battery creep.
- [x] Links its issue and states which acceptance criteria it satisfies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
