### PR TITLE
feat: BENCH-1 add the all-in-one `make benchmark` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-# Benchmark developer UX (issue #141 §10). The crud/crud-all/micro/footprint/
-# summary/report/metadata targets are here; -auth, -techempower, and the
-# all-in-one benchmark land with their phases.
+# Benchmark developer UX (issue #141 §10). The all-in-one `benchmark` plus the
+# crud/crud-all/micro/footprint/summary/report/metadata targets are here;
+# -auth and -techempower land with their phases.
 #
 # Run configuration is sourced from benchmarks/config/versions.env (the single
 # source of truth for the pinned k6 version, resource limits, and workload
@@ -26,7 +26,27 @@ OUT_DIR ?= benchmarks/results/latest
 # applied verdict per app (via inspect-limits).
 INTENDED_LIMITS ?= intended (applied only under benchmark-crud-all): app $(APP_CPUS)cpu/$(APP_MEMORY); postgres $(POSTGRES_CPUS)cpu/$(POSTGRES_MEMORY)
 
-.PHONY: benchmark-crud benchmark-crud-all benchmark-micro benchmark-footprint benchmark-summary benchmark-metadata benchmark-report benchmark-report-check
+.PHONY: benchmark benchmark-crud benchmark-crud-all benchmark-micro benchmark-footprint benchmark-summary benchmark-metadata benchmark-report benchmark-report-check
+
+## benchmark: run the whole suite end to end into OUT_DIR and regenerate the
+## README ## Performance block + summary.md — the one-command dedicated-host
+## run. Uses the canonical pins from versions.env by default (concurrency
+## 1/10/100/500/1000, 5 trials x 30s, 10s warm-up, 20 cold starts); narrow any
+## on the command line for a reduced run, e.g.
+##
+##   make benchmark                          # canonical
+##   make benchmark CONCURRENCY=1,10,100      # reduced sweep (unsustained 1000)
+##
+## Each step is invoked via $(MAKE) so they run strictly in order (they share the
+## compose stack and OUT_DIR) even under `make -j`. Bring a fresh Postgres up
+## first for clean app databases:
+##   docker compose --env-file $(BENCH_CONFIG) -f benchmarks/compose.yml down -v && \
+##     docker compose --env-file $(BENCH_CONFIG) -f benchmarks/compose.yml up -d postgres
+benchmark:
+	$(MAKE) benchmark-crud-all
+	$(MAKE) benchmark-footprint
+	$(MAKE) benchmark-micro
+	$(MAKE) benchmark-report
 
 # Framework-tax microbenchmark sample count (-count). Every ns/op sample is
 # persisted to microbench.json and the report publishes the median, so this is

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@
 # source of truth for the pinned k6 version, resource limits, and workload
 # defaults); any variable can be overridden on the command line.
 
+# A bare `make` at repo root must NOT run the multi-hour six-app suite and
+# rewrite the committed README — it prints the target list instead. `benchmark`
+# is an explicit command (issue #141 §10), never the accidental default goal, so
+# the default is pinned to `help` here rather than left to fall through to
+# whichever target happens to appear first in the file.
+.DEFAULT_GOAL := help
+
 BENCH_CONFIG ?= benchmarks/config/versions.env
 include $(BENCH_CONFIG)
 
@@ -26,13 +33,21 @@ OUT_DIR ?= benchmarks/results/latest
 # applied verdict per app (via inspect-limits).
 INTENDED_LIMITS ?= intended (applied only under benchmark-crud-all): app $(APP_CPUS)cpu/$(APP_MEMORY); postgres $(POSTGRES_CPUS)cpu/$(POSTGRES_MEMORY)
 
-.PHONY: benchmark benchmark-crud benchmark-crud-all benchmark-micro benchmark-footprint benchmark-summary benchmark-metadata benchmark-report benchmark-report-check
+.PHONY: help benchmark benchmark-crud benchmark-crud-all benchmark-micro benchmark-footprint benchmark-summary benchmark-metadata benchmark-report benchmark-report-check
+
+## help: list the benchmark targets (the default goal — a bare `make` prints
+## this, never a multi-hour run). Full docs: benchmarks/README.md.
+help:
+	@echo "Gombit benchmark targets (make <target>; see benchmarks/README.md):"
+	@echo ""
+	@grep -hE '^## [a-z][a-z0-9-]*:' $(MAKEFILE_LIST) | sed -E 's/^## /  make /'
 
 ## benchmark: run the whole suite end to end into OUT_DIR and regenerate the
 ## README ## Performance block + summary.md — the one-command dedicated-host
-## run. Uses the canonical pins from versions.env by default (concurrency
-## 1/10/100/500/1000, 5 trials x 30s, 10s warm-up, 20 cold starts); narrow any
-## on the command line for a reduced run, e.g.
+## run. The CRUD pins come from versions.env (concurrency 1/10/100/500/1000,
+## 5 trials x 30s, 10s warm-up); the cold-start count is footprint-all.sh's
+## COLD_START_RUNS default (20). Narrow any on the command line for a reduced
+## run, e.g.
 ##
 ##   make benchmark                          # canonical
 ##   make benchmark CONCURRENCY=1,10,100      # reduced sweep (unsustained 1000)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -125,9 +125,19 @@ docker compose --env-file benchmarks/config/versions.env -f benchmarks/compose.y
 docker compose --env-file benchmarks/config/versions.env -f benchmarks/compose.yml up -d postgres
 
 make benchmark                       # crud-all -> footprint -> micro -> report
-# canonical pins by default (1/10/100/500/1000 × 5 × 30s); narrow for a reduced run:
+# CRUD pins from versions.env by default (1/10/100/500/1000 × 5 × 30s, 10s
+# warm-up); cold starts default to footprint-all.sh's COLD_START_RUNS (20).
+# Narrow any on the command line for a reduced run:
 make benchmark CONCURRENCY=1,10,100  # e.g. if 500/1000 VUs are unsustained
 ```
+
+`make benchmark` is an explicit command, never the default goal — a bare `make`
+prints the target list (`make help`) so it can never accidentally kick off the
+multi-hour six-app run and rewrite the committed README. The stages compose as
+sequential recursive `$(MAKE)` lines (not prerequisites), so they stay ordered
+even under `make -j` and a failed stage halts the chain;
+`benchmarks/scripts/benchmark-target_test.sh` locks that (order, pin
+propagation, fail-closed) without Docker by stubbing the recursive make.
 
 The individual `make benchmark-crud-all`, `-footprint`, `-micro`, and `-report`
 targets below run each stage on its own.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -114,6 +114,24 @@ Markdown report is always generated from that, never the other way around.
 Pinned versions and limits are in
 [`benchmarks/config/versions.env`](config/versions.env).
 
+## Running the whole suite
+
+One command runs everything into `benchmarks/results/latest/` and regenerates
+the README `## Performance` block — the dedicated-host snapshot run:
+
+```sh
+# fresh Postgres for clean per-app databases:
+docker compose --env-file benchmarks/config/versions.env -f benchmarks/compose.yml down -v
+docker compose --env-file benchmarks/config/versions.env -f benchmarks/compose.yml up -d postgres
+
+make benchmark                       # crud-all -> footprint -> micro -> report
+# canonical pins by default (1/10/100/500/1000 × 5 × 30s); narrow for a reduced run:
+make benchmark CONCURRENCY=1,10,100  # e.g. if 500/1000 VUs are unsustained
+```
+
+The individual `make benchmark-crud-all`, `-footprint`, `-micro`, and `-report`
+targets below run each stage on its own.
+
 ## Running the CRUD-read workload
 
 The headline workload is `GET /api/projects?page=1&limit=20`

--- a/benchmarks/scripts/benchmark-target_test.sh
+++ b/benchmarks/scripts/benchmark-target_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Tests for the all-in-one `make benchmark` target (issue #141 §10). The four
+# stages are composed as sequential recursive `$(MAKE)` lines in ONE recipe — not
+# a prerequisite list — precisely so they stay ordered under `make -j` (four
+# compose-sharing stages must never run at once) and so a failed stage aborts the
+# chain. None of that is exercised by the per-stage tests, and the obvious
+# "cleanup" refactor to `benchmark: benchmark-crud-all benchmark-footprint ...`
+# looks identical without `-j`. This locks the contract WITHOUT Docker by
+# overriding the special `MAKE` variable so every `$(MAKE) benchmark-<stage>`
+# line runs a recording stub instead of the real (hours-long) stage.
+#
+#   bash benchmarks/scripts/benchmark-target_test.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail=0
+note() { echo "FAIL: $*" >&2; fail=1; }
+
+# ---- 1. a bare `make` must not be the full suite ----
+# The default goal must be an explicit, cheap target (help) — never `benchmark`,
+# which would make a bare `make` at repo root a multi-hour run that rewrites the
+# committed README. Reading it off `make -p` is the same check the review used.
+goal="$(make -p -n 2>/dev/null | grep -E '^\.DEFAULT_GOAL' | head -1 | sed -E 's/.*:= *//')"
+[ "$goal" = "help" ] || note "default goal is '$goal', want 'help' (a bare make must not run the suite)"
+
+# ---- 2. `benchmark` is composed as recipe lines, not prerequisites ----
+# A prerequisite list (`benchmark: benchmark-crud-all ...`) would let `make -j`
+# run the four stages concurrently. The rule's own line must carry no
+# prerequisites; the ordering lives in the recipe body.
+prereqs="$(sed -nE 's/^benchmark:[[:space:]]*(.*)$/\1/p' Makefile)"
+[ -z "$prereqs" ] || note "benchmark: has prerequisites '$prereqs' — -j would parallelize the stages; use recipe lines"
+
+# The make-driven cases below intercept the stages by overriding the special
+# MAKE variable, which only reaches recursive `$(MAKE)` lines — NOT a
+# prerequisite list, whose stages the parent make would build for real (Docker).
+# So if the composition regressed to prerequisites, fail fast here instead of
+# launching the real six-app suite.
+if [ "$fail" -ne 0 ]; then
+  echo "benchmark-target_test: FAILED (structural checks; skipping make-driven cases to avoid running the real suite)" >&2
+  exit 1
+fi
+
+# ---- stub over the recursive $(MAKE) so no real stage runs ----
+stubdir="$(mktemp -d)"
+trap 'rm -rf "${stubdir:-}"' EXIT
+REC="$stubdir/log"
+cat > "$stubdir/recmake" <<'EOF'
+#!/usr/bin/env bash
+# Records the stage (its make target arg) and the pins it inherited, then fails
+# if asked to — standing in for one recursive `$(MAKE) benchmark-<stage>` call.
+echo "$1 CONCURRENCY=${CONCURRENCY:-unset} OUT_DIR=${OUT_DIR:-unset} APPS=${APPS:-unset}" >> "$REC"
+[ "${FAIL_ON:-}" = "$1" ] && exit 1
+exit 0
+EOF
+chmod +x "$stubdir/recmake"
+run_benchmark() { REC="$REC" make benchmark MAKE="$stubdir/recmake" "$@"; }
+
+# ---- 3. stages run in the fixed order, even under -j ----
+: > "$REC"
+run_benchmark -j4 CONCURRENCY=1,10 OUT_DIR=/tmp/bench-x APPS=gin-gorm >/dev/null 2>&1 || note "benchmark chain failed on a clean stub run"
+got="$(cut -d' ' -f1 < "$REC" | paste -sd, -)"
+want="benchmark-crud-all,benchmark-footprint,benchmark-micro,benchmark-report"
+[ "$got" = "$want" ] || note "stage order under -j = '$got', want '$want'"
+
+# ---- 4. command-line pins reach every stage's environment ----
+while read -r line; do
+  case "$line" in
+    *"CONCURRENCY=1,10 OUT_DIR=/tmp/bench-x APPS=gin-gorm"*) : ;;
+    *) note "a stage did not inherit the CLI pins: $line" ;;
+  esac
+done < "$REC"
+
+# ---- 5. a failed stage aborts the chain (no later stage runs) ----
+: > "$REC"
+rc=0
+FAIL_ON=benchmark-footprint run_benchmark >/dev/null 2>&1 || rc=$?
+[ "$rc" -ne 0 ] || note "benchmark should fail when a stage fails"
+ran="$(cut -d' ' -f1 < "$REC" | paste -sd, -)"
+[ "$ran" = "benchmark-crud-all,benchmark-footprint" ] \
+  || note "fail-closed broken: stages that ran = '$ran', want the chain to stop after benchmark-footprint"
+if grep -qE '^(benchmark-micro|benchmark-report)' "$REC"; then
+  note "a stage ran after the failed one (chain did not abort)"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "benchmark-target_test: FAILED" >&2
+  exit 1
+fi
+echo "benchmark-target_test: default-goal, no-prereq composition, ordered stages, pin propagation, and fail-closed all pass"


### PR DESCRIPTION
## Summary

Adds **`make benchmark`** — the one-command all-in-one run that turns the
dedicated-host canonical snapshot into a single step plus a commit.

```
make benchmark   # benchmark-crud-all → benchmark-footprint → benchmark-micro → benchmark-report
```

- Each stage is invoked via `$(MAKE)` so they run **strictly in order** even
  under `make -j` (they share the compose stack and `OUT_DIR`), and a **failed
  stage halts the chain** rather than silently continuing.
- Uses the **canonical pins** from `versions.env` by default
  (1/10/100/500/1000 × 5 × 30s, 10s warm-up, 20 cold starts); any is overridable
  for a reduced run (e.g. `make benchmark CONCURRENCY=1,10,100`).
- `benchmarks/README` gains a "Running the whole suite" section (fresh-Postgres
  + `make benchmark`), and the Makefile header lists it as landed.

This directly supports the remaining "canonical dedicated-host snapshot" backlog
item: on a quiet machine it's `docker compose … down -v && up -d postgres`, then
`make benchmark`, then commit `benchmarks/results/latest` + `README.md`.

Refs #141

## Validation

- [x] `make -n benchmark` shows the four stages in order.
- [x] End to end (reduced: `APPS=gin-gorm`, tiny params): crud-all → footprint
      (recorded) → micro (all four stacks) → report ("regenerated the Performance
      block") ran in order and completed 0.
- [x] Verified the chain **halts on failure**: a fail-closed footprint stage
      stopped `make benchmark` with `Error 2` (it did not continue to micro).
- [x] `make benchmark-report-check` clean (smoke used a scratch `OUT_DIR`; the
      committed README/results are untouched).
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests — the composed stages are each already
      unit/integration-tested; this is a Make target verified end to end. DB
      matrix: N/A.
- [x] Stable features ship docs — `benchmarks/README` "Running the whole suite"
      + Makefile target doc.
- [x] Extraction preserves contracts — N/A.
- [ ] Generators — N/A.
- [ ] API changes regenerate OpenAPI + TS client — N/A.
- [x] No secrets in generated frontend source — N/A.
- [x] Scope stays inside this issue's milestone — M6/BENCH-1.
- [x] Links its issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
