### PR TITLE
feat: BENCH-1 orchestrate the CRUD-read workload across all six apps (make benchmark-crud-all)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,22 +19,25 @@ TARGET_URL ?=
 # Where the snapshot is written.
 OUT_DIR ?= benchmarks/results/latest
 
-# The pinned intended limits (issue #141 §7). run-crud does NOT apply these —
-# it starts nothing — so it records an honest "not applied" string instead;
-# these are only surfaced by benchmark-metadata, labelled as intended. The
-# compose loop (next slice) is what will actually enforce and record them.
-INTENDED_LIMITS ?= intended (not yet enforced): app $(APP_CPUS)cpu/$(APP_MEMORY); postgres $(POSTGRES_CPUS)cpu/$(POSTGRES_MEMORY)
+# The pinned intended limits (issue #141 §7). Standalone run-crud does NOT apply
+# these — it starts nothing — so it records an honest "not applied" string
+# instead; these are only surfaced by benchmark-metadata, labelled as intended.
+# benchmark-crud-all is what actually enforces them (compose) and records the
+# applied verdict per app (via inspect-limits).
+INTENDED_LIMITS ?= intended (applied only under benchmark-crud-all): app $(APP_CPUS)cpu/$(APP_MEMORY); postgres $(POSTGRES_CPUS)cpu/$(POSTGRES_MEMORY)
 
 .PHONY: benchmark-crud benchmark-crud-all benchmark-summary benchmark-metadata
 
 ## benchmark-crud-all: bring every containerized implementation up under compose
-## (with the §7 limits), migrate + seed it, verify the applied limit, run the
-## CRUD-read workload against it, and merge all six into OUT_DIR/results.json.
-## Each app is measured alone (stopped before the next) since the load generator
-## shares the host. Run `make benchmark-summary` afterwards. Override the set
-## with APPS="gin-gorm gombit".
+## (with the §7 limits), migrate + seed it, classify + record the applied limit
+## off the live container, run the CRUD-read workload against it, and merge all
+## six into OUT_DIR/results.json. Each app is measured alone (stopped before the
+## next) since the load generator shares the host. Run `make benchmark-summary`
+## afterwards. Override the set with APPS="gin-gorm gombit"; the workload pins
+## (CONCURRENCY/TRIALS/DURATION_SECONDS/...) are overridable on the command line.
 ##
 ##   make benchmark-crud-all
+##   make benchmark-crud-all CONCURRENCY=1 TRIALS=1 DURATION_SECONDS=3   # smoke
 benchmark-crud-all:
 	OUT_DIR="$(OUT_DIR)" bash benchmarks/scripts/run-crud-all.sh
 

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,23 @@ OUT_DIR ?= benchmarks/results/latest
 # compose loop (next slice) is what will actually enforce and record them.
 INTENDED_LIMITS ?= intended (not yet enforced): app $(APP_CPUS)cpu/$(APP_MEMORY); postgres $(POSTGRES_CPUS)cpu/$(POSTGRES_MEMORY)
 
-.PHONY: benchmark-crud benchmark-summary benchmark-metadata
+.PHONY: benchmark-crud benchmark-crud-all benchmark-summary benchmark-metadata
+
+## benchmark-crud-all: bring every containerized implementation up under compose
+## (with the §7 limits), migrate + seed it, verify the applied limit, run the
+## CRUD-read workload against it, and merge all six into OUT_DIR/results.json.
+## Each app is measured alone (stopped before the next) since the load generator
+## shares the host. Run `make benchmark-summary` afterwards. Override the set
+## with APPS="gin-gorm gombit".
+##
+##   make benchmark-crud-all
+benchmark-crud-all:
+	OUT_DIR="$(OUT_DIR)" bash benchmarks/scripts/run-crud-all.sh
 
 ## benchmark-crud: run the headline CRUD-read workload against one running,
 ## seeded implementation and write results.json/results.csv/metadata.json.
 ## Requires the app to be up and seeded (see benchmarks/apps/<name>/README.md);
-## the full "bring up all six under compose" loop is a later slice.
+## `benchmark-crud-all` orchestrates all six under compose instead.
 ##
 ##   make benchmark-crud FRAMEWORK=gin-gorm FRAMEWORK_VERSION=v1.11.0 \
 ##     RUNTIME=go RUNTIME_VERSION=go1.25.7 \

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -44,20 +44,18 @@ benchmarks/
 └── results/             generated output (issue §9); results/README.md documents the layout
 ```
 
-All six canonical CRUD implementations exist, the result schema / metadata
-collector / run-config pins are in place, and the headline CRUD-read workload
 All six canonical CRUD implementations run end to end under one command: **all
 six** (`gin-gorm`, `gombit`, `django`, `rails`, `laravel`, `nestjs`) are
 containerized with `compose.yml` services carrying the §7 resource budget —
 `gombit` also applies its real Atlas migrations in-container (pinned `atlas`
 image), and every migration-bearing app creates its own database idempotently on
 every bring-up (no fresh-volume init scripts) — and `make benchmark-crud-all`
-brings each up, seeds it, verifies the applied §7 ceiling on the live container
-(`internal/reslimits` + `scripts/inspect-limits`, issue #141's "detect/report
-rather than silently pretend"), runs the workload, and merges all six into one
-`results.json`. Still scoped to later phases: `docs/methodology.md`, per-app
-resource/RSS capture (Phase 6 footprint), the other `make benchmark-*`
-workloads, and extending `fairness_test.go` to all six.
+brings each up, seeds it, classifies the applied §7 ceiling on the live
+container and records it (`internal/reslimits` + `scripts/inspect-limits`, issue
+#141's "detect/report rather than silently pretend"), runs the workload, and
+merges all six into one `results.json`. Still scoped to later phases:
+`docs/methodology.md`, per-app resource/RSS capture (Phase 6 footprint), the
+other `make benchmark-*` workloads, and extending `fairness_test.go` to all six.
 
 ## Resource limits (§7): intention vs. reality
 
@@ -73,12 +71,13 @@ which the daemon zeroes or rejects when it can't apply them, an honest signal of
 a dropped ceiling) via `internal/reslimits` and classifies them against the
 intended budget — `enforced`, `partial`, or `not applied`.
 
-Today the command **prints** that verdict; nothing yet consumes it. Wiring it
-into what a run records as `metadata.resource_limits` — automatically in the
-six-app compose loop, or by hand via
-`run-crud -resource-limits "$(inspect-limits …)"` — is a later slice. Until
-then `benchmark-crud` records `run-crud`'s own honest default: it starts and
-constrains nothing, so it says "not applied" unless you pass the flag.
+`make benchmark-crud-all` records that verdict as `metadata.resource_limits`:
+for each app it classifies the live container and passes the result to
+`run-crud -resource-limits`, so the recorded limit is the one actually applied
+(and if `inspect-limits` cannot classify the container at all, that app's row is
+not published rather than recorded blank). The standalone `make benchmark-crud`
+starts and constrains nothing, so it records `run-crud`'s honest "not applied"
+default unless you pass `-resource-limits "$(inspect-limits …)"` yourself.
 
 ## Result schema and run metadata
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -71,13 +71,16 @@ which the daemon zeroes or rejects when it can't apply them, an honest signal of
 a dropped ceiling) via `internal/reslimits` and classifies them against the
 intended budget — `enforced`, `partial`, or `not applied`.
 
-`make benchmark-crud-all` records that verdict as `metadata.resource_limits`:
-for each app it classifies the live container and passes the result to
-`run-crud -resource-limits`, so the recorded limit is the one actually applied
-(and if `inspect-limits` cannot classify the container at all, that app's row is
-not published rather than recorded blank). The standalone `make benchmark-crud`
-starts and constrains nothing, so it records `run-crud`'s honest "not applied"
-default unless you pass `-resource-limits "$(inspect-limits …)"` yourself.
+`make benchmark-crud-all` records that classification as
+`metadata.resource_limits`: for each app it classifies the live container and
+passes the result to `run-crud -resource-limits`, so the recorded value is
+whichever of `enforced` / `partial` / `not applied` the container actually
+shows — a record of what was applied, not an assumption that the ceiling held.
+(If `inspect-limits` cannot classify the container at all — a tool failure — that
+app's row is not published rather than recorded blank.) The standalone
+`make benchmark-crud` starts and constrains nothing, so it records `run-crud`'s
+honest "not applied" default unless you pass
+`-resource-limits "$(inspect-limits …)"` yourself.
 
 ## Result schema and run metadata
 
@@ -147,7 +150,9 @@ against a healthy app must be error-free (`benchmarks/internal/k6`'s
 `Summary.Validate`). Standalone, `run-crud` does not start or resource-constrain
 the app, so its default `metadata.resource_limits` says so honestly; under
 `benchmark-crud-all` the app runs in its §7-limited container and the loop passes
-the live `inspect-limits` verdict, so the recorded limit is the enforced one.
+the live `inspect-limits` verdict, so the recorded value is that container's
+classification (`enforced` / `partial` / `not applied`), not an assumption that
+the ceiling held.
 Per-app `cpu_percent`/`rss_bytes` footprint capture is still a later Phase 6
 slice.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,6 +23,7 @@ benchmarks/
 ├── scripts/
 │   ├── collect-host-info/ CLI over internal/metadata: writes metadata.json for a run
 │   ├── run-crud/          runs crud-list.js (via the pinned k6 image) against one app → results snapshot
+│   ├── run-crud-all.sh    orchestrates run-crud over all six containerized apps (make benchmark-crud-all)
 │   ├── summarize/         results.json -> summary.md (make benchmark-summary)
 │   └── inspect-limits/    reports whether a live container got the §7 ceiling (uses internal/reslimits)
 ├── micro/                Go abstraction-overhead microbenchmarks (Phase 2)
@@ -45,18 +46,17 @@ benchmarks/
 
 All six canonical CRUD implementations exist, the result schema / metadata
 collector / run-config pins are in place, and the headline CRUD-read workload
-runs end to end against one implementation (`make benchmark-crud`). The Phase 6
-compose loop is now well underway: **all six** implementations (`gin-gorm`,
-`gombit`, `django`, `rails`, `laravel`, `nestjs`) are containerized with
-`compose.yml` services carrying the §7 resource budget — `gombit` also applies
-its real Atlas migrations in-container (pinned `atlas` image), and every
-migration-bearing app creates its own database idempotently on every bring-up
-(no fresh-volume init scripts) — and `internal/reslimits` +
-`scripts/inspect-limits` verify the ceiling actually landed on the live
-container (issue #141's "detect/report rather than silently pretend"). Still
-scoped to later phases: `docs/methodology.md`, the loop that brings all six up
-and runs `run-crud` over each, per-app resource/RSS capture (Phase 6 footprint),
-the other `make benchmark-*`
+All six canonical CRUD implementations run end to end under one command: **all
+six** (`gin-gorm`, `gombit`, `django`, `rails`, `laravel`, `nestjs`) are
+containerized with `compose.yml` services carrying the §7 resource budget —
+`gombit` also applies its real Atlas migrations in-container (pinned `atlas`
+image), and every migration-bearing app creates its own database idempotently on
+every bring-up (no fresh-volume init scripts) — and `make benchmark-crud-all`
+brings each up, seeds it, verifies the applied §7 ceiling on the live container
+(`internal/reslimits` + `scripts/inspect-limits`, issue #141's "detect/report
+rather than silently pretend"), runs the workload, and merges all six into one
+`results.json`. Still scoped to later phases: `docs/methodology.md`, per-app
+resource/RSS capture (Phase 6 footprint), the other `make benchmark-*`
 workloads, and extending `fairness_test.go` to all six.
 
 ## Resource limits (§7): intention vs. reality
@@ -109,11 +109,29 @@ network on the **same machine** as the app (the issue's "another container on
 the same host"), so at high concurrency k6 contends for CPU with the app —
 this is the recorded topology, not a separate load-generation host.
 
-Against **one already-running, already-seeded** implementation:
+**All six under compose (the usual way):**
+
+```sh
+make benchmark-crud-all      # then: make benchmark-summary
+```
+
+This brings each containerized app up under compose with the §7 limits, applies
+its migrations and seed (each app creates its own database idempotently), waits
+for `/livez` to report healthy, reads the *actually applied* limit off the live
+container (`inspect-limits`, recorded as `metadata.resource_limits`), runs the
+workload against it, then **stops** it before the next — the load generator
+shares the host, so only the app under test runs while it is measured. Each
+app's framework/runtime versions are derived from its own source-of-truth
+(manifest file, Dockerfile base image), never hand-copied. Override the set with
+`APPS="gin-gorm gombit"`. `benchmarks/scripts/run-crud-all.sh` is the
+orchestrator; `run-crud-all_test.sh` checks every app's identity resolves.
+
+**Or against one already-running, already-seeded implementation** (what the loop
+calls per app):
 
 ```sh
 # start + seed the app per its own README, e.g. benchmarks/apps/gin-gorm, then:
-make benchmark-crud FRAMEWORK=gin-gorm FRAMEWORK_VERSION=v1.11.0 \
+make benchmark-crud FRAMEWORK=gin-gorm FRAMEWORK_VERSION=v1.12.0 \
   RUNTIME=go RUNTIME_VERSION=go1.25.7 \
   TARGET_URL='http://127.0.0.1:8081/api/projects?page=1&limit=20'
 ```
@@ -127,9 +145,11 @@ six. A trial that sends no traffic, has any HTTP error, or fails a content
 check (a 200 with the wrong page shape) fails the command loudly **with
 nothing written** rather than recording a bogus row — the read workload
 against a healthy app must be error-free (`benchmarks/internal/k6`'s
-`Summary.Validate`). `run-crud` does not start or resource-constrain the app,
-so `metadata.resource_limits` says so honestly; the compose loop that enforces
-the §7 limits and captures `cpu_percent`/`rss_bytes` (Phase 6) is the next
+`Summary.Validate`). Standalone, `run-crud` does not start or resource-constrain
+the app, so its default `metadata.resource_limits` says so honestly; under
+`benchmark-crud-all` the app runs in its §7-limited container and the loop passes
+the live `inspect-limits` verdict, so the recorded limit is the enforced one.
+Per-app `cpu_percent`/`rss_bytes` footprint capture is still a later Phase 6
 slice.
 
 Once `results.json` exists, `make benchmark-summary` regenerates `summary.md`

--- a/benchmarks/apps/gin-gorm/README.md
+++ b/benchmarks/apps/gin-gorm/README.md
@@ -43,10 +43,11 @@ go run ./benchmarks/scripts/inspect-limits \
   -cpus 2 -memory 1g
 ```
 
-The entrypoint takes two verbs, `seed` and `serve` (default), matching the two
-modes below. The full "bring all six apps up and run `run-crud` over each" loop
-is a later Phase 6 slice; this is the containerization + honest limit-detection
-spine it builds on.
+The entrypoint takes three verbs, `migrate`, `seed`, and `serve` (default), so
+the orchestrator drives every app the same way; here `migrate` is a no-op (GORM
+AutoMigrate runs on seed/serve, and the database is the postgres service's
+`POSTGRES_DB`). `make benchmark-crud-all` brings all six apps up and runs
+`run-crud` over each; this app is one leg of it.
 
 Env vars (all optional, defaults match `benchmarks/compose.yml`):
 
@@ -103,12 +104,10 @@ and the cross-implementation fairness check comparing them are all done
 (tracked in [docs/plans/BENCH-1-benchmark-suite.md](../../../docs/plans/BENCH-1-benchmark-suite.md)
 Phase 3). See [../gombit/README.md](../gombit/README.md) for the Gombit-side
 details, including one discovered framework gap and two bugs the fairness
-comparison caught. This app is now containerized with a `benchmarks/compose.yml`
-`gin-gorm` service carrying the §7 budget (see [Run](#run) above); the `gombit`
-app has its own service too. Still open: wiring the fairness check into automated
-CI (it needs both databases at the full canonical 1,000/100,000 scale, deferred
-to Phase 8's lighter-seed CI work); the last ecosystem app's compose service
-(`nestjs`; django/rails/laravel are in) and the six-app bring-up loop (later
-Phase 6 slices); and consuming the
-`inspect-limits` verdict into a run's recorded `metadata.resource_limits` (today
-it is printed, not yet recorded).
+comparison caught. All six apps are now containerized with `benchmarks/compose.yml`
+services carrying the §7 budget (see [Run](#run) above), and
+`make benchmark-crud-all` brings each up, records the live `inspect-limits`
+verdict as `metadata.resource_limits`, and runs `run-crud` over each. Still open:
+wiring the fairness check into automated CI (it needs both databases at the full
+canonical 1,000/100,000 scale, deferred to Phase 8's lighter-seed CI work) and
+the per-app operational-footprint capture (Phase 6).

--- a/benchmarks/apps/gin-gorm/docker-entrypoint.sh
+++ b/benchmarks/apps/gin-gorm/docker-entrypoint.sh
@@ -1,13 +1,19 @@
 #!/bin/sh
-# gin-gorm container entrypoint. Two verbs, matching the app's own two modes
-# (benchmarks/apps/gin-gorm/README.md) so the compose loop controls seeding
-# explicitly rather than reseeding 100k rows on every serve start:
+# gin-gorm container entrypoint. Three verbs so the compose loop can drive every
+# app the same way (benchmarks/apps/gin-gorm/README.md):
 #
-#   seed    run the deterministic seed (truncate + insert) and exit
-#   serve   run the API (default)
+#   migrate  no-op: this app uses GORM AutoMigrate (run on seed/serve) and its
+#            database is the postgres service's POSTGRES_DB, so there is no
+#            separate migrate or database-create step — the verb exists only so
+#            the orchestrator's uniform migrate/seed/serve works here too
+#   seed     run the deterministic seed (truncate + insert) and exit
+#   serve    run the API (default)
 set -eu
 
 case "${1:-serve}" in
+  migrate)
+    echo "gin-gorm: schema is AutoMigrated on seed/serve; nothing to migrate"
+    ;;
   seed)
     exec gin-gorm -seed
     ;;
@@ -15,7 +21,7 @@ case "${1:-serve}" in
     exec gin-gorm
     ;;
   *)
-    echo "entrypoint: unknown command '$1' (want: seed | serve)" >&2
+    echo "entrypoint: unknown command '$1' (want: migrate | seed | serve)" >&2
     exit 2
     ;;
 esac

--- a/benchmarks/apps/gombit/README.md
+++ b/benchmarks/apps/gombit/README.md
@@ -88,8 +88,9 @@ go run ./benchmarks/scripts/inspect-limits \
   -cpus 2 -memory 1g
 ```
 
-The full six-app bring-up/`run-crud` loop is a later Phase 6 slice; this
-containerizes the second of the two Go apps on the same pattern as `gin-gorm`.
+`make benchmark-crud-all` brings all six apps up and runs `run-crud` over each;
+this containerizes the second of the two Go apps on the same pattern as
+`gin-gorm`.
 
 ## Test
 

--- a/benchmarks/compose.yml
+++ b/benchmarks/compose.yml
@@ -1,8 +1,8 @@
 # PostgreSQL + the benchmark app services under test. App services are added
 # as each is containerized (Phase 6 compose loop): the two Go apps `gin-gorm`
 # (the reference control) and `gombit` (same API on the Gombit runtime) plus all
-# four ecosystem apps (`django`, `rails`, `laravel`, `nestjs`) — all six are in.
-# Next is the loop that brings them up and runs run-crud over each.
+# four ecosystem apps (`django`, `rails`, `laravel`, `nestjs`) — all six are in,
+# and `make benchmark-crud-all` brings each up and runs run-crud over it.
 #
 # Version pin: issue #141 requires major.minor (or digest), not a
 # major-only floating tag. The pin lives once in

--- a/benchmarks/config/versions.env
+++ b/benchmarks/config/versions.env
@@ -45,10 +45,10 @@ POOL_MAX_IDLE=20
 # Workload defaults (issue #141 §7 "Concurrency and tail latency"): the
 # concurrency levels, per-trial measured duration, warm-up, and trial count
 # the CRUD workload uses. 1000 is in the pinned set (the issue's minimum is
-# 1/10/100/500/1000); the orchestrator attempts it and, if the test machine
-# can't sustain it without the load generator becoming the bottleneck, records
-# that limitation and drops it from the *reported* set rather than publishing
-# bogus data — the attempt is pinned here as data, not left to a comment.
+# 1/10/100/500/1000). run-crud runs every level and validates every trial, so a
+# level the test machine can't sustain fails the run loudly (no bogus row is
+# written) rather than being silently dropped; the operator then documents it
+# and narrows CONCURRENCY (overridable on the command line) for the reported set.
 CONCURRENCY=1,10,100,500,1000
 DURATION_SECONDS=30
 WARMUP_SECONDS=10

--- a/benchmarks/internal/reslimits/reslimits.go
+++ b/benchmarks/internal/reslimits/reslimits.go
@@ -17,8 +17,8 @@
 // `/sys/fs/cgroup`, but the daemon zeroes or rejects a limit it cannot apply,
 // so reading them back is an honest signal that an intended ceiling was
 // dropped. It classifies them against the intended budget, producing the honest
-// string a run can record as metadata.resource_limits (that wiring is a later
-// slice; today the string is produced and printed, not yet auto-recorded).
+// string a run records as metadata.resource_limits (the `make benchmark-crud-all`
+// loop wires it per app; standalone run-crud records its own honest default).
 package reslimits
 
 import (

--- a/benchmarks/results/README.md
+++ b/benchmarks/results/README.md
@@ -21,9 +21,10 @@ results/
 [`benchmarks/internal/metadata`](../internal/metadata) shape, collected by
 [`benchmarks/scripts/collect-host-info`](../scripts/collect-host-info).
 
-`latest/` is committed once the run pipeline exists (Phase 7 of
-[docs/plans/BENCH-1-benchmark-suite.md](../../docs/plans/BENCH-1-benchmark-suite.md)),
+`latest/` is committed once the full suite is run on a dedicated machine (Phase 7
+of [docs/plans/BENCH-1-benchmark-suite.md](../../docs/plans/BENCH-1-benchmark-suite.md)),
 so the published README performance tables are always regenerable from a
-committed snapshot. It does not exist yet — the schema, collector, and config
-pins land first (Phase 1 completion); the orchestration that fills `latest/`
-is the next slice.
+committed snapshot. The orchestration that fills `latest/` exists —
+`make benchmark-crud-all` runs the CRUD-read workload across all six apps and
+`make benchmark-summary` renders `summary.md`; committing a canonical snapshot is
+the Phase 7 reporting step.

--- a/benchmarks/scripts/inspect-limits/main.go
+++ b/benchmarks/scripts/inspect-limits/main.go
@@ -9,12 +9,12 @@
 //	go run ./benchmarks/scripts/inspect-limits \
 //	  -container benchmarks-gin-gorm-1 -cpus 2 -memory 1g
 //
-// This command only *prints* the verdict. Wiring the string into what a run
-// records as metadata.resource_limits — automatically in the six-app compose
-// loop, or by hand via `run-crud -resource-limits "$(inspect-limits …)"` — is a
-// later slice. With -strict it exits non-zero unless the budget was fully
-// enforced, so a bring-up script can refuse to record numbers gathered under
-// the wrong limits.
+// This command prints the verdict; `make benchmark-crud-all` consumes it,
+// passing the string to `run-crud -resource-limits` so a run records the
+// applied limit (standalone, you can do the same by hand via
+// `run-crud -resource-limits "$(inspect-limits …)"`). With -strict it exits
+// non-zero unless the budget was fully enforced, so a caller that wants to
+// refuse rather than record can fail closed.
 package main
 
 import (

--- a/benchmarks/scripts/run-crud-all.sh
+++ b/benchmarks/scripts/run-crud-all.sh
@@ -5,35 +5,56 @@
 # For each app it: builds the image, applies migrations and seeds (the app's
 # own `migrate`/`seed` verbs, which create their database idempotently), brings
 # the service up under its §7 cgroup budget, waits for /livez to report healthy,
-# reads the *actually applied* limit off the live container
-# (benchmarks/scripts/inspect-limits), runs the per-implementation measurement
-# engine (benchmarks/scripts/run-crud) against it recording that honest limit,
-# then stops the service so the next app is measured alone with Postgres — the
-# load generator shares the host, so only the app under test should be running.
+# classifies the *actually applied* limit off the live container
+# (benchmarks/scripts/inspect-limits) and records that honest string, runs the
+# per-implementation measurement engine (benchmarks/scripts/run-crud) against
+# it, then stops the service so the next app is measured alone with Postgres —
+# the load generator shares the host, so only the app under test should run.
 #
 # run-crud merges by framework key, so the six iterations accumulate into
 # benchmarks/results/latest/{results.json,results.csv,metadata.json}. Regenerate
 # the human report afterwards with `make benchmark-summary`.
 #
-#   make benchmark-crud-all               # all six
-#   APPS="gin-gorm gombit" make benchmark-crud-all   # a subset
+#   make benchmark-crud-all                           # all six
+#   APPS="gin-gorm gombit" make benchmark-crud-all    # a subset
+#   make benchmark-crud-all CONCURRENCY=1 TRIALS=1 DURATION_SECONDS=3   # smoke
 #
 # Versions are DERIVED from each app's own source-of-truth (framework manifest
 # file, Dockerfile base image) and the run fails closed if any comes back empty
-# — nothing about the recorded identity is hand-copied here.
+# — nothing about the recorded identity is hand-copied here. The framework key
+# is the compose service name, matching the rest of the harness.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
 CONFIG="benchmarks/config/versions.env"
-# shellcheck disable=SC1090
-set -a; . "$CONFIG"; set +a
+
+# load_pins sets each versions.env pin ONLY if it is not already in the
+# environment, so `make benchmark-crud-all CONCURRENCY=1` (make exports
+# command-line variables to recipe environments) and `CONCURRENCY=1 bash
+# run-crud-all.sh` override the file, instead of the file clobbering them.
+# printf -v sets the named variable without eval.
+load_pins() {
+  local k v
+  while IFS='=' read -r k v; do
+    case "$k" in ''|\#*) continue ;; esac
+    if [ -z "${!k-}" ]; then
+      printf -v "$k" '%s' "$v"
+    fi
+  done < <(grep -vE '^[[:space:]]*#|^[[:space:]]*$' "$CONFIG")
+}
+load_pins
 
 COMPOSE=(docker compose --env-file "$CONFIG" -f benchmarks/compose.yml)
 OUT_DIR="${OUT_DIR:-benchmarks/results/latest}"
 # Which apps to run (default: all six, in a stable order).
 APPS="${APPS:-gin-gorm gombit django rails laravel nestjs}"
+
+# Seams over the Go tools so the orchestration can be driven with fakes in the
+# test without Docker or a real build.
+inspect_limits() { go run ./benchmarks/scripts/inspect-limits "$@"; }
+run_crud() { go run ./benchmarks/scripts/run-crud "$@"; }
 
 # req NAME VALUE — echo VALUE, or abort if it is empty (fail closed so a broken
 # extractor never records a blank version).
@@ -54,32 +75,34 @@ base_tag() {
   printf '%s' "${tag%%-*}"
 }
 
-# Per-app identity, derived. Sets: PORT FRAMEWORK FRAMEWORK_VERSION RUNTIME
-# RUNTIME_VERSION for the given app.
+# app_identity APP — sets PORT FRAMEWORK FRAMEWORK_VERSION RUNTIME
+# RUNTIME_VERSION. FRAMEWORK is the compose service name (== the run-crud merge
+# key the rest of the harness uses); versions are derived from source.
 app_identity() {
+  FRAMEWORK="$1"
   case "$1" in
     gin-gorm)
-      PORT=8081; FRAMEWORK=gin; RUNTIME=go
+      PORT=8081; RUNTIME=go
       FRAMEWORK_VERSION="$(req gin "$(awk '/gin-gonic\/gin /{print $2; exit}' go.mod)")"
       RUNTIME_VERSION="go$(req go "$(base_tag gin-gorm golang)")" ;;
     gombit)
-      PORT=8080; FRAMEWORK=gombit; RUNTIME=go
+      PORT=8080; RUNTIME=go
       FRAMEWORK_VERSION="$(req gombit "$(git describe --tags --always --dirty)")"
       RUNTIME_VERSION="go$(req go "$(base_tag gombit golang)")" ;;
     django)
-      PORT=8082; FRAMEWORK=django; RUNTIME=python
+      PORT=8082; RUNTIME=python
       FRAMEWORK_VERSION="$(req django "$(sed -nE 's/^Django==([0-9.]+).*/\1/p' benchmarks/apps/django/requirements.txt)")"
       RUNTIME_VERSION="$(req python "$(base_tag django python)")" ;;
     rails)
-      PORT=8083; FRAMEWORK=rails; RUNTIME=ruby
+      PORT=8083; RUNTIME=ruby
       FRAMEWORK_VERSION="$(req rails "$(sed -nE 's/^ *rails \(([0-9.]+)\).*/\1/p' benchmarks/apps/rails/Gemfile.lock | head -1)")"
       RUNTIME_VERSION="$(req ruby "$(base_tag rails ruby)")" ;;
     laravel)
-      PORT=8084; FRAMEWORK=laravel; RUNTIME=php
+      PORT=8084; RUNTIME=php
       FRAMEWORK_VERSION="$(req laravel "$(sed -nE 's/.*"laravel\/framework": "([0-9.]+)".*/\1/p' benchmarks/apps/laravel/composer.json)")"
       RUNTIME_VERSION="$(req php "$(base_tag laravel php)")" ;;
     nestjs)
-      PORT=8085; FRAMEWORK=nestjs; RUNTIME=node
+      PORT=8085; RUNTIME=node
       FRAMEWORK_VERSION="$(req nestjs "$(sed -nE 's/.*"@nestjs\/core": "([0-9.]+)".*/\1/p' benchmarks/apps/nestjs/package.json)")"
       RUNTIME_VERSION="$(req node "$(base_tag nestjs node)")" ;;
     *)
@@ -102,26 +125,23 @@ wait_healthy() {
   return 1
 }
 
-# run_one APP — the full measured cycle for one implementation.
-run_one() {
-  local app="$1" cid limits
-  app_identity "$app"
-  echo "=== $app ($FRAMEWORK $FRAMEWORK_VERSION on $RUNTIME $RUNTIME_VERSION, :$PORT) ==="
-
-  "${COMPOSE[@]}" build "$app" >/dev/null
-  "${COMPOSE[@]}" run --rm "$app" migrate
-  "${COMPOSE[@]}" run --rm "$app" seed
-  "${COMPOSE[@]}" up -d "$app" >/dev/null
-
-  cid="$("${COMPOSE[@]}" ps -q "$app")"
-  wait_healthy "$cid"
-
-  # The honest, applied limit off the live container — recorded as-is.
-  limits="$(go run ./benchmarks/scripts/inspect-limits \
-    -container "$cid" -cpus "$APP_CPUS" -memory "$APP_MEMORY" || true)"
-  echo "run-crud-all: $app limits: $limits"
-
-  go run ./benchmarks/scripts/run-crud \
+# measure APP CID — classify the applied limit and run the workload. §7 is
+# detect/report, so enforced / partial / not-applied are all recorded as-is;
+# but inspect-limits exiting non-zero is a TOOL failure (bad args, docker
+# error), and on that we fail the app rather than record a blank
+# resource_limits (which would override run-crud's honest default and, via
+# mergedMetadata's last-write, blank the field for the whole snapshot).
+measure() {
+  local app="$1" cid="$2" limits
+  # measure is called as `measure || rc=$?`, which disables set -e inside it, so
+  # every failure a blank row could hide from is checked explicitly here.
+  wait_healthy "$cid" || return 1
+  if ! limits="$(inspect_limits -container "$cid" -cpus "$APP_CPUS" -memory "$APP_MEMORY")"; then
+    echo "run-crud-all: inspect-limits failed for $app; not publishing a row" >&2
+    return 1
+  fi
+  echo "run-crud-all: $app applied limit: $limits"
+  run_crud \
     -target-url "http://127.0.0.1:${PORT}/api/projects?page=1&limit=20" \
     -framework "$FRAMEWORK" -framework-version "$FRAMEWORK_VERSION" \
     -runtime "$RUNTIME" -runtime-version "$RUNTIME_VERSION" \
@@ -131,10 +151,25 @@ run_one() {
     -out-dir "$OUT_DIR" \
     -postgres-version "$POSTGRES_IMAGE" \
     -resource-limits "$limits"
+}
 
-  # Free CPU/RAM for the next app (only the app under test + Postgres should run
-  # while k6 — sharing this host — is measuring).
+# run_one APP — the full measured cycle for one implementation. The SUT is
+# always stopped before returning (even when measure fails under set -e) so it
+# never shares the host with the next app's run.
+run_one() {
+  local app="$1" cid rc=0
+  app_identity "$app"
+  echo "=== $app ($FRAMEWORK $FRAMEWORK_VERSION on $RUNTIME $RUNTIME_VERSION, :$PORT) ==="
+
+  "${COMPOSE[@]}" build "$app" >/dev/null
+  "${COMPOSE[@]}" run --rm "$app" migrate
+  "${COMPOSE[@]}" run --rm "$app" seed
+  "${COMPOSE[@]}" up -d "$app" >/dev/null
+  cid="$("${COMPOSE[@]}" ps -q "$app")"
+
+  measure "$app" "$cid" || rc=$?
   "${COMPOSE[@]}" stop "$app" >/dev/null
+  return "$rc"
 }
 
 main() {

--- a/benchmarks/scripts/run-crud-all.sh
+++ b/benchmarks/scripts/run-crud-all.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Orchestrate the headline CRUD-read workload across all six containerized
+# implementations and merge the result into one results.json.
+#
+# For each app it: builds the image, applies migrations and seeds (the app's
+# own `migrate`/`seed` verbs, which create their database idempotently), brings
+# the service up under its §7 cgroup budget, waits for /livez to report healthy,
+# reads the *actually applied* limit off the live container
+# (benchmarks/scripts/inspect-limits), runs the per-implementation measurement
+# engine (benchmarks/scripts/run-crud) against it recording that honest limit,
+# then stops the service so the next app is measured alone with Postgres — the
+# load generator shares the host, so only the app under test should be running.
+#
+# run-crud merges by framework key, so the six iterations accumulate into
+# benchmarks/results/latest/{results.json,results.csv,metadata.json}. Regenerate
+# the human report afterwards with `make benchmark-summary`.
+#
+#   make benchmark-crud-all               # all six
+#   APPS="gin-gorm gombit" make benchmark-crud-all   # a subset
+#
+# Versions are DERIVED from each app's own source-of-truth (framework manifest
+# file, Dockerfile base image) and the run fails closed if any comes back empty
+# — nothing about the recorded identity is hand-copied here.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+CONFIG="benchmarks/config/versions.env"
+# shellcheck disable=SC1090
+set -a; . "$CONFIG"; set +a
+
+COMPOSE=(docker compose --env-file "$CONFIG" -f benchmarks/compose.yml)
+OUT_DIR="${OUT_DIR:-benchmarks/results/latest}"
+# Which apps to run (default: all six, in a stable order).
+APPS="${APPS:-gin-gorm gombit django rails laravel nestjs}"
+
+# req NAME VALUE — echo VALUE, or abort if it is empty (fail closed so a broken
+# extractor never records a blank version).
+req() {
+  if [ -z "${2:-}" ]; then
+    echo "run-crud-all: could not determine $1" >&2
+    exit 1
+  fi
+  printf '%s' "$2"
+}
+
+# base_tag APP LANG — the base image tag from the app's Dockerfile `FROM
+# <lang>:<tag>` line, with any -slim/-alpine/-fpm suffix stripped (3.12-slim ->
+# 3.12, 1.25.7-alpine -> 1.25.7).
+base_tag() {
+  local tag
+  tag="$(sed -nE "s/^FROM ${2}:([^ ]+).*/\1/p" "benchmarks/apps/${1}/Dockerfile" | head -1)"
+  printf '%s' "${tag%%-*}"
+}
+
+# Per-app identity, derived. Sets: PORT FRAMEWORK FRAMEWORK_VERSION RUNTIME
+# RUNTIME_VERSION for the given app.
+app_identity() {
+  case "$1" in
+    gin-gorm)
+      PORT=8081; FRAMEWORK=gin; RUNTIME=go
+      FRAMEWORK_VERSION="$(req gin "$(awk '/gin-gonic\/gin /{print $2; exit}' go.mod)")"
+      RUNTIME_VERSION="go$(req go "$(base_tag gin-gorm golang)")" ;;
+    gombit)
+      PORT=8080; FRAMEWORK=gombit; RUNTIME=go
+      FRAMEWORK_VERSION="$(req gombit "$(git describe --tags --always --dirty)")"
+      RUNTIME_VERSION="go$(req go "$(base_tag gombit golang)")" ;;
+    django)
+      PORT=8082; FRAMEWORK=django; RUNTIME=python
+      FRAMEWORK_VERSION="$(req django "$(sed -nE 's/^Django==([0-9.]+).*/\1/p' benchmarks/apps/django/requirements.txt)")"
+      RUNTIME_VERSION="$(req python "$(base_tag django python)")" ;;
+    rails)
+      PORT=8083; FRAMEWORK=rails; RUNTIME=ruby
+      FRAMEWORK_VERSION="$(req rails "$(sed -nE 's/^ *rails \(([0-9.]+)\).*/\1/p' benchmarks/apps/rails/Gemfile.lock | head -1)")"
+      RUNTIME_VERSION="$(req ruby "$(base_tag rails ruby)")" ;;
+    laravel)
+      PORT=8084; FRAMEWORK=laravel; RUNTIME=php
+      FRAMEWORK_VERSION="$(req laravel "$(sed -nE 's/.*"laravel\/framework": "([0-9.]+)".*/\1/p' benchmarks/apps/laravel/composer.json)")"
+      RUNTIME_VERSION="$(req php "$(base_tag laravel php)")" ;;
+    nestjs)
+      PORT=8085; FRAMEWORK=nestjs; RUNTIME=node
+      FRAMEWORK_VERSION="$(req nestjs "$(sed -nE 's/.*"@nestjs\/core": "([0-9.]+)".*/\1/p' benchmarks/apps/nestjs/package.json)")"
+      RUNTIME_VERSION="$(req node "$(base_tag nestjs node)")" ;;
+    *)
+      echo "run-crud-all: unknown app '$1'" >&2; exit 1 ;;
+  esac
+}
+
+# wait_healthy CONTAINER — block until the container's health check passes.
+wait_healthy() {
+  local cid="$1" i status
+  for i in $(seq 1 60); do
+    status="$(docker inspect --format '{{.State.Health.Status}}' "$cid" 2>/dev/null || echo missing)"
+    case "$status" in
+      healthy) return 0 ;;
+      unhealthy|missing) echo "run-crud-all: $cid is $status" >&2; return 1 ;;
+    esac
+    sleep 2
+  done
+  echo "run-crud-all: $cid did not become healthy in time" >&2
+  return 1
+}
+
+# run_one APP — the full measured cycle for one implementation.
+run_one() {
+  local app="$1" cid limits
+  app_identity "$app"
+  echo "=== $app ($FRAMEWORK $FRAMEWORK_VERSION on $RUNTIME $RUNTIME_VERSION, :$PORT) ==="
+
+  "${COMPOSE[@]}" build "$app" >/dev/null
+  "${COMPOSE[@]}" run --rm "$app" migrate
+  "${COMPOSE[@]}" run --rm "$app" seed
+  "${COMPOSE[@]}" up -d "$app" >/dev/null
+
+  cid="$("${COMPOSE[@]}" ps -q "$app")"
+  wait_healthy "$cid"
+
+  # The honest, applied limit off the live container — recorded as-is.
+  limits="$(go run ./benchmarks/scripts/inspect-limits \
+    -container "$cid" -cpus "$APP_CPUS" -memory "$APP_MEMORY" || true)"
+  echo "run-crud-all: $app limits: $limits"
+
+  go run ./benchmarks/scripts/run-crud \
+    -target-url "http://127.0.0.1:${PORT}/api/projects?page=1&limit=20" \
+    -framework "$FRAMEWORK" -framework-version "$FRAMEWORK_VERSION" \
+    -runtime "$RUNTIME" -runtime-version "$RUNTIME_VERSION" \
+    -concurrency "$CONCURRENCY" \
+    -duration "${DURATION_SECONDS}s" -warmup "${WARMUP_SECONDS}s" -trials "$TRIALS" \
+    -k6-image "grafana/k6:$K6_VERSION" \
+    -out-dir "$OUT_DIR" \
+    -postgres-version "$POSTGRES_IMAGE" \
+    -resource-limits "$limits"
+
+  # Free CPU/RAM for the next app (only the app under test + Postgres should run
+  # while k6 — sharing this host — is measuring).
+  "${COMPOSE[@]}" stop "$app" >/dev/null
+}
+
+main() {
+  echo "run-crud-all: ensuring postgres is up"
+  "${COMPOSE[@]}" up -d postgres >/dev/null
+  for app in $APPS; do
+    run_one "$app"
+  done
+  echo "run-crud-all: done. Results in $OUT_DIR; run 'make benchmark-summary' to render summary.md."
+}
+
+# Only run the orchestration when executed directly; sourcing (e.g. from the
+# test) just defines the functions above.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/benchmarks/scripts/run-crud-all_test.sh
+++ b/benchmarks/scripts/run-crud-all_test.sh
@@ -84,8 +84,18 @@ run_one gombit || rc=$?
 [ "$RAN_CRUD" -eq 0 ]  || note "run_crud ran despite inspect failure (would publish a blank resource_limits)"
 called "compose stop gombit" || note "SUT not stopped after inspect failure"
 
+# ---- 4. load_pins respects an overriding environment (Make/CLI override) ----
+# A revert to `set -a; . versions.env` (which clobbers exported vars) fails here.
+if ! CONCURRENCY=__override__ bash -c '
+      APPS="" source benchmarks/scripts/run-crud-all.sh
+      [ "$CONCURRENCY" = "__override__" ] || { echo "CONCURRENCY clobbered to $CONCURRENCY" >&2; exit 1; }
+      [ -n "$TRIALS" ] || { echo "TRIALS not loaded from the file" >&2; exit 1; }
+    '; then
+  note "load_pins does not let the environment override versions.env"
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "run-crud-all_test: FAILED" >&2
   exit 1
 fi
-echo "run-crud-all_test: identity tuples, inspect consumption, stop-before-next, and fail-closed inspect all pass"
+echo "run-crud-all_test: identity tuples, inspect consumption, stop-before-next, fail-closed inspect, and env override all pass"

--- a/benchmarks/scripts/run-crud-all_test.sh
+++ b/benchmarks/scripts/run-crud-all_test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Smoke test for run-crud-all.sh's version derivation: sourcing must define the
+# functions (the main loop is guarded), and every app's identity must resolve to
+# a non-empty framework/runtime version from its own source-of-truth files. This
+# is what catches an app rename or a moved manifest before a real run does.
+#
+#   bash benchmarks/scripts/run-crud-all_test.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+# Sourcing runs the derivation code but not the orchestration (main guard).
+APPS="" source benchmarks/scripts/run-crud-all.sh
+
+fail=0
+for app in gin-gorm gombit django rails laravel nestjs; do
+  app_identity "$app"
+  for pair in "PORT=$PORT" "FRAMEWORK=$FRAMEWORK" "FRAMEWORK_VERSION=$FRAMEWORK_VERSION" \
+              "RUNTIME=$RUNTIME" "RUNTIME_VERSION=$RUNTIME_VERSION"; do
+    if [ -z "${pair#*=}" ]; then
+      echo "FAIL: $app has empty ${pair%%=*}" >&2
+      fail=1
+    fi
+  done
+  # A version should start with a digit or 'v' — a stray label would sail past
+  # the non-empty check but is not a version.
+  case "$FRAMEWORK_VERSION" in
+    [0-9]*|v[0-9]*) : ;;
+    *) echo "FAIL: $app framework_version '$FRAMEWORK_VERSION' is not version-shaped" >&2; fail=1 ;;
+  esac
+  echo "ok: $app -> $FRAMEWORK $FRAMEWORK_VERSION / $RUNTIME $RUNTIME_VERSION (:$PORT)"
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "run-crud-all_test: FAILED" >&2
+  exit 1
+fi
+echo "run-crud-all_test: all six identities resolve"

--- a/benchmarks/scripts/run-crud-all_test.sh
+++ b/benchmarks/scripts/run-crud-all_test.sh
@@ -1,39 +1,91 @@
 #!/usr/bin/env bash
-# Smoke test for run-crud-all.sh's version derivation: sourcing must define the
-# functions (the main loop is guarded), and every app's identity must resolve to
-# a non-empty framework/runtime version from its own source-of-truth files. This
-# is what catches an app rename or a moved manifest before a real run does.
+# Tests for run-crud-all.sh. Sourcing runs the derivation code but not the
+# orchestration (main is guarded), so the test can drive run_one with fake
+# COMPOSE / inspect_limits / run_crud / wait_healthy and assert the contracts
+# the README claims: the framework key matches the harness, the inspect verdict
+# is what gets recorded, the SUT is stopped before the next app, and an inspect
+# TOOL failure never publishes a blank resource_limits.
 #
 #   bash benchmarks/scripts/run-crud-all_test.sh
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
-
-# Sourcing runs the derivation code but not the orchestration (main guard).
+# shellcheck source=/dev/null
 APPS="" source benchmarks/scripts/run-crud-all.sh
 
 fail=0
-for app in gin-gorm gombit django rails laravel nestjs; do
+note() { echo "FAIL: $*" >&2; fail=1; }
+
+# ---- 1. identity tuples: framework == compose service name (the merge key) ----
+# port/runtime pinned; framework MUST equal the service name so a run-crud row
+# merges under the same key the rest of the harness (and the standalone recipe)
+# uses — recording "gin" here would be a second identity for gin-gorm.
+check_identity() {
+  local app="$1" want_port="$2" want_rt="$3"
   app_identity "$app"
-  for pair in "PORT=$PORT" "FRAMEWORK=$FRAMEWORK" "FRAMEWORK_VERSION=$FRAMEWORK_VERSION" \
-              "RUNTIME=$RUNTIME" "RUNTIME_VERSION=$RUNTIME_VERSION"; do
-    if [ -z "${pair#*=}" ]; then
-      echo "FAIL: $app has empty ${pair%%=*}" >&2
-      fail=1
-    fi
-  done
-  # A version should start with a digit or 'v' — a stray label would sail past
-  # the non-empty check but is not a version.
-  case "$FRAMEWORK_VERSION" in
-    [0-9]*|v[0-9]*) : ;;
-    *) echo "FAIL: $app framework_version '$FRAMEWORK_VERSION' is not version-shaped" >&2; fail=1 ;;
-  esac
-  echo "ok: $app -> $FRAMEWORK $FRAMEWORK_VERSION / $RUNTIME $RUNTIME_VERSION (:$PORT)"
-done
+  [ "$FRAMEWORK" = "$app" ] || note "$app: FRAMEWORK=$FRAMEWORK, want $app (the merge key)"
+  [ "$PORT" = "$want_port" ] || note "$app: PORT=$PORT, want $want_port"
+  [ "$RUNTIME" = "$want_rt" ] || note "$app: RUNTIME=$RUNTIME, want $want_rt"
+  case "$FRAMEWORK_VERSION" in [0-9]*|v[0-9]*) : ;; *) note "$app: framework_version '$FRAMEWORK_VERSION' not version-shaped" ;; esac
+  [ -n "$RUNTIME_VERSION" ] || note "$app: empty runtime_version"
+}
+check_identity gin-gorm 8081 go
+check_identity gombit   8080 go
+check_identity django   8082 python
+check_identity rails    8083 ruby
+check_identity laravel  8084 php
+check_identity nestjs   8085 node
+
+# ---- fakes for driving run_one without Docker / Go ----
+CALLS=()
+fake_compose() {
+  # `ps -q <svc>` must return a container id; everything else is recorded.
+  if [ "$1" = ps ]; then echo "cid-$3"; return 0; fi
+  CALLS+=("compose $*")
+}
+called() { printf '%s\n' "${CALLS[@]}" | grep -qF "$1"; }
+
+# ---- 2. happy path: inspect verdict is recorded, SUT stopped ----
+CALLS=()
+COMPOSE=(fake_compose)
+wait_healthy() { CALLS+=("wait_healthy $1"); return 0; }
+inspect_limits() { printf 'enforced: cpu 2.00 vCPU, memory 1 GiB'; }
+RUN_CRUD_ARGS=""
+run_crud() { RUN_CRUD_ARGS="$*"; CALLS+=("run_crud"); }
+
+run_one gin-gorm
+
+called "compose build gin-gorm"      || note "did not build gin-gorm"
+called "compose run --rm gin-gorm migrate" || note "did not migrate gin-gorm"
+called "compose run --rm gin-gorm seed"    || note "did not seed gin-gorm"
+called "wait_healthy cid-gin-gorm"   || note "did not wait for health"
+called "run_crud"                    || note "did not run run_crud"
+called "compose stop gin-gorm"       || note "did not stop gin-gorm before next"
+# the recorded resource_limits is exactly the inspect verdict, and the framework
+# key is the service name.
+case "$RUN_CRUD_ARGS" in
+  *"-framework gin-gorm "*) : ;;
+  *) note "run_crud framework is not the merge key gin-gorm: $RUN_CRUD_ARGS" ;;
+esac
+case "$RUN_CRUD_ARGS" in
+  *"-resource-limits enforced: cpu 2.00 vCPU, memory 1 GiB"*) : ;;
+  *) note "run_crud did not receive the inspect verdict as -resource-limits: $RUN_CRUD_ARGS" ;;
+esac
+
+# ---- 3. inspect TOOL failure must NOT publish a row, but still stop the SUT ----
+CALLS=()
+RAN_CRUD=0
+inspect_limits() { echo "inspect-limits: boom" >&2; return 2; }
+run_crud() { RAN_CRUD=1; }
+rc=0
+run_one gombit || rc=$?
+[ "$rc" -ne 0 ]        || note "run_one should fail when inspect-limits fails"
+[ "$RAN_CRUD" -eq 0 ]  || note "run_crud ran despite inspect failure (would publish a blank resource_limits)"
+called "compose stop gombit" || note "SUT not stopped after inspect failure"
 
 if [ "$fail" -ne 0 ]; then
   echo "run-crud-all_test: FAILED" >&2
   exit 1
 fi
-echo "run-crud-all_test: all six identities resolve"
+echo "run-crud-all_test: identity tuples, inspect consumption, stop-before-next, and fail-closed inspect all pass"

--- a/benchmarks/scripts/run-crud/main.go
+++ b/benchmarks/scripts/run-crud/main.go
@@ -11,11 +11,11 @@
 // errors, failed content checks) fails the command loudly with nothing written
 // (issue #141 §10).
 //
-// It does NOT start or resource-constrain the app; the recorded
-// resource_limits therefore says so honestly. The full make benchmark-crud
-// that brings all six apps up under compose with the §7 limits and loops this
-// over them is the next slice; this is the per-implementation engine, verified
-// end-to-end against benchmarks/apps/gin-gorm.
+// It does NOT start or resource-constrain the app; run standalone, the recorded
+// resource_limits therefore says so honestly. This is the per-implementation
+// engine: `make benchmark-crud-all` (benchmarks/scripts/run-crud-all.sh) brings
+// all six apps up under compose with the §7 limits, records each container's
+// applied-limit classification, and loops this over them.
 package main
 
 import (

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -163,8 +163,9 @@ SQLite/PostgreSQL/MySQL matrix green throughout (AGENTS.md §5.1).
 - Add the BENCH-1 backlog entry (§2). — **done**
 - Create the `benchmarks/` directory tree (§5); `micro/` landed in Phase 2,
   `apps/` in Phase 3-4, and `internal/`, `scripts/`, `config/`, `results/`,
-  `docs/` now exist (`workloads/` and the `make benchmark-*` orchestration are
-  still open, next slice).
+  `docs/` now exist; `workloads/crud-list.js` and the
+  `benchmark-crud`/`-crud-all`/`-summary`/`-metadata` targets exist too (the
+  remaining `benchmark-*` workloads are later slices).
 - Implement the result schema + metadata collector in `benchmarks/internal/`
   — **done.** `benchmarks/internal/result` is the `results.json` schema (issue
   §9's recommended shape plus a `schema_version`), with JSON and CSV encoders
@@ -190,7 +191,8 @@ SQLite/PostgreSQL/MySQL matrix green throughout (AGENTS.md §5.1).
 - **AC:** `go build ./benchmarks/...` succeeds (it does, including the new
   packages, and `go test ./...` covers their unit tests); `docs/GOMBIT_BUILD_PLAN.md`
   has the new entry. Satisfied for the schema/collector/config; the
-  `make benchmark-*` orchestration that consumes them is the next slice.
+  `benchmark-crud`/`-crud-all`/`-summary`/`-metadata` orchestration that consumes
+  them now exists (the remaining `benchmark-*` workloads are later slices).
 
 **Post-landing correction, round 2 (review on PR #183,
 github.com/gombit-dev/gombit/pull/183#pullrequestreview-5034497111):** the
@@ -1453,12 +1455,22 @@ in:
   host with k6. `run-crud` merges by framework, so the six iterations accumulate
   into one `results.json` for `make benchmark-summary`. Every app's
   framework/runtime version is **derived** from its own source-of-truth (manifest
-  file, Dockerfile base image), fail-closed on empty, so nothing is hand-copied;
-  `gin-gorm` gained a no-op `migrate` verb so the uniform migrate/seed/serve
-  drive works (it AutoMigrates). The script guards its main loop so it is
-  sourceable, and `run-crud-all_test.sh` asserts all six identities resolve to
-  version-shaped strings. Verified end to end: a reduced-parameter `run_one
-  gin-gorm` builds/migrates/seeds/serves, reaches healthy, records
+  file, Dockerfile base image), fail-closed on empty, so nothing is hand-copied.
+  The framework key is the compose **service name** (`gin-gorm`, not `gin`), the
+  same merge key the rest of the harness uses. §7 is detect/report, so the loop
+  records the honest classification (enforced/partial/not-applied) — but an
+  `inspect-limits` *tool* failure does not publish a blank row (that app is
+  skipped and the run fails), and the SUT is always stopped before the next app
+  even when a step fails. Workload pins (`CONCURRENCY`/`TRIALS`/…) are
+  overridable on the command line (the script loads `versions.env` only for vars
+  not already in the environment). `gin-gorm` gained a no-op `migrate` verb so
+  the uniform migrate/seed/serve drive works (it AutoMigrates). The script guards
+  its main loop so it is sourceable, and `run-crud-all_test.sh` drives `run_one`
+  with fake compose/inspect/run-crud to assert the merge key, that the inspect
+  verdict is what gets recorded, stop-before-next, and that a failed inspect
+  publishes no row — plus the six exact `(framework, port, runtime)` tuples.
+  Verified end to end too: a reduced-parameter run against `gin-gorm`
+  builds/migrates/seeds/serves, reaches healthy, records
   `enforced: cpu 2.00 / memory 1 GiB`, runs k6 (errors=0), and merges the rows.
   The remaining Phase 6 work is the per-app footprint capture below.
 - `benchmarks/internal/reslimits` + `benchmarks/scripts/inspect-limits`: the
@@ -1474,10 +1486,10 @@ in:
   and the CLI's `-strict` fail-closed exit + output formats via the
   `-inspect-file` seam. Verified end to end against a live container (enforced
   `NanoCpus=2e9`/`Memory=1GiB`; a genuinely unlimited `docker run` reads `not
-  applied`). **Not yet wired:** nothing consumes the string — `run-crud` still
-  records its own honest "not applied" default. Recording the verdict into
-  `metadata.resource_limits` (the six-app loop, or `run-crud -resource-limits`)
-  is a later slice.
+  applied`). At the time of this correction nothing consumed the string; the
+  `make benchmark-crud-all` loop later closed that — it passes each app's verdict
+  to `run-crud -resource-limits`, so a run records the applied limit (standalone
+  `run-crud` still records its own honest "not applied" default).
 - **Empirical correction to the plan's own assumption:** the `compose.yml`
   comment (and this plan's earlier framing) claimed a plain `docker compose up`
   "silently ignores" `deploy.resources.limits` and that `--compatibility` or

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1196,8 +1196,9 @@ real MAJOR findings, all confirmed and fixed.
 ### Phase 5 — Workload depth: auth overhead, TechEmpower-inspired, concurrency sweep
 
 **Headline CRUD-read workload + `make benchmark-crud` — the per-implementation
-measurement engine — done; the all-six compose loop and footprint capture are
-the next slices.**
+measurement engine — done; the all-six compose loop (`make benchmark-crud-all`)
+is done too (see the Phase 6 bullets), and footprint capture is the remaining
+slice.**
 
 - `benchmarks/workloads/crud-list.js`: the headline `GET /api/projects?page=1&limit=20`
   workload (issue §"Required headline workload"), run by the pinned k6 image
@@ -1232,12 +1233,12 @@ the next slices.**
   container runs as the invoking uid so the mounted summary file is writable.
   `cpu_percent`/`rss_bytes` stay 0 — per-app footprint (and enforcing/observing
   the §7 limits) is the compose loop / Phase 6, not this engine.
-- **Still open in Phase 5:** the loop that brings all six apps up under compose
-  (with the §7 resource limits) and runs `run-crud` over each; the auth,
-  TechEmpower-inspired, and concurrency-sweep workloads below; and the
-  CoV summarization the AC's "trial variance recorded" needs — **done** (see
-  the summarizer note below); still open is the multi-app loop that produces a
-  full six-framework `results.json` for it to summarize.
+- **Phase 5 follow-through:** the multi-app loop that brings all six apps up
+  under compose (with the §7 resource limits) and runs `run-crud` over each into
+  a full six-framework `results.json` is **done** (`make benchmark-crud-all`, see
+  the Phase 6 bullets); the CoV summarization is **done** (the summarizer note
+  below). Still open: the auth, TechEmpower-inspired, and concurrency-sweep
+  workloads below.
 
 **Trial-variance summarizer (`benchmarks/internal/summary` + `summarize` /
 `make benchmark-summary`) — done.** Reads `results.json`, groups the trial
@@ -1473,6 +1474,11 @@ in:
   builds/migrates/seeds/serves, reaches healthy, records
   `enforced: cpu 2.00 / memory 1 GiB`, runs k6 (errors=0), and merges the rows.
   The remaining Phase 6 work is the per-app footprint capture below.
+  Two follow-up review rounds on PR #192 fixed the framework key (`gin-gorm`, not
+  `gin`), the `|| true` blank-limit / no-trap bug, the Make override, weak tests,
+  and — across the whole benchmarks tree, not just the named paragraphs — every
+  present-tense claim that the loop is future work or that the recorded limit is
+  "enforced" rather than the honest detect/report classification.
 - `benchmarks/internal/reslimits` + `benchmarks/scripts/inspect-limits`: the
   issue's "detect and report rather than silently pretend limits were applied"
   requirement. A compose budget is only an *intention*; the tool reads the

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1443,9 +1443,24 @@ in:
   envelope (`total: 100000`), inspect-limits `enforced`. **All six
   implementations are now containerized** — two Go apps + four ecosystem apps,
   each a `compose.yml` service under the §7 budget with a `/livez` health check
-  and idempotent per-app database provisioning. The remaining Phase 6 work is
-  the orchestration loop that brings them up and runs `run-crud` over each into
-  one `results.json`, plus the footprint capture below.
+  and idempotent per-app database provisioning.
+- **Orchestration loop (`benchmarks/scripts/run-crud-all.sh` +
+  `make benchmark-crud-all`) — done.** Brings each app up under compose,
+  applies its migrate/seed verbs, waits for `/livez` healthy, reads the applied
+  limit off the live container (`inspect-limits`) and records it as
+  `metadata.resource_limits` — closing the #186 "verdict not yet consumed" gap —
+  runs `run-crud` against it, then stops it so only the app under test shares the
+  host with k6. `run-crud` merges by framework, so the six iterations accumulate
+  into one `results.json` for `make benchmark-summary`. Every app's
+  framework/runtime version is **derived** from its own source-of-truth (manifest
+  file, Dockerfile base image), fail-closed on empty, so nothing is hand-copied;
+  `gin-gorm` gained a no-op `migrate` verb so the uniform migrate/seed/serve
+  drive works (it AutoMigrates). The script guards its main loop so it is
+  sourceable, and `run-crud-all_test.sh` asserts all six identities resolve to
+  version-shaped strings. Verified end to end: a reduced-parameter `run_one
+  gin-gorm` builds/migrates/seeds/serves, reaches healthy, records
+  `enforced: cpu 2.00 / memory 1 GiB`, runs k6 (errors=0), and merges the rows.
+  The remaining Phase 6 work is the per-app footprint capture below.
 - `benchmarks/internal/reslimits` + `benchmarks/scripts/inspect-limits`: the
   issue's "detect and report rather than silently pretend limits were applied"
   requirement. A compose budget is only an *intention*; the tool reads the


### PR DESCRIPTION
## Summary

The capstone of the Phase 6 compose loop: **`make benchmark-crud-all`** brings
every containerized implementation up and produces one six-framework
`results.json`.

`benchmarks/scripts/run-crud-all.sh`, per app: builds the image, runs its
`migrate`/`seed` verbs (each app creates its own database idempotently), brings
the service up under its §7 cgroup budget, waits for `/livez` healthy, reads the
**actually applied** limit off the live container (`inspect-limits`, recorded as
`metadata.resource_limits`), runs the existing `run-crud` engine against it, then
**stops** it so only the app under test shares the host with k6. `run-crud`
merges by framework, so the six iterations accumulate into one snapshot for
`make benchmark-summary`.

Key design choices:

- **Versions are derived, not hand-copied.** Each app's framework version comes
  from its own source-of-truth (go.mod / requirements.txt / Gemfile.lock /
  composer.json / package.json / `git describe`) and its runtime version from the
  Dockerfile base image tag — **fail-closed** if any resolves empty. No second
  pin to drift from the apps.
- **Closes the #186 gap**: the `inspect-limits` verdict was produced but never
  consumed; the loop now records it into the run.
- `gin-gorm` gains a **no-op `migrate` verb** (it AutoMigrates) so the uniform
  migrate/seed/serve drive works for it too.
- The script **guards its main loop** (`BASH_SOURCE`) so it's sourceable, and
  `run-crud-all_test.sh` asserts all six identities resolve to version-shaped
  strings.

Closes #141 — partial (one Phase 6 slice; the issue stays open).

## Acceptance criteria

- [x] `make benchmark-crud-all` orchestrates all six under compose into one
      `results.json`, recording the enforced §7 limit per app.
- [ ] Per-app resource/RSS footprint capture (`benchmark-footprint`) — the
      remaining Phase 6 slice.

## Scope notes

Deferred: per-app `cpu_percent`/`rss_bytes` footprint capture, and the other
`make benchmark-*` workloads. The orchestrator is shell (docker-compose glue);
the measured logic it drives — `run-crud`, `internal/k6`, `internal/reslimits`,
`internal/summary` — is Go and already unit-tested. The one testable piece here,
version derivation, has `run-crud-all_test.sh`.

## Validation

- [x] `go build ./...`; `docker compose ... config` valid
- [x] `bash benchmarks/scripts/run-crud-all_test.sh` — all six identities resolve
      (gin v1.12.0/go1.25.7, gombit git-describe/go1.25.7, django 5.2.17/3.12,
      rails 8.1.3.1/3.3.12, laravel 13.29.0/8.3, nestjs 11.2.3/24)
- [x] End to end (reduced params, `run_one gin-gorm`): build → `migrate` (no-op)
      → seed → up → `/livez` healthy → `inspect-limits` = "enforced: cpu 2.00 /
      memory 1 GiB" → k6 run (errors=0) → 2 rows merged into `results.json` with
      the derived identity, and `metadata.resource_limits` = the enforced verdict.
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests — `run-crud-all_test.sh` (identity derivation); the
      Go engine it drives is already unit-tested. DB matrix: N/A (no Go/schema
      change).
- [x] Stable features ship docs and appear in an example app — `benchmarks/README`
      running section + tree, plan Phase 6 note; drives all six example apps.
- [x] Extraction preserves contracts — N/A: new orchestration, reuses run-crud.
- [ ] Generators — N/A.
- [ ] API changes regenerate OpenAPI + TS client — N/A.
- [x] No secrets in generated frontend source — N/A.
- [x] Scope stays inside this issue's milestone — M6/BENCH-1; no battery creep.
- [x] Links its issue and states which acceptance criteria it satisfies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
