### PR TITLE
feat: BENCH-1 operational footprint (cold-start, RSS, CPU) for all six containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,18 @@ OUT_DIR ?= benchmarks/results/latest
 # applied verdict per app (via inspect-limits).
 INTENDED_LIMITS ?= intended (applied only under benchmark-crud-all): app $(APP_CPUS)cpu/$(APP_MEMORY); postgres $(POSTGRES_CPUS)cpu/$(POSTGRES_MEMORY)
 
-.PHONY: benchmark-crud benchmark-crud-all benchmark-summary benchmark-metadata
+.PHONY: benchmark-crud benchmark-crud-all benchmark-footprint benchmark-summary benchmark-metadata
+
+## benchmark-footprint: measure the operational footprint (container-start cold
+## start median/p95, idle memory, memory + CPU under load) of all six
+## containerized apps into OUT_DIR/footprint.{json,csv}. Reduce COLD_START_RUNS /
+## LOAD_SECONDS for a smoke; APPS="gin-gorm gombit" narrows the set. The
+## embedded-Gombit single-binary variant is a follow-up slice.
+##
+##   make benchmark-footprint
+##   make benchmark-footprint COLD_START_RUNS=3 APPS=gin-gorm   # smoke
+benchmark-footprint:
+	OUT_DIR="$(OUT_DIR)" bash benchmarks/scripts/footprint-all.sh
 
 ## benchmark-crud-all: bring every containerized implementation up under compose
 ## (with the §7 limits), migrate + seed it, classify + record the applied limit

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -27,6 +27,7 @@ benchmarks/
 │   ├── run-crud-all.sh    orchestrates run-crud over all six containerized apps (make benchmark-crud-all)
 │   ├── footprint/         records one footprint row into footprint.{json,csv} (merge by framework,variant)
 │   ├── footprint-all.sh   measures cold-start/RSS/CPU for all six containers (make benchmark-footprint)
+│   ├── k6load/            drives validated crud-list load for the footprint loaded/CPU sampling (fail-closed)
 │   ├── summarize/         results.json -> summary.md (make benchmark-summary)
 │   └── inspect-limits/    reports whether a live container got the §7 ceiling (uses internal/reslimits)
 ├── micro/                Go abstraction-overhead microbenchmarks (Phase 2)
@@ -157,9 +158,8 @@ the app, so its default `metadata.resource_limits` says so honestly; under
 `benchmark-crud-all` the app runs in its §7-limited container and the loop passes
 the live `inspect-limits` verdict, so the recorded value is that container's
 classification (`enforced` / `partial` / `not applied`), not an assumption that
-the ceiling held.
-Per-app `cpu_percent`/`rss_bytes` footprint capture is still a later Phase 6
-slice.
+the ceiling held. Per-app memory/CPU footprint is captured separately by
+`make benchmark-footprint` (below).
 
 Once `results.json` exists, `make benchmark-summary` regenerates `summary.md`
 from it — one table per benchmark, one row per (framework, concurrency). The
@@ -184,14 +184,21 @@ budget, seeds it, and records into `benchmarks/results/latest/footprint.{json,cs
 - **cold-start** — container-start → first `200` on `/livez`, repeated
   `COLD_START_RUNS` times (default 20, the issue's "≥20 runs"), reported as
   median and p95;
-- **idle memory** — the container's cgroup working set (`docker stats`) after it
-  settles, recorded as `idle_rss_bytes`;
-- **loaded memory + CPU** — peak working set and peak CPU while the crud-list
-  workload drives it;
+- **idle memory** — the container's cgroup working set (`docker stats`) after an
+  `IDLE_SETTLE`-second settle (default 10, the issue's suggestion), recorded as
+  `idle_rss_bytes`;
+- **loaded memory + CPU** — the **steady-state median** working set and CPU
+  sampled once per second *while the crud-list workload drives the app*. The
+  load is run through `benchmarks/scripts/k6load`, which keeps and validates the
+  k6 summary (`benchmarks/internal/k6`'s `Summary.Validate`): if k6 sends no
+  traffic, errors, or fails a content check, the load is rejected and **no
+  loaded/CPU row is published** — the same fail-closed rule as `run-crud`, so an
+  idle sample can never masquerade as a loaded one. The k6 image is pre-pulled
+  so no pull lands inside the measured window;
 - **image size** — the container image's on-disk size.
 
-Reduce the cost for a smoke with `COLD_START_RUNS=3 LOAD_SECONDS=3`, and narrow
-the set with `APPS="gin-gorm gombit"`. The **embedded-Gombit** single-binary
+Reduce the cost for a smoke with `COLD_START_RUNS=3 LOAD_SECONDS=4 IDLE_SETTLE=1`,
+and narrow the set with `APPS="gin-gorm gombit"`. The **embedded-Gombit** single-binary
 variant (`gombit build --embed`: binary + image size, cold start, idle memory)
 is a follow-up slice — the footprint schema and CLI already carry it (`variant`
 `embedded`, `binary_size_bytes`); only the frontend-embedding build is not wired

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,13 +17,16 @@ benchmarks/
 │   ├── metadata/         reproducibility metadata struct + host/toolchain collector
 │   ├── k6/               parses a crud-list.js summary into result rows (+ Validate)
 │   ├── summary/          aggregates trials into per-group stats + renders summary.md (CoV flag)
-│   └── reslimits/        classifies a container's Docker-recorded limits (HostConfig) vs the §7 budget (honest detection)
+│   ├── reslimits/        classifies a container's Docker-recorded limits (HostConfig) vs the §7 budget (honest detection)
+│   └── footprint/        operational-footprint schema (cold-start/RSS/CPU) + encoders
 ├── workloads/
 │   └── crud-list.js      the headline GET /api/projects read workload (k6)
 ├── scripts/
 │   ├── collect-host-info/ CLI over internal/metadata: writes metadata.json for a run
 │   ├── run-crud/          runs crud-list.js (via the pinned k6 image) against one app → results snapshot
 │   ├── run-crud-all.sh    orchestrates run-crud over all six containerized apps (make benchmark-crud-all)
+│   ├── footprint/         records one footprint row into footprint.{json,csv} (merge by framework,variant)
+│   ├── footprint-all.sh   measures cold-start/RSS/CPU for all six containers (make benchmark-footprint)
 │   ├── summarize/         results.json -> summary.md (make benchmark-summary)
 │   └── inspect-limits/    reports whether a live container got the §7 ceiling (uses internal/reslimits)
 ├── micro/                Go abstraction-overhead microbenchmarks (Phase 2)
@@ -53,8 +56,10 @@ every bring-up (no fresh-volume init scripts) — and `make benchmark-crud-all`
 brings each up, seeds it, classifies the applied §7 ceiling on the live
 container and records it (`internal/reslimits` + `scripts/inspect-limits`, issue
 #141's "detect/report rather than silently pretend"), runs the workload, and
-merges all six into one `results.json`. Still scoped to later phases:
-`docs/methodology.md`, per-app resource/RSS capture (Phase 6 footprint), the
+merges all six into one `results.json`. `make benchmark-footprint` captures the
+operational footprint (cold-start, idle/loaded memory, CPU-under-load) of the
+same six containers into `footprint.json`. Still scoped to later phases:
+`docs/methodology.md`, the embedded-Gombit single-binary footprint variant, the
 other `make benchmark-*` workloads, and extending `fairness_test.go` to all six.
 
 ## Resource limits (§7): intention vs. reality
@@ -165,6 +170,32 @@ on any group whose trials vary by more than 5% (issue §7). The Markdown is
 generated from the structured rows, never hand-edited, and leads with the
 coordinated-omission / same-host caveats so a copied table can't be read as
 more than it is.
+
+## Running the operational footprint
+
+```sh
+make benchmark-footprint      # all six; writes footprint.json/.csv
+```
+
+For each of the six containerized apps this brings the service up under its §7
+budget, seeds it, and records into `benchmarks/results/latest/footprint.{json,csv}`
+(a schema separate from throughput — `benchmarks/internal/footprint`):
+
+- **cold-start** — container-start → first `200` on `/livez`, repeated
+  `COLD_START_RUNS` times (default 20, the issue's "≥20 runs"), reported as
+  median and p95;
+- **idle memory** — the container's cgroup working set (`docker stats`) after it
+  settles, recorded as `idle_rss_bytes`;
+- **loaded memory + CPU** — peak working set and peak CPU while the crud-list
+  workload drives it;
+- **image size** — the container image's on-disk size.
+
+Reduce the cost for a smoke with `COLD_START_RUNS=3 LOAD_SECONDS=3`, and narrow
+the set with `APPS="gin-gorm gombit"`. The **embedded-Gombit** single-binary
+variant (`gombit build --embed`: binary + image size, cold start, idle memory)
+is a follow-up slice — the footprint schema and CLI already carry it (`variant`
+`embedded`, `binary_size_bytes`); only the frontend-embedding build is not wired
+into the orchestrator yet.
 
 ## Running the framework-tax matrix
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -187,14 +187,17 @@ budget, seeds it, and records into `benchmarks/results/latest/footprint.{json,cs
 - **idle memory** — the container's cgroup working set (`docker stats`) after an
   `IDLE_SETTLE`-second settle (default 10, the issue's suggestion), recorded as
   `idle_rss_bytes`;
-- **loaded memory + CPU** — the **steady-state median** working set and CPU
-  sampled once per second *while the crud-list workload drives the app*. The
-  load is run through `benchmarks/scripts/k6load`, which keeps and validates the
-  k6 summary (`benchmarks/internal/k6`'s `Summary.Validate`): if k6 sends no
-  traffic, errors, or fails a content check, the load is rejected and **no
-  loaded/CPU row is published** — the same fail-closed rule as `run-crud`, so an
-  idle sample can never masquerade as a loaded one. The k6 image is pre-pulled
-  so no pull lands inside the measured window;
+- **loaded memory + CPU** — the **steady-state median** working set and CPU,
+  sampled once per `docker stats` tick (~1s) *while the crud-list workload drives
+  the app*, dropping the first (ramp) sample. Fail-closed on two fronts: the load
+  is run through `benchmarks/scripts/k6load`, which keeps and validates the k6
+  summary (`benchmarks/internal/k6`'s `Summary.Validate`) — no traffic, any HTTP
+  error, or a failed content check rejects the load; and the aggregator refuses
+  to publish unless at least two in-load samples remain, so a missing/one-sample
+  series can never become a `0`-byte "loaded" reading. Either failure means **no
+  loaded/CPU row is published** — the same rule as `run-crud`. The k6 image is
+  pre-pulled and `k6load` pre-built so neither a pull nor a Go compile lands
+  inside the measured window;
 - **image size** — the container image's on-disk size.
 
 Reduce the cost for a smoke with `COLD_START_RUNS=3 LOAD_SECONDS=4 IDLE_SETTLE=1`,

--- a/benchmarks/apps/gin-gorm/README.md
+++ b/benchmarks/apps/gin-gorm/README.md
@@ -107,7 +107,8 @@ details, including one discovered framework gap and two bugs the fairness
 comparison caught. All six apps are now containerized with `benchmarks/compose.yml`
 services carrying the §7 budget (see [Run](#run) above), and
 `make benchmark-crud-all` brings each up, records the live `inspect-limits`
-verdict as `metadata.resource_limits`, and runs `run-crud` over each. Still open:
-wiring the fairness check into automated CI (it needs both databases at the full
-canonical 1,000/100,000 scale, deferred to Phase 8's lighter-seed CI work) and
-the per-app operational-footprint capture (Phase 6).
+verdict as `metadata.resource_limits`, and runs `run-crud` over each;
+`make benchmark-footprint` captures the container footprint (cold-start,
+memory, CPU). Still open: wiring the fairness check into automated CI (it needs
+both databases at the full canonical 1,000/100,000 scale, deferred to Phase 8's
+lighter-seed CI work) and the embedded-Gombit single-binary footprint variant.

--- a/benchmarks/internal/footprint/footprint.go
+++ b/benchmarks/internal/footprint/footprint.go
@@ -1,0 +1,215 @@
+// Package footprint is the schema and encoders for the operational-footprint
+// half of the benchmark (issue #141 §"Operational footprint"): cold-start,
+// idle/loaded memory, and CPU-under-load per implementation, plus the
+// single-binary numbers (binary + image size) for the embedded-Gombit variant.
+//
+// It is deliberately separate from benchmarks/internal/result (throughput /
+// latency): those rows answer "how fast", these answer "how heavy to deploy",
+// and cold-start median/p95 has no natural home in a requests-per-second row.
+// The measurement orchestration (Docker start timing, `docker stats` sampling)
+// lives in benchmarks/scripts; this package owns only the schema, the
+// cold-start statistics, and the JSON/CSV encoding, so those are unit-tested
+// without Docker.
+package footprint
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strconv"
+)
+
+// SchemaVersion is bumped on any breaking change to the row shape (issue §9).
+const SchemaVersion = 1
+
+// Variants of a measured artifact.
+const (
+	// VariantContainer is an app served from its normal container image.
+	VariantContainer = "container"
+	// VariantEmbedded is the Gombit single binary from `gombit build --embed`
+	// (API + admin + frontend in one process) — the headline
+	// single-binary-deployment number.
+	VariantEmbedded = "embedded"
+)
+
+// ColdStart is the distribution of container-start → ready (first 200 on
+// /livez) latency across repeated starts. Median and p95 are reported (issue
+// requires "≥20 runs, median/p95"); Runs records how many samples backed them.
+type ColdStart struct {
+	MedianMs float64 `json:"median_ms"`
+	P95Ms    float64 `json:"p95_ms"`
+	Runs     int     `json:"runs"`
+}
+
+// Footprint is one implementation's operational-footprint row.
+//
+// Memory is the container's cgroup working set as reported by `docker stats`
+// (usage minus reclaimable page cache) — the standard container-footprint proxy
+// for RSS, recorded in bytes. BinarySizeBytes is set only for the embedded
+// Gombit variant (a container app has no single deploy binary to weigh).
+type Footprint struct {
+	SchemaVersion       int       `json:"schema_version"`
+	Framework           string    `json:"framework"`
+	FrameworkVersion    string    `json:"framework_version"`
+	Runtime             string    `json:"runtime"`
+	RuntimeVersion      string    `json:"runtime_version"`
+	Variant             string    `json:"variant"`
+	ColdStart           ColdStart `json:"cold_start_ms"`
+	IdleRSSBytes        int64     `json:"idle_rss_bytes"`
+	LoadedRSSBytes      int64     `json:"loaded_rss_bytes"`
+	CPUPercentUnderLoad float64   `json:"cpu_percent_under_load"`
+	ImageSizeBytes      int64     `json:"image_size_bytes"`
+	BinarySizeBytes     int64     `json:"binary_size_bytes,omitempty"`
+}
+
+// Key identifies a row for merge/replace: one implementation per variant.
+func (f Footprint) Key() string { return f.Framework + "\x00" + f.Variant }
+
+// ComputeColdStart returns the median, p95, and count of a set of cold-start
+// samples (milliseconds). An empty set is a zero distribution.
+func ComputeColdStart(samplesMs []float64) ColdStart {
+	n := len(samplesMs)
+	if n == 0 {
+		return ColdStart{}
+	}
+	s := append([]float64(nil), samplesMs...)
+	sort.Float64s(s)
+	return ColdStart{
+		MedianMs: percentile(s, 50),
+		P95Ms:    percentile(s, 95),
+		Runs:     n,
+	}
+}
+
+// percentile returns the p-th percentile (0-100) of a sorted slice using linear
+// interpolation between closest ranks. sorted must be non-empty.
+func percentile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 1 {
+		return sorted[0]
+	}
+	rank := (p / 100) * float64(n-1)
+	lo := int(math.Floor(rank))
+	hi := int(math.Ceil(rank))
+	if lo == hi {
+		return sorted[lo]
+	}
+	frac := rank - float64(lo)
+	return sorted[lo] + frac*(sorted[hi]-sorted[lo])
+}
+
+// Merge returns existing with the given framework+variant rows replaced by
+// incoming (rows for other keys are kept), so re-measuring one implementation
+// updates only its own rows. The result is sorted deterministically.
+func Merge(existing, incoming []Footprint) []Footprint {
+	replaced := make(map[string]bool, len(incoming))
+	for _, f := range incoming {
+		replaced[f.Key()] = true
+	}
+	out := make([]Footprint, 0, len(existing)+len(incoming))
+	for _, f := range existing {
+		if !replaced[f.Key()] {
+			out = append(out, f)
+		}
+	}
+	out = append(out, incoming...)
+	sortRows(out)
+	return out
+}
+
+func sortRows(rows []Footprint) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Framework != rows[j].Framework {
+			return rows[i].Framework < rows[j].Framework
+		}
+		return rows[i].Variant < rows[j].Variant
+	})
+}
+
+// WriteJSON encodes rows as indented JSON (the canonical footprint output).
+func WriteJSON(w io.Writer, rows []Footprint) error {
+	sorted := append([]Footprint(nil), rows...)
+	sortRows(sorted)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(sorted)
+}
+
+// ReadJSON decodes rows written by WriteJSON.
+func ReadJSON(r io.Reader) ([]Footprint, error) {
+	var rows []Footprint
+	if err := json.NewDecoder(r).Decode(&rows); err != nil {
+		return nil, fmt.Errorf("decode footprint json: %w", err)
+	}
+	return rows, nil
+}
+
+var csvHeader = []string{
+	"framework", "framework_version", "runtime", "runtime_version", "variant",
+	"cold_start_median_ms", "cold_start_p95_ms", "cold_start_runs",
+	"idle_rss_bytes", "loaded_rss_bytes", "cpu_percent_under_load",
+	"image_size_bytes", "binary_size_bytes",
+}
+
+// WriteCSV writes rows as CSV with a stable header and deterministic order.
+func WriteCSV(w io.Writer, rows []Footprint) error {
+	sorted := append([]Footprint(nil), rows...)
+	sortRows(sorted)
+	if _, err := fmt.Fprintln(w, joinCSV(csvHeader)); err != nil {
+		return err
+	}
+	for _, f := range sorted {
+		rec := []string{
+			f.Framework, f.FrameworkVersion, f.Runtime, f.RuntimeVersion, f.Variant,
+			formatFloat(f.ColdStart.MedianMs), formatFloat(f.ColdStart.P95Ms), strconv.Itoa(f.ColdStart.Runs),
+			strconv.FormatInt(f.IdleRSSBytes, 10), strconv.FormatInt(f.LoadedRSSBytes, 10),
+			formatFloat(f.CPUPercentUnderLoad),
+			strconv.FormatInt(f.ImageSizeBytes, 10), strconv.FormatInt(f.BinarySizeBytes, 10),
+		}
+		if _, err := fmt.Fprintln(w, joinCSV(rec)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func formatFloat(f float64) string { return strconv.FormatFloat(f, 'f', -1, 64) }
+
+// joinCSV joins fields with commas, quoting any that need it. Footprint fields
+// are simple (identifiers/numbers), but quote defensively for versions like
+// "v0.1.3-59-g...".
+func joinCSV(fields []string) string {
+	out := make([]byte, 0, 64)
+	for i, f := range fields {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = append(out, csvField(f)...)
+	}
+	return string(out)
+}
+
+func csvField(s string) string {
+	needQuote := false
+	for _, r := range s {
+		if r == ',' || r == '"' || r == '\n' || r == '\r' {
+			needQuote = true
+			break
+		}
+	}
+	if !needQuote {
+		return s
+	}
+	q := make([]byte, 0, len(s)+2)
+	q = append(q, '"')
+	for _, r := range s {
+		if r == '"' {
+			q = append(q, '"')
+		}
+		q = append(q, string(r)...)
+	}
+	q = append(q, '"')
+	return string(q)
+}

--- a/benchmarks/internal/footprint/footprint_test.go
+++ b/benchmarks/internal/footprint/footprint_test.go
@@ -1,0 +1,117 @@
+package footprint
+
+import (
+	"bytes"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestComputeColdStart(t *testing.T) {
+	// 1..9 ms: median 5, p95 = interpolate at rank 0.95*8=7.6 -> 8 + .6*(9-8)=8.6.
+	cs := ComputeColdStart([]float64{5, 1, 9, 3, 7, 2, 8, 4, 6})
+	if cs.Runs != 9 {
+		t.Errorf("Runs = %d, want 9", cs.Runs)
+	}
+	if math.Abs(cs.MedianMs-5) > 1e-9 {
+		t.Errorf("median = %v, want 5", cs.MedianMs)
+	}
+	if math.Abs(cs.P95Ms-8.6) > 1e-9 {
+		t.Errorf("p95 = %v, want 8.6", cs.P95Ms)
+	}
+}
+
+func TestComputeColdStartEdge(t *testing.T) {
+	if got := ComputeColdStart(nil); got != (ColdStart{}) {
+		t.Errorf("empty = %+v, want zero", got)
+	}
+	one := ComputeColdStart([]float64{42})
+	if one.MedianMs != 42 || one.P95Ms != 42 || one.Runs != 1 {
+		t.Errorf("single = %+v, want 42/42/1", one)
+	}
+}
+
+func TestMergeReplacesByFrameworkAndVariant(t *testing.T) {
+	existing := []Footprint{
+		{Framework: "gin-gorm", Variant: VariantContainer, IdleRSSBytes: 10},
+		{Framework: "gombit", Variant: VariantContainer, IdleRSSBytes: 20},
+		{Framework: "gombit", Variant: VariantEmbedded, IdleRSSBytes: 30},
+	}
+	// Re-measure gombit's container row only.
+	incoming := []Footprint{{Framework: "gombit", Variant: VariantContainer, IdleRSSBytes: 99}}
+	merged := Merge(existing, incoming)
+
+	if len(merged) != 3 {
+		t.Fatalf("len = %d, want 3", len(merged))
+	}
+	byKey := map[string]int64{}
+	for _, f := range merged {
+		byKey[f.Key()] = f.IdleRSSBytes
+	}
+	if byKey["gombit\x00container"] != 99 {
+		t.Errorf("gombit/container not replaced: %d", byKey["gombit\x00container"])
+	}
+	if byKey["gombit\x00embedded"] != 30 {
+		t.Errorf("gombit/embedded should be kept: %d", byKey["gombit\x00embedded"])
+	}
+	if byKey["gin-gorm\x00container"] != 10 {
+		t.Errorf("gin-gorm/container should be kept: %d", byKey["gin-gorm\x00container"])
+	}
+}
+
+func TestJSONRoundTripAndDeterministicOrder(t *testing.T) {
+	rows := []Footprint{
+		{SchemaVersion: SchemaVersion, Framework: "gombit", Variant: VariantEmbedded, BinarySizeBytes: 25_000_000},
+		{SchemaVersion: SchemaVersion, Framework: "gin-gorm", Variant: VariantContainer, IdleRSSBytes: 8_000_000},
+		{SchemaVersion: SchemaVersion, Framework: "gombit", Variant: VariantContainer, IdleRSSBytes: 12_000_000},
+	}
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, rows); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	encoded := buf.String() // ReadJSON drains buf, so keep the text for assertions
+	got, err := ReadJSON(&buf)
+	if err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	// Sorted by (framework, variant): gin-gorm/container, gombit/container, gombit/embedded.
+	wantOrder := []string{"gin-gorm\x00container", "gombit\x00container", "gombit\x00embedded"}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("len = %d, want %d", len(got), len(wantOrder))
+	}
+	for i, k := range wantOrder {
+		if got[i].Key() != k {
+			t.Errorf("row %d = %q, want %q", i, got[i].Key(), k)
+		}
+	}
+	// binary_size_bytes is omitted when zero, so it appears only in the one
+	// embedded row (the two container rows omit it).
+	if n := strings.Count(encoded, "binary_size_bytes"); n != 1 {
+		t.Errorf("binary_size_bytes appears %d times, want 1 (only the embedded row):\n%s", n, encoded)
+	}
+}
+
+func TestWriteCSV(t *testing.T) {
+	var buf bytes.Buffer
+	rows := []Footprint{{
+		Framework: "gombit", FrameworkVersion: "v0.1.3", Runtime: "go", RuntimeVersion: "go1.25.7",
+		Variant: VariantEmbedded, ColdStart: ColdStart{MedianMs: 12.5, P95Ms: 18, Runs: 20},
+		IdleRSSBytes: 15_000_000, ImageSizeBytes: 30_000_000, BinarySizeBytes: 25_000_000,
+	}}
+	if err := WriteCSV(&buf, rows); err != nil {
+		t.Fatalf("WriteCSV: %v", err)
+	}
+	out := buf.String()
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want header + 1 row, got %d lines:\n%s", len(lines), out)
+	}
+	if !strings.HasPrefix(lines[0], "framework,framework_version,") {
+		t.Errorf("bad header: %s", lines[0])
+	}
+	for _, want := range []string{"gombit", "v0.1.3", "embedded", "12.5", "18", "20", "25000000"} {
+		if !strings.Contains(lines[1], want) {
+			t.Errorf("row missing %q: %s", want, lines[1])
+		}
+	}
+}

--- a/benchmarks/results/README.md
+++ b/benchmarks/results/README.md
@@ -11,9 +11,11 @@ results/
 └── latest/
     ├── metadata.json   reproducibility metadata (benchmarks/internal/metadata)
     ├── raw/            per-trial raw load-generator output (k6 JSON, ...)
-    ├── results.json    the canonical structured results (benchmarks/internal/result)
+    ├── results.json    the canonical structured throughput results (benchmarks/internal/result)
     ├── results.csv     flat CSV derived from results.json
-    └── summary.md      human-readable tables derived from results.json
+    ├── summary.md      human-readable tables derived from results.json
+    ├── footprint.json  operational-footprint rows (benchmarks/internal/footprint)
+    └── footprint.csv   flat CSV derived from footprint.json
 ```
 
 `results.json` / `results.csv` are the machine-readable schema defined in

--- a/benchmarks/scripts/footprint-all.sh
+++ b/benchmarks/scripts/footprint-all.sh
@@ -27,6 +27,25 @@ APPS="${APPS:-gin-gorm gombit django rails laravel nestjs}"
 COLD_START_RUNS="${COLD_START_RUNS:-20}"
 LOAD_VUS="${LOAD_VUS:-100}"
 LOAD_SECONDS="${LOAD_SECONDS:-10}"
+IDLE_SETTLE="${IDLE_SETTLE:-10}" # issue #141's suggested settle before idle RSS
+
+# Seams over the Go tools so the orchestration can be driven with fakes in the
+# test. run_load drives *validated* load (k6load keeps + validates the summary
+# and exits non-zero on dirty/absent traffic — the load generator is the
+# authority for whether load happened); record_footprint writes the row.
+# run_load uses a PRE-BUILT k6load binary (K6LOAD_BIN, built once in main) rather
+# than `go run` so the ~1-2s Go compile does not delay k6's start and leave the
+# early samples reading an idle app. Falls back to `go run` if unset (tests
+# override this seam anyway).
+run_load() {
+  if [ -n "${K6LOAD_BIN:-}" ]; then "$K6LOAD_BIN" "$@"; else go run ./benchmarks/scripts/k6load "$@"; fi
+}
+record_footprint() { go run ./benchmarks/scripts/footprint "$@"; }
+
+# median_int / median_float read numbers on stdin and echo the median (integer
+# floored for byte counts). Empty input -> 0.
+median_int() { sort -n | awk '{a[NR]=$1} END{ if(NR==0){print 0;exit} if(NR%2){printf "%d", a[(NR+1)/2]} else {printf "%d", (a[NR/2]+a[NR/2+1])/2} }'; }
+median_float() { sort -n | awk '{a[NR]=$1} END{ if(NR==0){print 0;exit} if(NR%2){print a[(NR+1)/2]} else {print (a[NR/2]+a[NR/2+1])/2} }'; }
 
 # to_bytes converts a `docker stats` size token (45.2MiB, 1.1GiB, 900B, …) to an
 # integer byte count on stdin.
@@ -66,13 +85,43 @@ wait_ready_ms() {
   return 1
 }
 
-# generate_load TARGET_URL — drive the crud-list workload for LOAD_SECONDS at
-# LOAD_VUS (same env contract as run-crud), output discarded.
-generate_load() {
-  docker run --rm --network host \
-    -e TARGET_URL="$1" -e VUS="$LOAD_VUS" -e DURATION="${LOAD_SECONDS}s" \
-    -v "$ROOT/benchmarks/workloads/crud-list.js:/workload/crud-list.js:ro" \
-    "grafana/k6:$K6_VERSION" run --quiet /workload/crud-list.js >/dev/null 2>&1 || true
+# sample_stats CONTAINER FILE STOPFILE — until STOPFILE exists, append
+# "<mem_bytes> <cpu_pct>" once per second. Runs concurrently with the load so
+# the samples are provably taken while k6 is driving the app.
+sample_stats() {
+  while [ ! -f "$3" ]; do
+    printf '%s %s\n' "$(mem_bytes "$1")" "$(cpu_pct "$1")" >> "$2"
+    sleep 1
+  done
+}
+
+# measure_under_load CONTAINER TARGET_URL — echo "<loaded_rss_bytes> <cpu_pct>"
+# from steady-state samples taken *while validated load runs*, or fail (non-zero)
+# if the load was not a clean measurement — so a failed/absent k6 never yields a
+# loaded/CPU number. The load generator is the authority (k6load validates).
+measure_under_load() {
+  local cid="$1" turl="$2" sf stop spid load_ok=0
+  sf="$(mktemp)"; stop="$sf.stop"; rm -f "$stop"
+  sample_stats "$cid" "$sf" "$stop" &
+  spid=$!
+  # run_load's own output must not pollute this function's stdout (the caller
+  # captures it for "<loaded> <cpu>"); send it to stderr.
+  if run_load -target-url "$turl" -vus "$LOAD_VUS" -duration "${LOAD_SECONDS}s" \
+      -k6-image "grafana/k6:$K6_VERSION" -workload "$ROOT/benchmarks/workloads/crud-list.js" >&2; then
+    load_ok=1
+  fi
+  touch "$stop"; wait "$spid" 2>/dev/null || true
+
+  if [ "$load_ok" -ne 1 ]; then
+    rm -f "$sf" "$stop"
+    return 1
+  fi
+  # Drop the first sample (ramp) and report the steady-state median, not a peak.
+  local loaded cpu
+  loaded="$(tail -n +2 "$sf" | awk '{print $1}' | median_int)"
+  cpu="$(tail -n +2 "$sf" | awk '{print $2}' | median_float)"
+  rm -f "$sf" "$stop"
+  printf '%s %s' "$loaded" "$cpu"
 }
 
 # cold_start_samples APP LIVEZ_URL — echo COLD_START_RUNS comma-separated
@@ -88,43 +137,31 @@ cold_start_samples() {
   printf '%s' "$samples"
 }
 
-# measure_container APP — full container footprint for one app.
-measure_container() {
-  local app="$1" cid livez turl samples idle loaded cpu m c image
-  app_identity "$app"
+# do_measure APP CID — the measured half (cold-start, idle, load, record).
+# Called as `do_measure ... || rc`, so set -e is disabled inside it; every
+# failure a bad row could hide behind is checked explicitly, and a failed load
+# never publishes loaded/CPU (measure_under_load fails closed).
+do_measure() {
+  local app="$1" cid="$2" livez turl samples idle image loaded_cpu loaded cpu
   livez="http://127.0.0.1:${PORT}/livez"
   turl="http://127.0.0.1:${PORT}/api/projects?page=1&limit=20"
-  echo "=== footprint: $app ($FRAMEWORK_VERSION on $RUNTIME $RUNTIME_VERSION) ==="
 
-  "${COMPOSE[@]}" build "$app" >/dev/null
-  "${COMPOSE[@]}" run --rm "$app" migrate
-  "${COMPOSE[@]}" run --rm "$app" seed
-  "${COMPOSE[@]}" up -d "$app" >/dev/null
-  cid="$("${COMPOSE[@]}" ps -q "$app")"
-  wait_healthy "$cid"
+  wait_healthy "$cid" || return 1
+  samples="$(cold_start_samples "$app" "$livez")" || return 1
 
-  samples="$(cold_start_samples "$app" "$livez")"
+  sleep "$IDLE_SETTLE" # settle before reading idle memory
+  idle="$(mem_bytes "$cid")" || return 1
 
-  sleep 3 # settle before reading idle memory
-  idle="$(mem_bytes "$cid")"
+  loaded_cpu="$(measure_under_load "$cid" "$turl")" || {
+    echo "footprint: $app load was not a clean measurement; not publishing a row" >&2
+    return 1
+  }
+  loaded="${loaded_cpu% *}"
+  cpu="${loaded_cpu#* }"
 
-  # Under load: sample memory (peak) and CPU (peak) while k6 runs.
-  loaded=0
-  cpu=0
-  generate_load "$turl" &
-  local loadpid=$!
-  sleep 2
-  for _ in 1 2 3 4; do
-    m="$(mem_bytes "$cid")"; c="$(cpu_pct "$cid")"
-    [ "$m" -gt "$loaded" ] && loaded="$m"
-    cpu="$(awk -v a="$cpu" -v b="$c" 'BEGIN { print (b > a) ? b : a }')"
-    sleep 1
-  done
-  wait "$loadpid" 2>/dev/null || true
+  image="$(docker image inspect "$(docker inspect "$cid" --format '{{.Image}}')" --format '{{.Size}}')" || return 1
 
-  image="$(docker image inspect "$(docker inspect "$cid" --format '{{.Image}}')" --format '{{.Size}}')"
-
-  go run ./benchmarks/scripts/footprint \
+  record_footprint \
     -framework "$app" -framework-version "$FRAMEWORK_VERSION" \
     -runtime "$RUNTIME" -runtime-version "$RUNTIME_VERSION" \
     -variant container \
@@ -132,13 +169,38 @@ measure_container() {
     -idle-rss-bytes "$idle" -loaded-rss-bytes "$loaded" -cpu-percent "$cpu" \
     -image-size-bytes "$image" \
     -out "$OUT"
+}
 
+# measure_container APP — bring the app up, measure it, and ALWAYS stop it
+# before returning (even when do_measure fails under set -e), so the SUT never
+# shares the host with the next app's load. Mirrors run-crud-all.sh's run_one.
+measure_container() {
+  local app="$1" cid rc=0
+  app_identity "$app"
+  echo "=== footprint: $app ($FRAMEWORK_VERSION on $RUNTIME $RUNTIME_VERSION) ==="
+
+  "${COMPOSE[@]}" build "$app" >/dev/null
+  "${COMPOSE[@]}" run --rm "$app" migrate
+  "${COMPOSE[@]}" run --rm "$app" seed
+  "${COMPOSE[@]}" up -d "$app" >/dev/null
+  cid="$("${COMPOSE[@]}" ps -q "$app")"
+
+  do_measure "$app" "$cid" || rc=$?
   "${COMPOSE[@]}" stop "$app" >/dev/null
+  return "$rc"
 }
 
 main() {
   echo "footprint: ensuring postgres is up"
   "${COMPOSE[@]}" up -d postgres >/dev/null
+  # Pre-pull the load generator and pre-build k6load so neither an image pull
+  # nor a Go compile lands inside a measured load window (either would leave the
+  # samples reading idle, not loaded).
+  docker pull -q "grafana/k6:$K6_VERSION" >/dev/null
+  local bindir; bindir="$(mktemp -d)"
+  trap 'rm -rf "$bindir"' EXIT
+  K6LOAD_BIN="$bindir/k6load"
+  go build -o "$K6LOAD_BIN" ./benchmarks/scripts/k6load
   for app in $APPS; do
     measure_container "$app"
   done

--- a/benchmarks/scripts/footprint-all.sh
+++ b/benchmarks/scripts/footprint-all.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Measure the operational footprint of every containerized implementation (issue
+# #141 §"Operational footprint") into OUT_DIR/footprint.{json,csv}: container-
+# start → ready cold-start (median/p95 over COLD_START_RUNS restarts), idle
+# memory, and memory + CPU under load, for all six apps.
+#
+# It reuses run-crud-all.sh (sourced) for app identity derivation, the compose
+# wrapper, and the health wait; the throughput half is `make benchmark-crud-all`.
+#
+# The embedded-Gombit single-binary variant (`gombit build --embed`: binary +
+# image size, cold start, idle memory) is a follow-up slice — the footprint
+# schema already carries it (variant "embedded", binary_size_bytes) and the
+# footprint CLI accepts it; only the `gombit build --embed` frontend-build step
+# is not wired here yet.
+#
+#   make benchmark-footprint
+#   COLD_START_RUNS=3 APPS=gin-gorm make benchmark-footprint   # smoke
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+# shellcheck source=/dev/null
+APPS="" source benchmarks/scripts/run-crud-all.sh
+
+OUT="${OUT_DIR:-benchmarks/results/latest}/footprint.json"
+APPS="${APPS:-gin-gorm gombit django rails laravel nestjs}"
+COLD_START_RUNS="${COLD_START_RUNS:-20}"
+LOAD_VUS="${LOAD_VUS:-100}"
+LOAD_SECONDS="${LOAD_SECONDS:-10}"
+
+# to_bytes converts a `docker stats` size token (45.2MiB, 1.1GiB, 900B, …) to an
+# integer byte count on stdin.
+to_bytes() {
+  awk '{
+    n = $0 + 0
+    if ($0 ~ /GiB/)      printf "%d", n * 1073741824
+    else if ($0 ~ /MiB/) printf "%d", n * 1048576
+    else if ($0 ~ /KiB/) printf "%d", n * 1024
+    else if ($0 ~ /GB/)  printf "%d", n * 1000000000
+    else if ($0 ~ /MB/)  printf "%d", n * 1000000
+    else if ($0 ~ /kB|KB/) printf "%d", n * 1000
+    else                 printf "%d", n
+  }'
+}
+
+# mem_bytes CONTAINER — the container's memory usage (cgroup working set), bytes.
+mem_bytes() {
+  docker stats --no-stream --format '{{.MemUsage}}' "$1" | awk -F' / ' '{print $1}' | to_bytes
+}
+# cpu_pct CONTAINER — CPU percent (docker stats; 100 == one core).
+cpu_pct() { docker stats --no-stream --format '{{.CPUPerc}}' "$1" | tr -d '% '; }
+
+# wait_ready_ms URL — poll until HTTP 200, echo elapsed milliseconds (or fail).
+wait_ready_ms() {
+  local url="$1" start now code
+  start="$(date +%s%3N)"
+  for _ in $(seq 1 600); do
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$url" 2>/dev/null || true)"
+    if [ "$code" = "200" ]; then
+      now="$(date +%s%3N)"
+      echo "$((now - start))"
+      return 0
+    fi
+    sleep 0.05
+  done
+  return 1
+}
+
+# generate_load TARGET_URL — drive the crud-list workload for LOAD_SECONDS at
+# LOAD_VUS (same env contract as run-crud), output discarded.
+generate_load() {
+  docker run --rm --network host \
+    -e TARGET_URL="$1" -e VUS="$LOAD_VUS" -e DURATION="${LOAD_SECONDS}s" \
+    -v "$ROOT/benchmarks/workloads/crud-list.js:/workload/crud-list.js:ro" \
+    "grafana/k6:$K6_VERSION" run --quiet /workload/crud-list.js >/dev/null 2>&1 || true
+}
+
+# cold_start_samples APP LIVEZ_URL — echo COLD_START_RUNS comma-separated
+# start→ready samples (ms), stopping/starting the existing container each time.
+cold_start_samples() {
+  local app="$1" url="$2" samples="" ms
+  for _ in $(seq 1 "$COLD_START_RUNS"); do
+    "${COMPOSE[@]}" stop "$app" >/dev/null
+    "${COMPOSE[@]}" start "$app" >/dev/null
+    ms="$(wait_ready_ms "$url")" || { echo "footprint: $app cold-start did not become ready" >&2; return 1; }
+    samples="${samples:+$samples,}$ms"
+  done
+  printf '%s' "$samples"
+}
+
+# measure_container APP — full container footprint for one app.
+measure_container() {
+  local app="$1" cid livez turl samples idle loaded cpu m c image
+  app_identity "$app"
+  livez="http://127.0.0.1:${PORT}/livez"
+  turl="http://127.0.0.1:${PORT}/api/projects?page=1&limit=20"
+  echo "=== footprint: $app ($FRAMEWORK_VERSION on $RUNTIME $RUNTIME_VERSION) ==="
+
+  "${COMPOSE[@]}" build "$app" >/dev/null
+  "${COMPOSE[@]}" run --rm "$app" migrate
+  "${COMPOSE[@]}" run --rm "$app" seed
+  "${COMPOSE[@]}" up -d "$app" >/dev/null
+  cid="$("${COMPOSE[@]}" ps -q "$app")"
+  wait_healthy "$cid"
+
+  samples="$(cold_start_samples "$app" "$livez")"
+
+  sleep 3 # settle before reading idle memory
+  idle="$(mem_bytes "$cid")"
+
+  # Under load: sample memory (peak) and CPU (peak) while k6 runs.
+  loaded=0
+  cpu=0
+  generate_load "$turl" &
+  local loadpid=$!
+  sleep 2
+  for _ in 1 2 3 4; do
+    m="$(mem_bytes "$cid")"; c="$(cpu_pct "$cid")"
+    [ "$m" -gt "$loaded" ] && loaded="$m"
+    cpu="$(awk -v a="$cpu" -v b="$c" 'BEGIN { print (b > a) ? b : a }')"
+    sleep 1
+  done
+  wait "$loadpid" 2>/dev/null || true
+
+  image="$(docker image inspect "$(docker inspect "$cid" --format '{{.Image}}')" --format '{{.Size}}')"
+
+  go run ./benchmarks/scripts/footprint \
+    -framework "$app" -framework-version "$FRAMEWORK_VERSION" \
+    -runtime "$RUNTIME" -runtime-version "$RUNTIME_VERSION" \
+    -variant container \
+    -cold-start-ms "$samples" \
+    -idle-rss-bytes "$idle" -loaded-rss-bytes "$loaded" -cpu-percent "$cpu" \
+    -image-size-bytes "$image" \
+    -out "$OUT"
+
+  "${COMPOSE[@]}" stop "$app" >/dev/null
+}
+
+main() {
+  echo "footprint: ensuring postgres is up"
+  "${COMPOSE[@]}" up -d postgres >/dev/null
+  for app in $APPS; do
+    measure_container "$app"
+  done
+  echo "footprint: done. Rows in $OUT (and .csv)."
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/benchmarks/scripts/footprint-all.sh
+++ b/benchmarks/scripts/footprint-all.sh
@@ -43,9 +43,11 @@ run_load() {
 record_footprint() { go run ./benchmarks/scripts/footprint "$@"; }
 
 # median_int / median_float read numbers on stdin and echo the median (integer
-# floored for byte counts). Empty input -> 0.
-median_int() { sort -n | awk '{a[NR]=$1} END{ if(NR==0){print 0;exit} if(NR%2){printf "%d", a[(NR+1)/2]} else {printf "%d", (a[NR/2]+a[NR/2+1])/2} }'; }
-median_float() { sort -n | awk '{a[NR]=$1} END{ if(NR==0){print 0;exit} if(NR%2){print a[(NR+1)/2]} else {print (a[NR/2]+a[NR/2+1])/2} }'; }
+# floored for byte counts). Empty input FAILS (non-zero) rather than printing a
+# 0 sentinel — an absent series is not "0 bytes", and the caller must refuse the
+# row, not record a zero (issue #141: don't publish bogus data).
+median_int() { sort -n | awk '{a[NR]=$1} END{ if(NR==0){exit 1} if(NR%2){printf "%d", a[(NR+1)/2]} else {printf "%d", (a[NR/2]+a[NR/2+1])/2} }'; }
+median_float() { sort -n | awk '{a[NR]=$1} END{ if(NR==0){exit 1} if(NR%2){print a[(NR+1)/2]} else {print (a[NR/2]+a[NR/2+1])/2} }'; }
 
 # to_bytes converts a `docker stats` size token (45.2MiB, 1.1GiB, 900B, …) to an
 # integer byte count on stdin.
@@ -69,6 +71,15 @@ mem_bytes() {
 # cpu_pct CONTAINER — CPU percent (docker stats; 100 == one core).
 cpu_pct() { docker stats --no-stream --format '{{.CPUPerc}}' "$1" | tr -d '% '; }
 
+# stats_sample CONTAINER — one "<mem_bytes> <cpu_pct>" line from a single
+# `docker stats --no-stream` call (which already blocks ~1s, so this is the 1s
+# tick — no extra sleep needed, and it reads mem+cpu from the same instant).
+stats_sample() {
+  docker stats --no-stream --format '{{.MemUsage}}|{{.CPUPerc}}' "$1" \
+    | awk -F'|' '{gsub(/ .*/, "", $1); print $1, $2}' \
+    | { read -r mem cpu; printf '%s %s\n' "$(printf '%s' "$mem" | to_bytes)" "$(printf '%s' "$cpu" | tr -d '% ')"; }
+}
+
 # wait_ready_ms URL — poll until HTTP 200, echo elapsed milliseconds (or fail).
 wait_ready_ms() {
   local url="$1" start now code
@@ -85,22 +96,38 @@ wait_ready_ms() {
   return 1
 }
 
-# sample_stats CONTAINER FILE STOPFILE — until STOPFILE exists, append
-# "<mem_bytes> <cpu_pct>" once per second. Runs concurrently with the load so
-# the samples are provably taken while k6 is driving the app.
+# sample_stats CONTAINER FILE STOPFILE — until STOPFILE exists, append one
+# "<mem_bytes> <cpu_pct>" line per `docker stats` tick (~1s). Runs concurrently
+# with the load so the samples are provably taken while k6 drives the app.
 sample_stats() {
   while [ ! -f "$3" ]; do
-    printf '%s %s\n' "$(mem_bytes "$1")" "$(cpu_pct "$1")" >> "$2"
-    sleep 1
+    stats_sample "$1" >> "$2"
   done
+}
+
+# aggregate_load_samples FILE — echo "<loaded_rss_bytes> <cpu_pct>" as the
+# steady-state median of the samples, dropping the first (ramp) sample. FAILS
+# (non-zero) unless at least two in-load samples remain: a missing or one-sample
+# series must not become a 0-byte/0% "loaded" reading (that would be a sentinel
+# with a field name, not a measurement). median_* also fail on empty input.
+aggregate_load_samples() {
+  local n loaded cpu
+  n="$(wc -l < "$1")"
+  if [ "$n" -lt 3 ]; then
+    return 1 # need >= 2 after dropping the ramp sample
+  fi
+  loaded="$(tail -n +2 "$1" | awk '{print $1}' | median_int)" || return 1
+  cpu="$(tail -n +2 "$1" | awk '{print $2}' | median_float)" || return 1
+  printf '%s %s' "$loaded" "$cpu"
 }
 
 # measure_under_load CONTAINER TARGET_URL — echo "<loaded_rss_bytes> <cpu_pct>"
 # from steady-state samples taken *while validated load runs*, or fail (non-zero)
-# if the load was not a clean measurement — so a failed/absent k6 never yields a
-# loaded/CPU number. The load generator is the authority (k6load validates).
+# if the load was not a clean measurement (k6load Validate) OR too few in-load
+# samples exist — so neither a failed/absent k6 nor an empty sample series yields
+# a loaded/CPU number.
 measure_under_load() {
-  local cid="$1" turl="$2" sf stop spid load_ok=0
+  local cid="$1" turl="$2" sf stop spid out load_ok=0
   sf="$(mktemp)"; stop="$sf.stop"; rm -f "$stop"
   sample_stats "$cid" "$sf" "$stop" &
   spid=$!
@@ -116,12 +143,9 @@ measure_under_load() {
     rm -f "$sf" "$stop"
     return 1
   fi
-  # Drop the first sample (ramp) and report the steady-state median, not a peak.
-  local loaded cpu
-  loaded="$(tail -n +2 "$sf" | awk '{print $1}' | median_int)"
-  cpu="$(tail -n +2 "$sf" | awk '{print $2}' | median_float)"
+  out="$(aggregate_load_samples "$sf")" || { rm -f "$sf" "$stop"; return 1; }
   rm -f "$sf" "$stop"
-  printf '%s %s' "$loaded" "$cpu"
+  printf '%s' "$out"
 }
 
 # cold_start_samples APP LIVEZ_URL — echo COLD_START_RUNS comma-separated

--- a/benchmarks/scripts/footprint-all_test.sh
+++ b/benchmarks/scripts/footprint-all_test.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Tests for footprint-all.sh. The Docker orchestration IS the measurement — when
-# the SUT is stopped, and whether a failed/absent load can still publish a
-# loaded/CPU row — so beyond the pure to_bytes parser, this drives
-# measure_container with fake COMPOSE / run_load / record_footprint / stats
-# seams and locks those two contracts. Sourcing runs no real measurement (main
-# is guarded).
+# Tests for footprint-all.sh. The Docker orchestration IS the measurement, so
+# beyond the pure to_bytes parser this locks the two contracts a bad row hides
+# behind: the load aggregator refuses a too-short sample series (no 0-byte
+# "loaded" sentinel), and measure_container records the real loaded/CPU values
+# on a clean load, publishes nothing on a failed one, and always stops the SUT.
+# Sourcing runs no real measurement (main is guarded).
 #
 #   bash benchmarks/scripts/footprint-all_test.sh
 set -euo pipefail
@@ -29,48 +29,65 @@ check_bytes "900B"     900
 check_bytes "2MB"      2000000
 check_bytes "1.5GiB"   1610612736
 
-# ---- fakes shared by the orchestration tests ----
+# ---- 2. aggregate_load_samples: fail-closed on a too-short series ----
+sample_file() { local f; f="$(mktemp)"; printf '%b' "$1" > "$f"; echo "$f"; }
+
+for n_lines in "" "10 1\n" "10 1\n20 2\n"; do
+  f="$(sample_file "$n_lines")"
+  if aggregate_load_samples "$f" >/dev/null 2>&1; then
+    note "aggregate_load_samples accepted a <2-in-load-sample series ($(printf '%b' "$n_lines" | wc -l) lines)"
+  fi
+  rm -f "$f"
+done
+# Three samples -> drop the ramp, median of the last two.
+f="$(sample_file '10 1\n20 2\n30 3\n')"
+got="$(aggregate_load_samples "$f")"
+[ "$got" = "25 2.5" ] || note "aggregate_load_samples(3 samples) = '$got', want '25 2.5'"
+rm -f "$f"
+
+# ---- fakes for the measure_container control-flow tests ----
 CALLS=()
 fake_compose() { if [ "$1" = ps ]; then echo "cid-$3"; return 0; fi; CALLS+=("compose $*"); }
 called() { printf '%s\n' "${CALLS[@]}" | grep -qF "$1"; }
-# neutralise the slow/real bits
 app_identity() { PORT=8081; FRAMEWORK=gin-gorm; FRAMEWORK_VERSION=v1; RUNTIME=go; RUNTIME_VERSION=go1; }
 wait_healthy() { return 0; }
 cold_start_samples() { echo "100,110,120"; }
-mem_bytes() { echo 8000000; }
-cpu_pct() { echo 150; }
-docker() { echo 22000000; } # only used for `docker image/inspect` size here
+mem_bytes() { echo 5000000; }
+docker() { echo 22000000; } # stands in for the image-size inspects
 IDLE_SETTLE=0
 
-# ---- 2. happy path: records a row (with load numbers) and stops the SUT ----
+# ---- 3. clean load: records the REAL loaded/CPU values, stops the SUT ----
 CALLS=()
 COMPOSE=(fake_compose)
-run_load() { return 0; }              # clean load
+measure_under_load() { printf '8000000 150'; }   # a clean, well-sampled load
 RECORD_ARGS=""
 record_footprint() { RECORD_ARGS="$*"; CALLS+=("record"); }
-run_one_ok=0
-measure_container gin-gorm && run_one_ok=1
-[ "$run_one_ok" = 1 ]         || note "happy path returned non-zero"
-called "record"               || note "happy path did not record a row"
-called "compose stop gin-gorm" || note "happy path did not stop the SUT"
-case "$RECORD_ARGS" in *"-loaded-rss-bytes "*"-cpu-percent "*) : ;; *) note "record missing loaded/cpu: $RECORD_ARGS";; esac
+ok=0
+measure_container gin-gorm && ok=1
+[ "$ok" = 1 ]                 || note "clean-load path returned non-zero"
+called "record"              || note "clean-load path did not record a row"
+called "compose stop gin-gorm" || note "clean-load path did not stop the SUT"
+case "$RECORD_ARGS" in
+  *"-loaded-rss-bytes 8000000 "*"-cpu-percent 150 "*) : ;;
+  *) note "record did not carry the real loaded/CPU values: $RECORD_ARGS" ;;
+esac
 
-# ---- 3. failed load: NO row published, but SUT still stopped ----
+# ---- 4. failed load (or too-few samples): NO row, SUT still stopped ----
 CALLS=()
 RECORDED=0
-run_load() { return 1; }              # dirty/absent load
+measure_under_load() { return 1; }
 record_footprint() { RECORDED=1; }
 rc=0
 measure_container gin-gorm || rc=$?
-[ "$rc" -ne 0 ]  || note "failed load should fail the app"
-[ "$RECORDED" -eq 0 ] || note "failed load still published a loaded/CPU row"
+[ "$rc" -ne 0 ]        || note "failed load should fail the app"
+[ "$RECORDED" -eq 0 ]  || note "failed load still published a loaded/CPU row"
 called "compose stop gin-gorm" || note "SUT not stopped after failed load"
 
-# ---- 4. mid-measure failure (health) still stops the SUT ----
+# ---- 5. mid-measure failure (health) still stops the SUT ----
 CALLS=()
 wait_healthy() { return 1; }
 record_footprint() { :; }
-run_load() { return 0; }
+measure_under_load() { printf '8000000 150'; }
 rc=0
 measure_container gin-gorm || rc=$?
 [ "$rc" -ne 0 ] || note "unhealthy app should fail"
@@ -80,4 +97,4 @@ if [ "$fail" -ne 0 ]; then
   echo "footprint-all_test: FAILED" >&2
   exit 1
 fi
-echo "footprint-all_test: to_bytes, record-on-clean-load, no-row-on-failed-load, and stop-before-return all pass"
+echo "footprint-all_test: to_bytes, fail-closed aggregator, real-value record, no-row-on-failure, and stop-before-return all pass"

--- a/benchmarks/scripts/footprint-all_test.sh
+++ b/benchmarks/scripts/footprint-all_test.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Unit test for footprint-all.sh's one bit of parsing logic — to_bytes, which
-# turns `docker stats` size tokens into byte counts. Sourcing runs no
-# measurement (main is guarded); the Docker orchestration is glue over the
-# unit-tested Go footprint package + CLI.
+# Tests for footprint-all.sh. The Docker orchestration IS the measurement — when
+# the SUT is stopped, and whether a failed/absent load can still publish a
+# loaded/CPU row — so beyond the pure to_bytes parser, this drives
+# measure_container with fake COMPOSE / run_load / record_footprint / stats
+# seams and locks those two contracts. Sourcing runs no real measurement (main
+# is guarded).
 #
 #   bash benchmarks/scripts/footprint-all_test.sh
 set -euo pipefail
@@ -13,24 +15,69 @@ cd "$ROOT"
 APPS="" source benchmarks/scripts/footprint-all.sh
 
 fail=0
-check() {
-  local in="$1" want="$2" got
-  got="$(printf '%s' "$in" | to_bytes)"
-  if [ "$got" != "$want" ]; then
-    echo "FAIL: to_bytes($in) = $got, want $want" >&2
-    fail=1
-  fi
-}
+note() { echo "FAIL: $*" >&2; fail=1; }
 
-check "1GiB"     1073741824
-check "45.66MiB" 47877980   # 45.66 * 1048576, truncated
-check "512KiB"   524288
-check "900B"     900
-check "2MB"      2000000     # decimal unit
-check "1.5GiB"   1610612736
+# ---- 1. to_bytes conversions ----
+check_bytes() {
+  local got; got="$(printf '%s' "$1" | to_bytes)"
+  [ "$got" = "$2" ] || note "to_bytes($1) = $got, want $2"
+}
+check_bytes "1GiB"     1073741824
+check_bytes "45.66MiB" 47877980
+check_bytes "512KiB"   524288
+check_bytes "900B"     900
+check_bytes "2MB"      2000000
+check_bytes "1.5GiB"   1610612736
+
+# ---- fakes shared by the orchestration tests ----
+CALLS=()
+fake_compose() { if [ "$1" = ps ]; then echo "cid-$3"; return 0; fi; CALLS+=("compose $*"); }
+called() { printf '%s\n' "${CALLS[@]}" | grep -qF "$1"; }
+# neutralise the slow/real bits
+app_identity() { PORT=8081; FRAMEWORK=gin-gorm; FRAMEWORK_VERSION=v1; RUNTIME=go; RUNTIME_VERSION=go1; }
+wait_healthy() { return 0; }
+cold_start_samples() { echo "100,110,120"; }
+mem_bytes() { echo 8000000; }
+cpu_pct() { echo 150; }
+docker() { echo 22000000; } # only used for `docker image/inspect` size here
+IDLE_SETTLE=0
+
+# ---- 2. happy path: records a row (with load numbers) and stops the SUT ----
+CALLS=()
+COMPOSE=(fake_compose)
+run_load() { return 0; }              # clean load
+RECORD_ARGS=""
+record_footprint() { RECORD_ARGS="$*"; CALLS+=("record"); }
+run_one_ok=0
+measure_container gin-gorm && run_one_ok=1
+[ "$run_one_ok" = 1 ]         || note "happy path returned non-zero"
+called "record"               || note "happy path did not record a row"
+called "compose stop gin-gorm" || note "happy path did not stop the SUT"
+case "$RECORD_ARGS" in *"-loaded-rss-bytes "*"-cpu-percent "*) : ;; *) note "record missing loaded/cpu: $RECORD_ARGS";; esac
+
+# ---- 3. failed load: NO row published, but SUT still stopped ----
+CALLS=()
+RECORDED=0
+run_load() { return 1; }              # dirty/absent load
+record_footprint() { RECORDED=1; }
+rc=0
+measure_container gin-gorm || rc=$?
+[ "$rc" -ne 0 ]  || note "failed load should fail the app"
+[ "$RECORDED" -eq 0 ] || note "failed load still published a loaded/CPU row"
+called "compose stop gin-gorm" || note "SUT not stopped after failed load"
+
+# ---- 4. mid-measure failure (health) still stops the SUT ----
+CALLS=()
+wait_healthy() { return 1; }
+record_footprint() { :; }
+run_load() { return 0; }
+rc=0
+measure_container gin-gorm || rc=$?
+[ "$rc" -ne 0 ] || note "unhealthy app should fail"
+called "compose stop gin-gorm" || note "SUT not stopped after health failure"
 
 if [ "$fail" -ne 0 ]; then
   echo "footprint-all_test: FAILED" >&2
   exit 1
 fi
-echo "footprint-all_test: to_bytes conversions pass"
+echo "footprint-all_test: to_bytes, record-on-clean-load, no-row-on-failed-load, and stop-before-return all pass"

--- a/benchmarks/scripts/footprint-all_test.sh
+++ b/benchmarks/scripts/footprint-all_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Unit test for footprint-all.sh's one bit of parsing logic — to_bytes, which
+# turns `docker stats` size tokens into byte counts. Sourcing runs no
+# measurement (main is guarded); the Docker orchestration is glue over the
+# unit-tested Go footprint package + CLI.
+#
+#   bash benchmarks/scripts/footprint-all_test.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+# shellcheck source=/dev/null
+APPS="" source benchmarks/scripts/footprint-all.sh
+
+fail=0
+check() {
+  local in="$1" want="$2" got
+  got="$(printf '%s' "$in" | to_bytes)"
+  if [ "$got" != "$want" ]; then
+    echo "FAIL: to_bytes($in) = $got, want $want" >&2
+    fail=1
+  fi
+}
+
+check "1GiB"     1073741824
+check "45.66MiB" 47877980   # 45.66 * 1048576, truncated
+check "512KiB"   524288
+check "900B"     900
+check "2MB"      2000000     # decimal unit
+check "1.5GiB"   1610612736
+
+if [ "$fail" -ne 0 ]; then
+  echo "footprint-all_test: FAILED" >&2
+  exit 1
+fi
+echo "footprint-all_test: to_bytes conversions pass"

--- a/benchmarks/scripts/footprint/main.go
+++ b/benchmarks/scripts/footprint/main.go
@@ -1,0 +1,157 @@
+// Command footprint records one implementation's operational-footprint row
+// (issue #141 §"Operational footprint"). The measurement orchestration —
+// timing container starts, sampling `docker stats`, weighing images/binaries —
+// lives in benchmarks/scripts/footprint-all.sh; this command turns those raw
+// numbers into a typed benchmarks/internal/footprint row and merges it into
+// OUT_DIR/footprint.{json,csv} by (framework, variant), so re-measuring one
+// implementation replaces only its own row.
+//
+//	go run ./benchmarks/scripts/footprint \
+//	  -framework gombit -framework-version v0.1.3 -runtime go -runtime-version go1.25.7 \
+//	  -variant container -cold-start-ms 210,235,228 \
+//	  -idle-rss-bytes 18000000 -loaded-rss-bytes 42000000 -cpu-percent 165 \
+//	  -image-size-bytes 30000000 -out benchmarks/results/latest/footprint.json
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gombit-dev/gombit/benchmarks/internal/footprint"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("footprint", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		framework = fs.String("framework", "", "framework name / merge key (required)")
+		fwVersion = fs.String("framework-version", "", "framework version")
+		runtime   = fs.String("runtime", "", "runtime, e.g. go")
+		rtVersion = fs.String("runtime-version", "", "runtime version")
+		variant   = fs.String("variant", footprint.VariantContainer, "container | embedded")
+		coldStart = fs.String("cold-start-ms", "", "comma-separated container-start→ready samples in ms")
+		idleRSS   = fs.Int64("idle-rss-bytes", 0, "idle container memory (cgroup working set), bytes")
+		loadedRSS = fs.Int64("loaded-rss-bytes", 0, "container memory under load, bytes")
+		cpuPct    = fs.Float64("cpu-percent", 0, "CPU percent under load (docker stats, 100 = one core)")
+		imageSize = fs.Int64("image-size-bytes", 0, "container image size, bytes")
+		binSize   = fs.Int64("binary-size-bytes", 0, "deploy binary size, bytes (embedded-Gombit only)")
+		out       = fs.String("out", "benchmarks/results/latest/footprint.json", "output footprint.json (a sibling .csv is written too)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *framework == "" || *variant == "" {
+		_, _ = fmt.Fprintln(stderr, "footprint: -framework and -variant are required")
+		return 2
+	}
+	samples, err := parseFloats(*coldStart)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "footprint: -cold-start-ms: %v\n", err)
+		return 2
+	}
+
+	row := footprint.Footprint{
+		SchemaVersion:       footprint.SchemaVersion,
+		Framework:           *framework,
+		FrameworkVersion:    *fwVersion,
+		Runtime:             *runtime,
+		RuntimeVersion:      *rtVersion,
+		Variant:             *variant,
+		ColdStart:           footprint.ComputeColdStart(samples),
+		IdleRSSBytes:        *idleRSS,
+		LoadedRSSBytes:      *loadedRSS,
+		CPUPercentUnderLoad: *cpuPct,
+		ImageSizeBytes:      *imageSize,
+		BinarySizeBytes:     *binSize,
+	}
+
+	if err := mergeIntoFiles(*out, row); err != nil {
+		_, _ = fmt.Fprintf(stderr, "footprint: %v\n", err)
+		return 1
+	}
+	_, _ = fmt.Fprintf(stdout, "footprint: recorded %s/%s (cold-start median %.0fms over %d runs, idle %d B) into %s\n",
+		row.Framework, row.Variant, row.ColdStart.MedianMs, row.ColdStart.Runs, row.IdleRSSBytes, *out)
+	return 0
+}
+
+// mergeIntoFiles reads the existing footprint.json (if any), replaces this row's
+// (framework, variant), and rewrites both the .json and its sibling .csv.
+func mergeIntoFiles(jsonPath string, f footprint.Footprint) error {
+	if jsonPath == "" {
+		return fmt.Errorf("-out is required")
+	}
+	existing, err := readExisting(jsonPath)
+	if err != nil {
+		return err
+	}
+	merged := footprint.Merge(existing, []footprint.Footprint{f})
+
+	if err := os.MkdirAll(filepath.Dir(jsonPath), 0o755); err != nil { //nolint:gosec // operator-supplied output dir
+		return err
+	}
+	if err := writeFile(jsonPath, func(w io.Writer) error { return footprint.WriteJSON(w, merged) }); err != nil {
+		return err
+	}
+	csvPath := strings.TrimSuffix(jsonPath, ".json") + ".csv"
+	return writeFile(csvPath, func(w io.Writer) error { return footprint.WriteCSV(w, merged) })
+}
+
+func readExisting(path string) ([]footprint.Footprint, error) {
+	file, err := os.Open(path) //nolint:gosec // operator-supplied output path
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+	return footprint.ReadJSON(file)
+}
+
+func writeFile(path string, encode func(io.Writer) error) error {
+	f, err := os.Create(path) //nolint:gosec // operator-supplied output path
+	if err != nil {
+		return err
+	}
+	if err := encode(f); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// parseFloats parses a comma-separated list of non-negative floats (the
+// cold-start samples). An empty string is an empty set (zero distribution).
+func parseFloats(s string) ([]float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]float64, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		v, err := strconv.ParseFloat(p, 64)
+		if err != nil {
+			return nil, fmt.Errorf("%q is not a number", p)
+		}
+		if v < 0 {
+			return nil, fmt.Errorf("%q is negative", p)
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}

--- a/benchmarks/scripts/footprint/main_test.go
+++ b/benchmarks/scripts/footprint/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gombit-dev/gombit/benchmarks/internal/footprint"
+)
+
+func TestRunMergesContainerAndEmbeddedRows(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "footprint.json")
+	var so, se bytes.Buffer
+
+	// First a container row.
+	code := run([]string{
+		"-framework", "gombit", "-framework-version", "v0.1.3",
+		"-runtime", "go", "-runtime-version", "go1.25.7",
+		"-variant", "container", "-cold-start-ms", "200,220,240",
+		"-idle-rss-bytes", "18000000", "-out", out,
+	}, &so, &se)
+	if code != 0 {
+		t.Fatalf("container run exit=%d stderr=%s", code, se.String())
+	}
+	// Then an embedded row for the same framework — must accumulate, not replace.
+	code = run([]string{
+		"-framework", "gombit", "-variant", "embedded",
+		"-cold-start-ms", "150", "-binary-size-bytes", "25000000", "-out", out,
+	}, &so, &se)
+	if code != 0 {
+		t.Fatalf("embedded run exit=%d stderr=%s", code, se.String())
+	}
+
+	f, err := os.Open(out) //nolint:gosec // test reads a temp file it just wrote
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	rows, err := footprint.ReadJSON(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 (container + embedded)", len(rows))
+	}
+	byVariant := map[string]footprint.Footprint{}
+	for _, r := range rows {
+		byVariant[r.Variant] = r
+	}
+	// median of 200,220,240 is 220.
+	if byVariant["container"].ColdStart.MedianMs != 220 {
+		t.Errorf("container cold-start median = %v, want 220", byVariant["container"].ColdStart.MedianMs)
+	}
+	if byVariant["embedded"].BinarySizeBytes != 25000000 {
+		t.Errorf("embedded binary size = %d, want 25000000", byVariant["embedded"].BinarySizeBytes)
+	}
+	// The sibling CSV is written too.
+	if _, err := os.Stat(strings.TrimSuffix(out, ".json") + ".csv"); err != nil {
+		t.Errorf("sibling .csv not written: %v", err)
+	}
+}
+
+func TestRunRejectsBadInput(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "footprint.json")
+	cases := map[string][]string{
+		"missing framework":   {"-variant", "container", "-out", out},
+		"bad cold-start":      {"-framework", "x", "-variant", "container", "-cold-start-ms", "1,two,3", "-out", out},
+		"negative cold-start": {"-framework", "x", "-variant", "container", "-cold-start-ms", "-5", "-out", out},
+	}
+	for name, args := range cases {
+		var so, se bytes.Buffer
+		if code := run(args, &so, &se); code == 0 {
+			t.Errorf("%s: exit=0, want non-zero", name)
+		}
+	}
+}

--- a/benchmarks/scripts/k6load/main.go
+++ b/benchmarks/scripts/k6load/main.go
@@ -1,0 +1,107 @@
+// Command k6load runs the crud-list workload against a target for a fixed
+// window and KEEPS + validates the k6 summary, exiting non-zero unless the load
+// was a clean measurement (traffic sent, no HTTP errors, no failed checks —
+// benchmarks/internal/k6's Summary.Validate). It is the load half of the
+// footprint measurement: the load generator, not a wall-clock guess, is the
+// authority for whether load actually happened, so footprint-all.sh only
+// records loaded-memory / CPU numbers when this exits 0. Unlike run-crud it
+// writes no results row — it exists purely to drive validated load while the
+// orchestrator samples `docker stats` concurrently.
+//
+//	go run ./benchmarks/scripts/k6load \
+//	  -target-url 'http://127.0.0.1:8081/api/projects?page=1&limit=20' \
+//	  -vus 100 -duration 10s -k6-image grafana/k6:0.55.0 \
+//	  -workload benchmarks/workloads/crud-list.js
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/gombit-dev/gombit/benchmarks/internal/k6"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("k6load", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		target   = fs.String("target-url", "", "the app's list endpoint (required)")
+		vus      = fs.Int("vus", 100, "concurrent VUs")
+		duration = fs.String("duration", "10s", "load duration (k6 duration string)")
+		image    = fs.String("k6-image", "grafana/k6:0.55.0", "pinned k6 image")
+		workload = fs.String("workload", "benchmarks/workloads/crud-list.js", "k6 workload script")
+		runner   = fs.String("docker", "docker", "docker binary (overridable for tests)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *target == "" {
+		_, _ = fmt.Fprintln(stderr, "k6load: -target-url is required")
+		return 2
+	}
+	workloadAbs, err := filepath.Abs(*workload)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "k6load: %v\n", err)
+		return 2
+	}
+
+	summaryDir, err := os.MkdirTemp("", "k6load")
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "k6load: %v\n", err)
+		return 1
+	}
+	defer func() { _ = os.RemoveAll(summaryDir) }()
+
+	// Same env/mount contract as run-crud's dockerK6Runner, plus SUMMARY_OUT so
+	// the summary is kept for validation (run-crud § dockerK6Runner).
+	dockerArgs := []string{
+		"run", "--rm", "--network", "host",
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+		"-e", "TARGET_URL=" + *target,
+		"-e", "VUS=" + strconv.Itoa(*vus),
+		"-e", "DURATION=" + *duration,
+		"-e", "SUMMARY_OUT=/out/summary.json",
+		"-v", workloadAbs + ":/workload/crud-list.js:ro",
+		"-v", summaryDir + ":/out",
+		*image, "run", "--quiet", "/workload/crud-list.js",
+	}
+	cmd := exec.CommandContext(context.Background(), *runner, dockerArgs...) //nolint:gosec // fixed argv, operator-supplied target/image only
+	cmd.Stdout = stderr                                                      // k6's own progress goes to stderr, keeping our stdout clean
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		_, _ = fmt.Fprintf(stderr, "k6load: k6 did not run: %v\n", err)
+		return 1
+	}
+
+	summary, err := parseSummary(filepath.Join(summaryDir, "summary.json"))
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "k6load: %v\n", err)
+		return 1
+	}
+	if err := summary.Validate(); err != nil {
+		_, _ = fmt.Fprintf(stderr, "k6load: load was not a clean measurement: %v\n", err)
+		return 1
+	}
+	_, _ = fmt.Fprintf(stdout, "k6load: %d requests, %d errors over %.1fs — clean\n",
+		summary.Requests, summary.Errors, summary.DurationSeconds)
+	return 0
+}
+
+func parseSummary(path string) (k6.Summary, error) {
+	f, err := os.Open(path) //nolint:gosec // path composed from our own temp dir
+	if err != nil {
+		return k6.Summary{}, fmt.Errorf("k6 produced no summary: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	return k6.ParseSummary(f)
+}

--- a/benchmarks/scripts/k6load/main_test.go
+++ b/benchmarks/scripts/k6load/main_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeDocker writes a shell script standing in for `docker`: it finds the
+// `-v <dir>:/out` mount in its args and, if goldenAbs is non-empty, copies that
+// k6 summary golden into <dir>/summary.json — exactly what a real k6 run would
+// leave behind. An empty goldenAbs simulates a run that produced no summary.
+func fakeDocker(t *testing.T, goldenAbs string) string {
+	t.Helper()
+	script := "#!/bin/sh\nd=\nfor a in \"$@\"; do case \"$a\" in *:/out) d=\"${a%:/out}\";; esac; done\n"
+	if goldenAbs != "" {
+		script += "cp '" + goldenAbs + "' \"$d/summary.json\"\n"
+	}
+	script += "exit 0\n"
+	p := filepath.Join(t.TempDir(), "fakedocker.sh")
+	if err := os.WriteFile(p, []byte(script), 0o700); err != nil { //nolint:gosec // test helper script must be executable
+		t.Fatal(err)
+	}
+	return p
+}
+
+func golden(t *testing.T, name string) string {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("..", "..", "internal", "k6", "testdata", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		t.Fatalf("golden %s missing: %v", name, err)
+	}
+	return abs
+}
+
+func TestRunCleanLoadExitsZero(t *testing.T) {
+	code := run([]string{
+		"-target-url", "http://127.0.0.1:9/x",
+		"-docker", fakeDocker(t, golden(t, "summary_ok.json")),
+	}, io.Discard, io.Discard)
+	if code != 0 {
+		t.Fatalf("clean load exit = %d, want 0", code)
+	}
+}
+
+// The whole point of k6load: a run whose traffic all failed must NOT be blessed
+// as a clean measurement. Deleting summary.Validate() would fail this test.
+func TestRunFailedLoadExitsNonZero(t *testing.T) {
+	code := run([]string{
+		"-target-url", "http://127.0.0.1:9/x",
+		"-docker", fakeDocker(t, golden(t, "summary_all_failed.json")),
+	}, io.Discard, io.Discard)
+	if code == 0 {
+		t.Fatal("all-failed load exit = 0, want non-zero (Validate must reject error traffic)")
+	}
+}
+
+func TestRunNoSummaryExitsNonZero(t *testing.T) {
+	// fakeDocker with no golden writes no summary.json.
+	code := run([]string{
+		"-target-url", "http://127.0.0.1:9/x",
+		"-docker", fakeDocker(t, ""),
+	}, io.Discard, io.Discard)
+	if code == 0 {
+		t.Fatal("no-summary run exit = 0, want non-zero")
+	}
+}
+
+func TestRunRequiresTarget(t *testing.T) {
+	if code := run([]string{"-docker", fakeDocker(t, "")}, io.Discard, io.Discard); code != 2 {
+		t.Fatalf("missing -target-url exit = %d, want 2", code)
+	}
+}

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1582,7 +1582,16 @@ two code leftovers, all fixed.
   SUT on the happy path — the exact `|| true` / no-trap pattern PR #192 had just
   removed. Fixed as above (validated `k6load`, concurrent steady-state sampling,
   fail-closed no-row-on-dirty-load, always-stop) and the leftover "footprint is a
-  later slice" sentences in the touched files were swept.
+  later slice" sentences in the touched files were swept. A second round closed
+  two more: (1) the sample aggregator still fail-*open*ed — `median_*` printed a
+  `0` sentinel on empty input, so a dropped-ramp/one-sample series wrote
+  `loaded=0`/`cpu=0`; now `median_*` fail on empty and `aggregate_load_samples`
+  refuses unless ≥2 in-load samples remain (and `stats_sample` reads mem+cpu in
+  one `docker stats` call, a true 1s tick, no extra sleep). (2) `k6load` had no
+  tests despite being the load authority; added `k6load/main_test.go` driving its
+  `-docker` seam with the real k6 goldens — clean → exit 0, all-failed → non-zero
+  (deleting `Validate` fails it), no summary → non-zero. The shell test now
+  asserts the real 8 MB / 150% values and the aggregator's fail-closed.
 - Gombit-specific: build via `gombit build --embed`, verify the embedded
   binary serves API + admin + frontend assets, measure its binary size,
   container image size, cold start, and idle RSS as the headline

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1473,7 +1473,8 @@ in:
   Verified end to end too: a reduced-parameter run against `gin-gorm`
   builds/migrates/seeds/serves, reaches healthy, records
   `enforced: cpu 2.00 / memory 1 GiB`, runs k6 (errors=0), and merges the rows.
-  The remaining Phase 6 work is the per-app footprint capture below.
+  The per-app footprint capture below is done for the container variant
+  (`make benchmark-footprint`); the embedded-Gombit variant is the remaining bit.
   Two follow-up review rounds on PR #192 fixed the framework key (`gin-gorm`, not
   `gin`), the `|| true` blank-limit / no-trap bug, the Make override, weak tests,
   and — across the whole benchmarks tree, not just the named paragraphs — every
@@ -1555,13 +1556,28 @@ two code leftovers, all fixed.
   of the tree; the tree and scope notes already say the wiring is deferred.)
 
 - Cold-start (≥20 runs, median/p95), idle RSS, loaded RSS, CPU-under-load for
-  all 6 implementations.
+  all 6 implementations. **Container variant — done** (`make benchmark-footprint`,
+  `benchmarks/scripts/footprint-all.sh` + `benchmarks/internal/footprint` +
+  `benchmarks/scripts/footprint`): a dedicated `footprint.{json,csv}` schema
+  (separate from throughput; cold-start has no home in a rps row), cold-start =
+  container-start → first 200 on `/livez` over `COLD_START_RUNS` restarts
+  (median/p95), idle/loaded memory from `docker stats` cgroup working set, peak
+  CPU while the crud-list workload drives it, and image size. The
+  median/p95/merge/encoding are unit-tested in Go; the shell `to_bytes` parser
+  has its own test; verified live against `gin-gorm` (cold-start ~117ms median,
+  idle ~8 MB, image ~22 MB).
 - Gombit-specific: build via `gombit build --embed`, verify the embedded
   binary serves API + admin + frontend assets, measure its binary size,
   container image size, cold start, and idle RSS as the headline
-  single-binary-deployment number.
+  single-binary-deployment number. **Follow-up slice.** The footprint schema and
+  CLI already carry it (`variant: embedded`, `binary_size_bytes`); the blocker is
+  only the `gombit build --embed` frontend build, which failed to run in the dev
+  environment used here (pnpm 11 refuses esbuild's build script,
+  `ERR_PNPM_IGNORED_BUILDS`; the npm fallback hit WSL/Windows interop). That is a
+  `gombit build --embed` / toolchain issue outside this suite, so the variant is
+  deferred rather than faked or shipped untested.
 - **AC:** `make benchmark-footprint` produces footprint rows for all 6 apps
-  plus the embedded-Gombit variant.
+  (container variant); the embedded-Gombit variant lands with the follow-up.
 
 ### Phase 7 — Reporting, README integration, drift detection
 

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1197,8 +1197,8 @@ real MAJOR findings, all confirmed and fixed.
 
 **Headline CRUD-read workload + `make benchmark-crud` — the per-implementation
 measurement engine — done; the all-six compose loop (`make benchmark-crud-all`)
-is done too (see the Phase 6 bullets), and footprint capture is the remaining
-slice.**
+and the container footprint (`make benchmark-footprint`) are done too (see the
+Phase 6 bullets); the embedded-Gombit footprint variant is the remaining slice.**
 
 - `benchmarks/workloads/crud-list.js`: the headline `GET /api/projects?page=1&limit=20`
   workload (issue §"Required headline workload"), run by the pinned k6 image
@@ -1561,11 +1561,28 @@ two code leftovers, all fixed.
   `benchmarks/scripts/footprint`): a dedicated `footprint.{json,csv}` schema
   (separate from throughput; cold-start has no home in a rps row), cold-start =
   container-start → first 200 on `/livez` over `COLD_START_RUNS` restarts
-  (median/p95), idle/loaded memory from `docker stats` cgroup working set, peak
-  CPU while the crud-list workload drives it, and image size. The
-  median/p95/merge/encoding are unit-tested in Go; the shell `to_bytes` parser
-  has its own test; verified live against `gin-gorm` (cold-start ~117ms median,
-  idle ~8 MB, image ~22 MB).
+  (median/p95); idle memory from `docker stats` cgroup working set after an
+  `IDLE_SETTLE` (default 10s) settle; loaded memory + CPU as the **steady-state
+  median** sampled once/second *while validated load runs* — the load goes
+  through `benchmarks/scripts/k6load`, which keeps and validates the k6 summary
+  (`internal/k6` `Summary.Validate`) so a k6 run that sent no traffic, errored,
+  or failed a check publishes **no** loaded/CPU row (the same fail-closed rule as
+  `run-crud`; the k6 image is pre-pulled so no pull falls inside the window); and
+  image size. `measure_container` always stops the SUT before returning, even on
+  a mid-measure failure. Unit-tested: the Go median/p95/merge/encoding; the shell
+  `to_bytes` parser; and — via fake compose/load/record seams — that a clean load
+  records a row, a failed load publishes none, and the SUT is stopped on failure.
+  Verified live against `gin-gorm` (cold-start ~117ms median, idle ~8 MB, image
+  ~22 MB).
+
+  **Post-landing correction (review on PR #193,
+  github.com/gombit-dev/gombit/pull/193#pullrequestreview-5038071646):** the
+  first cut backgrounded k6 with its summary discarded and `|| true`, sampled a
+  peak-of-four wall-clock guess, always wrote loaded/CPU, and only stopped the
+  SUT on the happy path — the exact `|| true` / no-trap pattern PR #192 had just
+  removed. Fixed as above (validated `k6load`, concurrent steady-state sampling,
+  fail-closed no-row-on-dirty-load, always-stop) and the leftover "footprint is a
+  later slice" sentences in the touched files were swept.
 - Gombit-specific: build via `gombit build --embed`, verify the embedded
   binary serves API + admin + frontend assets, measure its binary size,
   container image size, cold start, and idle RSS as the headline


### PR DESCRIPTION
## Summary

Phase 6 operational footprint (container variant): **`make benchmark-footprint`**
records cold-start, memory, and CPU-under-load for every containerized app into a
dedicated `footprint.{json,csv}` — a schema separate from throughput, because
cold-start median/p95 has no natural home in a requests-per-second row.

- **`benchmarks/internal/footprint`** — the schema + cold-start statistics
  (median/p95 with linear interpolation) + JSON/CSV encoders + merge by
  `(framework, variant)`. Unit-tested: percentile math, merge/replace, JSON
  round-trip + deterministic order, CSV.
- **`benchmarks/scripts/footprint`** — CLI that turns raw measurements into a
  typed row and merges it into `footprint.{json,csv}`. Tested (accumulates
  container + embedded rows, rejects bad input).
- **`benchmarks/scripts/footprint-all.sh`** — orchestrator, reusing the
  sourceable `run-crud-all.sh` for app identity. Per app: cold-start =
  container-start → first `200` on `/livez` over `COLD_START_RUNS` restarts
  (median/p95, default 20 = the issue's "≥20 runs"); idle/loaded memory from the
  `docker stats` cgroup working set; peak CPU while the crud-list workload drives
  it; image size. The one parsing bit (`to_bytes`) has its own shell test.

#141 — partial (one Phase 6 slice; the issue stays open).

## Acceptance criteria

- [x] `make benchmark-footprint` produces footprint rows (cold-start, idle/loaded
      memory, CPU-under-load, image size) for all six **containerized** apps.
- [ ] Embedded-Gombit single-binary variant — follow-up (see scope notes).

## Scope notes

The **embedded-Gombit** variant (`gombit build --embed`: binary + image size,
cold start, idle memory) is deferred. The footprint schema and CLI already carry
it (`variant: embedded`, `binary_size_bytes`), so it's a matter of wiring the
build — but `gombit build --embed` could not run in the dev environment used
here: pnpm 11 refuses esbuild's build script (`ERR_PNPM_IGNORED_BUILDS`), and the
npm fallback hit WSL/Windows interop (`cmd.exe`/`tsc`). That's a `gombit build
--embed` / frontend-toolchain issue outside this suite, so I deferred it rather
than fake a number or ship an untested measurement path.

## Validation

- [x] `go build ./...`; `go vet`; `gofmt -l` clean; `golangci-lint` 0 issues
- [x] `go test ./benchmarks/internal/footprint/... ./benchmarks/scripts/footprint/...`
- [x] `bash benchmarks/scripts/footprint-all_test.sh` (to_bytes conversions);
      `run-crud-all_test.sh` still green
- [x] End to end (reduced params, `APPS=gin-gorm COLD_START_RUNS=3`): builds,
      migrates, seeds, cold-start median ~117ms / p95 ~120ms, idle ~8 MB, loaded
      ~19 MB, CPU sampled, image ~22 MB, all recorded into `footprint.json`/`.csv`.
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests — the footprint schema/CLI (Go) and the shell
      parser; the Docker orchestration is glue over them. DB matrix: N/A.
- [x] Stable features ship docs and appear in an example app — `benchmarks/README`
      footprint section + tree, `results/README` layout, plan Phase 6 note; runs
      against all six example apps.
- [x] Extraction preserves contracts — N/A: new tooling.
- [ ] Generators — N/A.
- [ ] API changes regenerate OpenAPI + TS client — N/A.
- [x] No secrets in generated frontend source — N/A.
- [x] Scope stays inside this issue's milestone — M6/BENCH-1; no battery creep.
- [x] Links its issue and states which acceptance criteria it satisfies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
