### PR TITLE
feat: BENCH-1 containerize the nestjs app — all six implementations now containerized

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,7 +7,7 @@ Full plan: [docs/plans/BENCH-1-benchmark-suite.md](../docs/plans/BENCH-1-benchma
 
 ```text
 benchmarks/
-├── compose.yml          PostgreSQL + app services (gin-gorm, gombit, django, rails, laravel; §7 limits); nestjs lands next
+├── compose.yml          PostgreSQL + all six app services (gin-gorm, gombit, django, rails, laravel, nestjs; §7 limits)
 ├── config/
 │   └── versions.env     pinned load generator (k6), Postgres image, resource limits, workload defaults
 ├── docs/
@@ -46,18 +46,17 @@ benchmarks/
 All six canonical CRUD implementations exist, the result schema / metadata
 collector / run-config pins are in place, and the headline CRUD-read workload
 runs end to end against one implementation (`make benchmark-crud`). The Phase 6
-compose loop has started: the two Go apps (`gin-gorm`, `gombit`) and the
-`django`, `rails`, and `laravel` ecosystem apps are containerized with
+compose loop is now well underway: **all six** implementations (`gin-gorm`,
+`gombit`, `django`, `rails`, `laravel`, `nestjs`) are containerized with
 `compose.yml` services carrying the §7 resource budget — `gombit` also applies
 its real Atlas migrations in-container (pinned `atlas` image), and every
 migration-bearing app creates its own database idempotently on every bring-up
 (no fresh-volume init scripts) — and `internal/reslimits` +
 `scripts/inspect-limits` verify the ceiling actually landed on the live
 container (issue #141's "detect/report rather than silently pretend"). Still
-scoped to later phases: `docs/methodology.md`, containerizing the last ecosystem
-app (`nestjs`) and the loop that brings all six up and runs `run-crud` over
-each, per-app resource/RSS capture (Phase 6 footprint), the other
-`make benchmark-*`
+scoped to later phases: `docs/methodology.md`, the loop that brings all six up
+and runs `run-crud` over each, per-app resource/RSS capture (Phase 6 footprint),
+the other `make benchmark-*`
 workloads, and extending `fairness_test.go` to all six.
 
 ## Resource limits (§7): intention vs. reality

--- a/benchmarks/apps/nestjs/.dockerignore
+++ b/benchmarks/apps/nestjs/.dockerignore
@@ -1,0 +1,6 @@
+# Build context is this directory; node_modules and dist are regenerated in the
+# image (npm ci + npm run build), so keep the local copies out of the context.
+.git
+node_modules
+dist
+*.log

--- a/benchmarks/apps/nestjs/Dockerfile
+++ b/benchmarks/apps/nestjs/Dockerfile
@@ -1,0 +1,24 @@
+# Container image for the nestjs benchmark app.
+#
+# Self-contained (no Go module), so the build context is THIS directory:
+#
+#   docker build -t bench-nestjs:local benchmarks/apps/nestjs
+#
+# benchmarks/compose.yml builds it with `context: apps/nestjs`. `serve` runs the
+# compiled output (`node dist/main`, issue #141 §17), never a ts-node/watch dev
+# server. migrate/seed use the committed npm scripts, which drive TypeORM via
+# ts-node — so devDependencies are kept in the image (NODE_ENV is set at run
+# time by compose, NOT here: setting it to production would make `npm ci` skip
+# the devDependencies those scripts need).
+FROM node:24-slim
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . ./
+RUN npm run build && chown -R node:node /app
+USER node
+EXPOSE 8085
+# Verbs: migrate (ensure the database + TypeORM migration:run), seed, serve
+# (node dist/main, default). serve does NOT migrate — run migrate first.
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["serve"]

--- a/benchmarks/apps/nestjs/README.md
+++ b/benchmarks/apps/nestjs/README.md
@@ -157,13 +157,41 @@ in CI):
   serializer converts them to numbers for the response (ids fit in a JS
   number).
 
+### Under compose (containerized, with the §7 resource budget)
+
+The app is containerized (`Dockerfile`; self-contained, so the build context is
+this directory) and wired into `benchmarks/compose.yml` with the §7 app ceiling
+(2 vCPU / 1 GiB). The entrypoint has three verbs — `migrate`, `seed`, `serve`.
+`serve` runs the compiled `node dist/main`; `migrate`/`seed` use the committed
+ts-node npm scripts, so the image keeps devDependencies (`NODE_ENV=production`
+is set only at run time). `serve` does **not** migrate, so run them in order.
+`migrate` creates the `gombit_bench_nestjs` database if absent (idempotent,
+every bring-up, via `ensure_db.js` using `pg` — not a fresh-volume init script):
+
+```sh
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml up -d postgres
+
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml run --rm nestjs migrate
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml run --rm nestjs seed
+
+docker compose --env-file benchmarks/config/versions.env \
+  -f benchmarks/compose.yml up -d nestjs
+go run ./benchmarks/scripts/inspect-limits \
+  -container "$(docker compose -f benchmarks/compose.yml ps -q nestjs)" \
+  -cpus 2 -memory 1g
+```
+
 ## Status
 
 Schema, seed, CRUD app, its own test suite, and CI (a Node 24 + `npm test`
 step in `.github/workflows/ci.yml`'s `database-postgres` job) are done
 (tracked in
 [docs/plans/BENCH-1-benchmark-suite.md](../../../docs/plans/BENCH-1-benchmark-suite.md)
-Phase 4). Still open, matching the Phase 3/4 precedent: a
-`benchmarks/compose.yml` app service, and extending the Go
-`benchmarks/apps/fairness_test.go` cross-implementation check to include this
-app.
+Phase 4). This app now has a `Dockerfile` + `benchmarks/compose.yml` `nestjs`
+service with the §7 budget (see [Under compose](#under-compose-containerized-with-the-7-resource-budget)),
+completing the containerization of all six implementations. Still open:
+extending the Go `benchmarks/apps/fairness_test.go` cross-implementation check
+to include this app.

--- a/benchmarks/apps/nestjs/docker-entrypoint.sh
+++ b/benchmarks/apps/nestjs/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# nestjs container entrypoint. Three verbs so the compose loop drives migrate /
+# seed / serve explicitly (benchmarks/apps/nestjs/README.md):
+#
+#   migrate  ensure the target database exists, run TypeORM migrations, exit
+#   seed     run the deterministic seed (truncate + insert) and exit
+#   serve    run the compiled app (node dist/main) — does NOT migrate
+#
+# migrate/seed use the committed npm scripts (ts-node-driven); serve runs the
+# compiled dist directly so node is the process, for clean signal handling.
+set -eu
+
+case "${1:-serve}" in
+  migrate)
+    # ensure_db.js creates the target database if absent (idempotent, every
+    # bring-up), so provisioning does not depend on a fresh Postgres volume.
+    node ensure_db.js
+    exec npm run migration:run
+    ;;
+  seed)
+    exec npm run seed
+    ;;
+  serve)
+    exec node dist/main
+    ;;
+  *)
+    echo "entrypoint: unknown command '$1' (want: migrate | seed | serve)" >&2
+    exit 2
+    ;;
+esac

--- a/benchmarks/apps/nestjs/ensure_db.js
+++ b/benchmarks/apps/nestjs/ensure_db.js
@@ -1,0 +1,44 @@
+// Create the app's target database if it does not already exist.
+//
+// TypeORM's migration:run creates tables, not the database, and this app uses
+// its own gombit_bench_nestjs database. Provisioning via
+// docker-entrypoint-initdb.d would only run on a fresh Postgres volume — this
+// suite's volume already exists — so the `migrate` verb calls this on every
+// bring-up: a guarded catalog check plus CREATE DATABASE (which has no
+// IF NOT EXISTS), idempotent and never requiring `down -v`.
+//
+// ADMIN_DATABASE_URL is an existing database on the same server (the
+// maintenance connection); TARGET_DB is the database to ensure. If either is
+// unset (a hand-provisioned local DB), this is a no-op. Uses pg — already the
+// app's database driver — rather than adding a psql client to the image.
+
+const { Client } = require('pg');
+
+async function main() {
+  const admin = process.env.ADMIN_DATABASE_URL;
+  const target = process.env.TARGET_DB;
+  if (!admin || !target) {
+    return;
+  }
+
+  const client = new Client({ connectionString: admin });
+  await client.connect();
+  try {
+    const { rowCount } = await client.query(
+      'SELECT 1 FROM pg_database WHERE datname = $1',
+      [target],
+    );
+    if (rowCount === 0) {
+      console.error(`ensure_db: creating database ${target}`);
+      // Guarded above; quote the identifier defensively.
+      await client.query(`CREATE DATABASE "${target.replace(/"/g, '""')}"`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/benchmarks/compose.yml
+++ b/benchmarks/compose.yml
@@ -1,7 +1,8 @@
 # PostgreSQL + the benchmark app services under test. App services are added
 # as each is containerized (Phase 6 compose loop): the two Go apps `gin-gorm`
-# (the reference control) and `gombit` (same API on the Gombit runtime) plus the
-# `django`, `rails`, and `laravel` ecosystem apps are in; nestjs is the last.
+# (the reference control) and `gombit` (same API on the Gombit runtime) plus all
+# four ecosystem apps (`django`, `rails`, `laravel`, `nestjs`) — all six are in.
+# Next is the loop that brings them up and runs run-crud over each.
 #
 # Version pin: issue #141 requires major.minor (or digest), not a
 # major-only floating tag. The pin lives once in
@@ -265,6 +266,47 @@ services:
     # php-fpm — never the measured route. The php image has php but no wget/curl.
     healthcheck:
       test: ["CMD-SHELL", "php -r \"exit(@file_get_contents('http://127.0.0.1:8084/livez') !== false ? 0 : 1);\""]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+    deploy:
+      resources:
+        limits:
+          cpus: "${APP_CPUS:-2}"
+          memory: ${APP_MEMORY:-1g}
+
+  # The nestjs app (issue #141 §7 app budget: 2 vCPU / 1 GiB) — Node/TypeORM
+  # ecosystem context. Self-contained build context. `serve` runs the compiled
+  # output (node dist/main); migrate/seed use the committed ts-node npm scripts,
+  # so the image keeps devDependencies (NODE_ENV=production is set here at run
+  # time, not at build, or npm ci would drop them). `migrate` ensures its own
+  # gombit_bench_nestjs database (ensure_db.js):
+  #
+  #   docker compose ... up -d postgres
+  #   docker compose ... run --rm nestjs migrate
+  #   docker compose ... run --rm nestjs seed
+  #   docker compose ... up -d nestjs
+  nestjs:
+    build:
+      context: apps/nestjs
+    image: bench-nestjs:local
+    command: ["serve"]
+    environment:
+      DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench_nestjs?sslmode=disable
+      ADMIN_DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench?sslmode=disable
+      TARGET_DB: gombit_bench_nestjs
+      NODE_ENV: production
+      PORT: "8085"
+      POOL_MAX_OPEN: "${POOL_MAX_OPEN:-20}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:8085:8085"
+    # /livez -> HealthController (200, no DB), excluded from the /api prefix —
+    # never the measured route. The slim node image has node but no wget/curl.
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"require('http').get('http://127.0.0.1:8085/livez',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\""]
       interval: 3s
       timeout: 3s
       retries: 20

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1431,6 +1431,21 @@ in:
   FPM access lines. Also pinned `mlocati/php-extension-installer` to `2.9.0`
   (was the floating `:2`) and reconciled the gin-gorm/gombit README Status
   lines that still called the ecosystem services open.
+- `benchmarks/apps/nestjs/Dockerfile` + `docker-entrypoint.sh` + `ensure_db.js`
+  (Node/NestJS/TypeORM ecosystem app — the last one). `node:24-slim`, `npm ci`
+  + `nest build`; devDependencies are kept because `migrate`/`seed` use the
+  committed ts-node npm scripts (`NODE_ENV=production` is a run-time env, not a
+  build arg, so `npm ci` doesn't drop them). `serve` runs the compiled
+  `node dist/main`. `migrate` provisions `gombit_bench_nestjs` via
+  `ensure_db.js` (pg, guarded `CREATE DATABASE`, every bring-up). Verified end
+  to end against a live container: ensure_db creates the DB + TypeORM
+  `migration:run` (second run a no-op), seed, `healthy` via `/livez`, canonical
+  envelope (`total: 100000`), inspect-limits `enforced`. **All six
+  implementations are now containerized** — two Go apps + four ecosystem apps,
+  each a `compose.yml` service under the §7 budget with a `/livez` health check
+  and idempotent per-app database provisioning. The remaining Phase 6 work is
+  the orchestration loop that brings them up and runs `run-crud` over each into
+  one `results.json`, plus the footprint capture below.
 - `benchmarks/internal/reslimits` + `benchmarks/scripts/inspect-limits`: the
   issue's "detect and report rather than silently pretend limits were applied"
   requirement. A compose budget is only an *intention*; the tool reads the


### PR DESCRIPTION
## Summary

Last ecosystem-app compose service (issue #141 Phase 6): the **NestJS + TypeORM**
app. With this, **all six implementations are containerized**.

- **`benchmarks/apps/nestjs/Dockerfile`** — `node:24-slim`, `npm ci` +
  `nest build`. devDependencies are kept because `migrate`/`seed` use the
  committed ts-node npm scripts; `NODE_ENV=production` is a run-time env, not a
  build arg, so `npm ci` doesn't drop them. Self-contained context.
- **`docker-entrypoint.sh`** — `migrate` / `seed` / `serve`. `serve` runs the
  compiled `node dist/main` directly (clean signals); `migrate`/`seed` run the
  committed npm scripts.
- **`ensure_db.js`** — creates `gombit_bench_nestjs` if absent (pg, guarded
  `CREATE DATABASE`) on every `migrate` — the #187 idempotent-provisioning
  lesson, using the app's own driver.
- **`compose.yml`** — `nestjs` service on `:8085` with the §7 budget and a
  `/livez` health check (node `http.get`, since the slim image has no
  wget/curl), never the measured route.

Closes #141 — partial (one Phase 6 slice; the issue stays open).

## Acceptance criteria

- [x] NestJS ecosystem app containerized with its migrate step and the §7 budget,
      verified enforced on the live container.
- [x] **All six implementations containerized** (two Go + four ecosystem apps).
- [ ] The six-app bring-up/`run-crud` loop into one `results.json` — next slice.
- [ ] Per-app resource/RSS footprint capture — later Phase 6.

## Scope notes

Deferred: the orchestration loop that brings all six up and runs `run-crud` over
each, and per-app RSS/CPU footprint capture. devDependencies ship in the runtime
image because the committed `migration:run`/`seed` scripts are ts-node-driven;
`serve` runs the compiled output only.

## Validation

- [x] `go build ./...` (no Go changed; sanity)
- [x] `docker compose ... config` valid
- [x] End to end against a live container: `run --rm nestjs migrate` →
      "ensure_db: creating database gombit_bench_nestjs" + TypeORM
      "1 migrations ... must be executed"; a second migrate is a no-op (exit 0);
      `run --rm nestjs seed`; the served container reaches `healthy` via `/livez`
      in ~3s; `GET /api/projects` returns the canonical D10 envelope
      (`total: 100000`, confirming the seed); `inspect-limits` reads
      `enforced: cpu 2.00 / memory 1 GiB`.
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB matrix — N/A: no Go/schema changes; the app and
      its migration/seed are already tested (`npm test` in CI); this adds
      containerization verified live end to end.
- [x] Stable features ship docs and appear in an example app — nestjs README
      compose section + Status, `benchmarks/README` tree + note, plan Phase 6 note.
- [x] Extraction preserves contracts — N/A: new tooling, no template extraction.
- [ ] Generators — N/A.
- [ ] API changes regenerate OpenAPI + TS client — N/A: no API changes.
- [x] No secrets in generated frontend source — N/A: no frontend changes.
- [x] Scope stays inside this issue's milestone — M6/BENCH-1; no battery creep.
- [x] Links its issue and states which acceptance criteria it satisfies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
