### PR TITLE
feat: BENCH-1 per-PR benchmark-smoke CI gate (build six, harness-test the Go pair)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,31 @@ jobs:
       - name: Fail on benchmark report drift
         run: git diff --exit-code -- README.md
 
+  benchmark-smoke:
+    name: Benchmark smoke
+    # Correctness-only guard for the benchmark suite: build all six app images (a
+    # broken Dockerfile fails here) and run the harness end to end (compose up ->
+    # migrate -> seed -> k6 -> parse) against the two Go reference apps with a
+    # tiny 1-VU x 1 short trial. The numbers are discarded (throwaway out-dir);
+    # only success/failure matters. The four ecosystem apps' routes are covered
+    # by their own suites in database-postgres, so this proves the harness path
+    # cheaply rather than re-seeding all six. Docker + Compose v2 are
+    # preinstalled on ubuntu-latest; k6 and Postgres run as pinned images.
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run benchmark smoke
+        run: make benchmark-smoke
+
   database-sqlite:
     name: Database (sqlite)
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,14 +136,16 @@ jobs:
 
   benchmark-smoke:
     name: Benchmark smoke
-    # Correctness-only guard for the benchmark suite: build all six app images (a
-    # broken Dockerfile fails here) and run the harness end to end (compose up ->
-    # migrate -> seed -> k6 -> parse) against the two Go reference apps with a
-    # tiny 1-VU x 1 short trial. The numbers are discarded (throwaway out-dir);
-    # only success/failure matters. The four ecosystem apps' routes are covered
-    # by their own suites in database-postgres, so this proves the harness path
-    # cheaply rather than re-seeding all six. Docker + Compose v2 are
-    # preinstalled on ubuntu-latest; k6 and Postgres run as pinned images.
+    # Correctness-only guard for the benchmark suite (issue #141 §11): build all
+    # six app images (a broken Dockerfile fails here) and run the containerized
+    # harness end to end (compose up -> migrate -> seed -> k6 -> parse) for ALL
+    # SIX apps with a tiny deterministic seed (BENCH_SEED_*) and a 1-VU x 1 short
+    # trial. Detects broken builds, broken endpoints, schema/migration drift,
+    # orchestration failures, and result-parser breakage. Numbers are discarded
+    # (throwaway out-dir); only success/failure matters (no perf gate on noisy
+    # shared runners, per §11). The small seed is what keeps all six affordable
+    # per PR. Docker + Compose v2 are preinstalled on ubuntu-latest; k6 and
+    # Postgres run as pinned images.
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OUT_DIR ?= benchmarks/results/latest
 # applied verdict per app (via inspect-limits).
 INTENDED_LIMITS ?= intended (applied only under benchmark-crud-all): app $(APP_CPUS)cpu/$(APP_MEMORY); postgres $(POSTGRES_CPUS)cpu/$(POSTGRES_MEMORY)
 
-.PHONY: help benchmark benchmark-crud benchmark-crud-all benchmark-micro benchmark-footprint benchmark-summary benchmark-metadata benchmark-report benchmark-report-check
+.PHONY: help benchmark benchmark-smoke benchmark-crud benchmark-crud-all benchmark-micro benchmark-footprint benchmark-summary benchmark-metadata benchmark-report benchmark-report-check
 
 ## help: list the benchmark targets (the default goal — a bare `make` prints
 ## this, never a multi-hour run). Full docs: benchmarks/README.md.
@@ -62,6 +62,26 @@ benchmark:
 	$(MAKE) benchmark-footprint
 	$(MAKE) benchmark-micro
 	$(MAKE) benchmark-report
+
+# The two Go reference apps the smoke exercises end to end. The other four
+# ecosystem apps are still image-built by the smoke (a broken Dockerfile fails
+# there), but their routes are covered by their own suites in the CI
+# database-postgres job, so the harness path (up -> migrate -> seed -> k6 ->
+# parse) is proven cheaply on gin-gorm + gombit rather than re-seeding all six.
+BENCH_SMOKE_APPS ?= gin-gorm gombit
+
+## benchmark-smoke: per-PR correctness guard — build all six app images (a
+## broken Dockerfile fails here) and run the harness end to end (compose up ->
+## migrate -> seed -> k6 -> parse) against the two Go reference apps with a tiny
+## 1-VU x 1 short trial, into a THROWAWAY dir so it never touches
+## results/latest. Numbers are discarded; only pass/fail matters — a route
+## regression or a broken result parser fails the run. This is what CI runs on
+## every PR (the `benchmark-smoke` job in ci.yml).
+benchmark-smoke:
+	docker compose --env-file $(BENCH_CONFIG) -f benchmarks/compose.yml build
+	@dir="$$(mktemp -d)"; trap 'rm -rf "$$dir"' EXIT; \
+		$(MAKE) benchmark-crud-all APPS="$(BENCH_SMOKE_APPS)" OUT_DIR="$$dir" \
+			CONCURRENCY=1 TRIALS=1 DURATION_SECONDS=3 WARMUP_SECONDS=1
 
 # Framework-tax microbenchmark sample count (-count). Every ns/op sample is
 # persisted to microbench.json and the report publishes the median, so this is

--- a/Makefile
+++ b/Makefile
@@ -63,23 +63,28 @@ benchmark:
 	$(MAKE) benchmark-micro
 	$(MAKE) benchmark-report
 
-# The two Go reference apps the smoke exercises end to end. The other four
-# ecosystem apps are still image-built by the smoke (a broken Dockerfile fails
-# there), but their routes are covered by their own suites in the CI
-# database-postgres job, so the harness path (up -> migrate -> seed -> k6 ->
-# parse) is proven cheaply on gin-gorm + gombit rather than re-seeding all six.
-BENCH_SMOKE_APPS ?= gin-gorm gombit
+# The apps the smoke runs end to end (default: all six) and the small
+# deterministic seed it uses (issue #141 §11). 20 users / 100 projects is tiny
+# but keeps a full 20-row first page, which the read workload asserts. Every app
+# reads BENCH_SEED_USERS/BENCH_SEED_PROJECTS with the same semantics
+# (benchmarks/apps/shared.SeedCounts and its per-language ports); unset falls
+# back to the canonical 1,000/100,000.
+BENCH_SMOKE_APPS ?= gin-gorm gombit django rails laravel nestjs
+SMOKE_SEED_USERS ?= 20
+SMOKE_SEED_PROJECTS ?= 100
 
-## benchmark-smoke: per-PR correctness guard — build all six app images (a
-## broken Dockerfile fails here) and run the harness end to end (compose up ->
-## migrate -> seed -> k6 -> parse) against the two Go reference apps with a tiny
-## 1-VU x 1 short trial, into a THROWAWAY dir so it never touches
-## results/latest. Numbers are discarded; only pass/fail matters — a route
-## regression or a broken result parser fails the run. This is what CI runs on
-## every PR (the `benchmark-smoke` job in ci.yml).
+## benchmark-smoke: per-PR correctness guard (issue #141 §11) — build all six
+## app images (a broken Dockerfile fails here) and run the containerized harness
+## end to end (compose up -> migrate -> seed -> k6 -> parse) for all six with a
+## tiny deterministic seed and a 1-VU x 1 short trial, into a THROWAWAY dir so it
+## never touches results/latest. Numbers are discarded; only pass/fail matters —
+## a broken image, endpoint, migration/schema, orchestration, or result parser
+## fails the run. This is what CI runs on every PR (the `benchmark-smoke` job in
+## ci.yml). The small seed is what keeps all six affordable per PR.
 benchmark-smoke:
 	docker compose --env-file $(BENCH_CONFIG) -f benchmarks/compose.yml build
 	@dir="$$(mktemp -d)"; trap 'rm -rf "$$dir"' EXIT; \
+		BENCH_SEED_USERS=$(SMOKE_SEED_USERS) BENCH_SEED_PROJECTS=$(SMOKE_SEED_PROJECTS) \
 		$(MAKE) benchmark-crud-all APPS="$(BENCH_SMOKE_APPS)" OUT_DIR="$$dir" \
 			CONCURRENCY=1 TRIALS=1 DURATION_SECONDS=3 WARMUP_SECONDS=1
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -74,9 +74,9 @@ snapshot already backs the README numbers, but from a **reduced run on a single
 dev host** (recorded in `metadata.json` and printed in the README block); still
 scoped to later phases: the embedded-Gombit single-binary footprint variant, the
 other `make benchmark-*` workloads, extending `fairness_test.go` to all six,
-re-running the full canonical sweep on dedicated hardware, the `benchmark-smoke`
-CI job that builds the six app images, and the `benchmarks.yml` manual workflow
-(Phase 8).
+re-running the full canonical sweep on dedicated hardware, and the
+`benchmarks.yml` manual workflow (Phase 8). The per-PR `benchmark-smoke` CI job
+is in (see below).
 
 ## Resource limits (§7): intention vs. reality
 
@@ -152,17 +152,20 @@ make benchmark-smoke
 ```
 
 It builds **all six** app images (`docker compose build` — a broken Dockerfile
-fails here), then runs the harness end to end (compose up → migrate → seed → k6
-→ parse) against the **two Go reference apps** (`gin-gorm`, `gombit`) with a tiny
-1-VU × 1 short trial, into a throwaway `mktemp` dir — so a route regression or a
-broken result parser fails CI, and the run never touches `results/latest`. The
-numbers are discarded; only pass/fail matters. The four ecosystem apps' routes
-are covered by their own suites in the `database-postgres` CI job, so the smoke
-proves the containerized harness path cheaply rather than re-seeding all six
-(the heavier all-six run — plus a tiny-seed knob across the six languages — is a
-follow-up). `benchmarks/scripts/benchmark-target_test.sh` locks the target's
-contract (builds all six, runs the two-Go-app tiny params, throwaway `OUT_DIR`)
-without Docker by stubbing the recursive make and `docker`.
+fails here), then runs the containerized harness end to end (compose up →
+migrate → seed → k6 → parse) for **all six** apps with a **small deterministic
+seed** (20 users / 100 projects, enough for the workload's full 20-row first
+page) and a 1-VU × 1 short trial, into a throwaway `mktemp` dir. This is the
+issue #141 §11 smoke: it detects broken builds, broken endpoints, schema/
+migration drift, orchestration failures, and result-parser breakage. The numbers
+are discarded and `results/latest` is never touched — only pass/fail matters (no
+perf gate on noisy shared runners). The small seed is what keeps all six
+affordable per PR: every app reads `BENCH_SEED_USERS` / `BENCH_SEED_PROJECTS`
+with the same semantics (`benchmarks/apps/shared.SeedCounts` and its per-language
+ports; unset → the canonical 1,000/100,000). `benchmark-target_test.sh` locks the
+target's contract (builds all six, runs all six with the tiny params + small
+seed, throwaway `OUT_DIR`) without Docker by stubbing the recursive make and
+`docker`.
 
 ## Running the CRUD-read workload
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -142,6 +142,28 @@ propagation, fail-closed) without Docker by stubbing the recursive make.
 The individual `make benchmark-crud-all`, `-footprint`, `-micro`, and `-report`
 targets below run each stage on its own.
 
+### Per-PR smoke
+
+`make benchmark-smoke` is the fast correctness guard CI runs on every PR (the
+`benchmark-smoke` job in `.github/workflows/ci.yml`, `needs: test`):
+
+```sh
+make benchmark-smoke
+```
+
+It builds **all six** app images (`docker compose build` — a broken Dockerfile
+fails here), then runs the harness end to end (compose up → migrate → seed → k6
+→ parse) against the **two Go reference apps** (`gin-gorm`, `gombit`) with a tiny
+1-VU × 1 short trial, into a throwaway `mktemp` dir — so a route regression or a
+broken result parser fails CI, and the run never touches `results/latest`. The
+numbers are discarded; only pass/fail matters. The four ecosystem apps' routes
+are covered by their own suites in the `database-postgres` CI job, so the smoke
+proves the containerized harness path cheaply rather than re-seeding all six
+(the heavier all-six run — plus a tiny-seed knob across the six languages — is a
+follow-up). `benchmarks/scripts/benchmark-target_test.sh` locks the target's
+contract (builds all six, runs the two-Go-app tiny params, throwaway `OUT_DIR`)
+without Docker by stubbing the recursive make and `docker`.
+
 ## Running the CRUD-read workload
 
 The headline workload is `GET /api/projects?page=1&limit=20`

--- a/benchmarks/apps/django/projects/management/commands/seed.py
+++ b/benchmarks/apps/django/projects/management/commands/seed.py
@@ -1,4 +1,6 @@
-from django.core.management.base import BaseCommand
+import os
+
+from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
 
 from projects.models import Project, User
@@ -77,8 +79,25 @@ def seed_database_n(user_count, project_count):
     )
 
 
+# BENCH_SEED_USERS / BENCH_SEED_PROJECTS override the row counts for the CI
+# smoke's small deterministic seed (issue #141 §11) — same content formulas,
+# fewer rows. Unset/empty means the canonical default; a non-empty value that
+# is not a positive integer is a fatal error, never a silent fall back to 100k.
+# Same names and semantics as benchmarks/apps/shared.SeedCounts (Go).
+def _seed_count(env, default):
+    raw = os.environ.get(env, "").strip()
+    if raw == "":
+        return default
+    if not raw.isdigit() or int(raw) < 1:
+        raise CommandError(f"{env}={raw!r}: must be a positive integer")
+    return int(raw)
+
+
 def seed_database():
-    seed_database_n(SEED_USER_COUNT, SEED_PROJECT_COUNT)
+    seed_database_n(
+        _seed_count("BENCH_SEED_USERS", SEED_USER_COUNT),
+        _seed_count("BENCH_SEED_PROJECTS", SEED_PROJECT_COUNT),
+    )
 
 
 class Command(BaseCommand):

--- a/benchmarks/apps/gin-gorm/seed.go
+++ b/benchmarks/apps/gin-gorm/seed.go
@@ -15,9 +15,14 @@ import (
 const seedBatchSize = 1000
 
 // seedDatabase truncates and repopulates the canonical benchmark dataset at
-// production scale. See seedDatabaseN.
+// production scale — or the small deterministic size BENCH_SEED_USERS/
+// BENCH_SEED_PROJECTS request (issue #141 §11's CI smoke). See seedDatabaseN.
 func seedDatabase(ctx context.Context, db *gorm.DB) error {
-	return seedDatabaseN(ctx, db, shared.SeedUserCount, shared.SeedProjectCount)
+	users, projects, err := shared.SeedCounts()
+	if err != nil {
+		return err
+	}
+	return seedDatabaseN(ctx, db, users, projects)
 }
 
 // seedDatabaseN is seedDatabase parameterized by row counts, so tests can

--- a/benchmarks/apps/gombit/seed.go
+++ b/benchmarks/apps/gombit/seed.go
@@ -15,14 +15,19 @@ import (
 // content formulas and row counts — matching benchmarks/apps/gin-gorm/seed.go.
 const seedBatchSize = 1000
 
-// seedDatabase truncates and repopulates the canonical benchmark dataset at
-// production scale using benchmarks/apps/shared's deterministic content
+// seedDatabase truncates and repopulates the canonical benchmark dataset — at
+// production scale, or the small BENCH_SEED_USERS/BENCH_SEED_PROJECTS size the
+// CI smoke requests (issue #141 §11) — using benchmarks/apps/shared's content
 // formulas, the same ones benchmarks/apps/gin-gorm/seed.go uses, so the two
 // implementations' seeded row N are content-identical. See
 // benchmarks/apps/gin-gorm/seed.go's seedDatabaseN for the truncate/identity
 // reasoning this mirrors.
 func seedDatabase(ctx context.Context, db *gorm.DB) error {
-	return seedDatabaseN(ctx, db, shared.SeedUserCount, shared.SeedProjectCount)
+	users, projects, err := shared.SeedCounts()
+	if err != nil {
+		return err
+	}
+	return seedDatabaseN(ctx, db, users, projects)
 }
 
 func seedDatabaseN(ctx context.Context, db *gorm.DB, userCount, projectCount int) error {

--- a/benchmarks/apps/laravel/app/Support/CanonicalSeed.php
+++ b/benchmarks/apps/laravel/app/Support/CanonicalSeed.php
@@ -97,8 +97,31 @@ class CanonicalSeed
         }
     }
 
+    // BENCH_SEED_USERS / BENCH_SEED_PROJECTS override the row counts for the CI
+    // smoke's small deterministic seed (issue #141 §11) — same content
+    // formulas, fewer rows. Unset/empty means the canonical default; a
+    // non-empty value that is not a positive integer is a fatal error, never a
+    // silent fall back to 100k. Same names and semantics as
+    // benchmarks/apps/shared.SeedCounts (Go). getenv (not env()) so it reads the
+    // real process environment the container is given, unaffected by config
+    // caching.
+    private static function seedCount(string $env, int $default): int
+    {
+        $raw = trim((string) getenv($env));
+        if ($raw === '') {
+            return $default;
+        }
+        if (preg_match('/^[1-9]\d*$/', $raw) !== 1) {
+            throw new \InvalidArgumentException("{$env}={$raw}: must be a positive integer");
+        }
+        return (int) $raw;
+    }
+
     public static function seedDatabase(): void
     {
-        self::seedDatabaseN(self::USER_COUNT, self::PROJECT_COUNT);
+        self::seedDatabaseN(
+            self::seedCount('BENCH_SEED_USERS', self::USER_COUNT),
+            self::seedCount('BENCH_SEED_PROJECTS', self::PROJECT_COUNT),
+        );
     }
 }

--- a/benchmarks/apps/nestjs/src/seed.ts
+++ b/benchmarks/apps/nestjs/src/seed.ts
@@ -54,10 +54,28 @@ export async function seedDatabaseN(
   }
 }
 
+// BENCH_SEED_USERS / BENCH_SEED_PROJECTS override the row counts for the CI
+// smoke's small deterministic seed (issue #141 §11) — same content formulas,
+// fewer rows. Unset/empty means the canonical default; a non-empty value that
+// is not a positive integer is a fatal error, never a silent fall back to 100k.
+// Same names and semantics as benchmarks/apps/shared.SeedCounts (Go).
+function seedCount(env: string, def: number): number {
+  const raw = (process.env[env] ?? '').trim();
+  if (raw === '') {
+    return def;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`${env}=${raw}: must be a positive integer`);
+  }
+  return Number(raw);
+}
+
 async function main(): Promise<void> {
+  const userCount = seedCount('BENCH_SEED_USERS', USER_COUNT);
+  const projectCount = seedCount('BENCH_SEED_PROJECTS', PROJECT_COUNT);
   await AppDataSource.initialize();
   try {
-    await seedDatabaseN(AppDataSource, USER_COUNT, PROJECT_COUNT);
+    await seedDatabaseN(AppDataSource, userCount, projectCount);
     console.log('nestjs: seed complete');
   } finally {
     await AppDataSource.destroy();

--- a/benchmarks/apps/rails/app/services/canonical_seed.rb
+++ b/benchmarks/apps/rails/app/services/canonical_seed.rb
@@ -70,7 +70,22 @@ module CanonicalSeed
     end
   end
 
+  # BENCH_SEED_USERS / BENCH_SEED_PROJECTS override the row counts for the CI
+  # smoke's small deterministic seed (issue #141 §11) — same content formulas,
+  # fewer rows. Unset/empty means the canonical default; a non-empty value that
+  # is not a positive integer is a fatal error, never a silent fall back to
+  # 100k. Same names and semantics as benchmarks/apps/shared.SeedCounts (Go).
+  def seed_count(env, default)
+    raw = ENV[env].to_s.strip
+    return default if raw.empty?
+    raise ArgumentError, "#{env}=#{raw.inspect}: must be a positive integer" unless raw.match?(/\A[1-9]\d*\z/)
+    raw.to_i
+  end
+
   def seed_database
-    seed_database_n(USER_COUNT, PROJECT_COUNT)
+    seed_database_n(
+      seed_count("BENCH_SEED_USERS", USER_COUNT),
+      seed_count("BENCH_SEED_PROJECTS", PROJECT_COUNT),
+    )
   end
 end

--- a/benchmarks/apps/shared/seed.go
+++ b/benchmarks/apps/shared/seed.go
@@ -1,6 +1,11 @@
 package shared
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
 
 // SeedUserCount and SeedProjectCount are issue #141's recommended initial
 // dataset (benchmarks/docs/schema.md "Seed dataset"), shared so every
@@ -10,6 +15,46 @@ const (
 	SeedUserCount    = 1000
 	SeedProjectCount = 100000
 )
+
+// SeedUsersEnv and SeedProjectsEnv override the seeded row counts for a run.
+// They exist for the CI smoke's small deterministic seed (issue #141 §11): a
+// tiny row count over the SAME deterministic content formulas, so the
+// containerized migrate → seed → serve → k6 path is exercised on every PR
+// without a 100,000-row insert. Every implementation (Go, Python, Ruby, PHP,
+// Node) reads these exact names with the same semantics — unset/empty means the
+// canonical default; a non-empty value that is not a positive integer is a
+// fatal error, never a silent fall back to 100k. Note the read workload asserts
+// a full 20-row first page, so an override must keep at least 20 projects.
+const (
+	SeedUsersEnv    = "BENCH_SEED_USERS"
+	SeedProjectsEnv = "BENCH_SEED_PROJECTS"
+)
+
+// SeedCounts resolves the user and project counts to seed: the canonical
+// constants, unless SeedUsersEnv / SeedProjectsEnv are set to a positive
+// integer. A malformed override is returned as an error rather than silently
+// falling back, so a typo in CI fails loudly instead of seeding 100k.
+func SeedCounts() (users, projects int, err error) {
+	if users, err = seedCount(SeedUsersEnv, SeedUserCount); err != nil {
+		return 0, 0, err
+	}
+	if projects, err = seedCount(SeedProjectsEnv, SeedProjectCount); err != nil {
+		return 0, 0, err
+	}
+	return users, projects, nil
+}
+
+func seedCount(env string, def int) (int, error) {
+	raw := strings.TrimSpace(os.Getenv(env))
+	if raw == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return 0, fmt.Errorf("%s=%q: must be a positive integer", env, raw)
+	}
+	return n, nil
+}
 
 // UserEmail, UserName, ProjectOwnerID, ProjectName, and ProjectDescription
 // are the pure, deterministic-content formulas issue #141's seed dataset

--- a/benchmarks/apps/shared/seed_test.go
+++ b/benchmarks/apps/shared/seed_test.go
@@ -2,6 +2,55 @@ package shared
 
 import "testing"
 
+// TestSeedCountsEnvOverride locks the small-deterministic-seed contract (issue
+// #141 §11) the CI smoke and every per-language port depend on: unset/empty ->
+// canonical, a positive integer overrides, and a malformed value is a fatal
+// error rather than a silent fall back to 100k.
+func TestSeedCountsEnvOverride(t *testing.T) {
+	t.Run("unset -> canonical", func(t *testing.T) {
+		u, p, err := SeedCounts()
+		if err != nil {
+			t.Fatalf("SeedCounts() unset: %v", err)
+		}
+		if u != SeedUserCount || p != SeedProjectCount {
+			t.Errorf("unset = %d/%d, want canonical %d/%d", u, p, SeedUserCount, SeedProjectCount)
+		}
+	})
+
+	t.Run("positive integers override", func(t *testing.T) {
+		t.Setenv(SeedUsersEnv, "20")
+		t.Setenv(SeedProjectsEnv, "100")
+		u, p, err := SeedCounts()
+		if err != nil {
+			t.Fatalf("SeedCounts() override: %v", err)
+		}
+		if u != 20 || p != 100 {
+			t.Errorf("override = %d/%d, want 20/100", u, p)
+		}
+	})
+
+	t.Run("empty -> canonical", func(t *testing.T) {
+		t.Setenv(SeedUsersEnv, "")
+		t.Setenv(SeedProjectsEnv, "   ")
+		u, p, err := SeedCounts()
+		if err != nil {
+			t.Fatalf("SeedCounts() empty: %v", err)
+		}
+		if u != SeedUserCount || p != SeedProjectCount {
+			t.Errorf("empty = %d/%d, want canonical", u, p)
+		}
+	})
+
+	for _, bad := range []string{"0", "-5", "abc", "12x", "1.5"} {
+		t.Run("malformed "+bad+" is fatal", func(t *testing.T) {
+			t.Setenv(SeedUsersEnv, bad)
+			if _, _, err := SeedCounts(); err == nil {
+				t.Errorf("SeedCounts() with %s=%q = nil error; want a failure, not a silent fall back", SeedUsersEnv, bad)
+			}
+		})
+	}
+}
+
 // TestSeedContentIsDeterministic pins the exact deterministic-content
 // formulas issue #141's seed dataset requires ("the same values for every
 // implementation"). No database, no build tag.

--- a/benchmarks/compose.yml
+++ b/benchmarks/compose.yml
@@ -78,6 +78,11 @@ services:
     command: ["serve"]
     environment:
       DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench?sslmode=disable
+      # Small deterministic seed for the CI smoke (issue #141 §11); empty ->
+      # the app's canonical 1,000/100,000 default. Passed through to the `seed`
+      # container from the orchestrator's environment.
+      BENCH_SEED_USERS: "${BENCH_SEED_USERS:-}"
+      BENCH_SEED_PROJECTS: "${BENCH_SEED_PROJECTS:-}"
       PORT: "8081"
       POOL_MAX_OPEN: "${POOL_MAX_OPEN:-20}"
       POOL_MAX_IDLE: "${POOL_MAX_IDLE:-20}"
@@ -124,6 +129,8 @@ services:
     command: ["serve"]
     environment:
       DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench_gombit?sslmode=disable
+      BENCH_SEED_USERS: "${BENCH_SEED_USERS:-}"
+      BENCH_SEED_PROJECTS: "${BENCH_SEED_PROJECTS:-}"
       # The migrate verb creates TARGET_DB if absent, connecting via
       # ADMIN_DATABASE_URL (an existing DB on the same server) — idempotent,
       # every bring-up, no fresh-volume dependency.
@@ -168,6 +175,8 @@ services:
     environment:
       DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench_django?sslmode=disable
       ADMIN_DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench?sslmode=disable
+      BENCH_SEED_USERS: "${BENCH_SEED_USERS:-}"
+      BENCH_SEED_PROJECTS: "${BENCH_SEED_PROJECTS:-}"
       TARGET_DB: gombit_bench_django
       PORT: "8082"
       GUNICORN_WORKERS: "4"
@@ -209,6 +218,8 @@ services:
     command: ["serve"]
     environment:
       DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench_rails?sslmode=disable
+      BENCH_SEED_USERS: "${BENCH_SEED_USERS:-}"
+      BENCH_SEED_PROJECTS: "${BENCH_SEED_PROJECTS:-}"
       PORT: "8083"
       WEB_CONCURRENCY: "2"
       RAILS_MAX_THREADS: "3"
@@ -252,6 +263,8 @@ services:
     environment:
       DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench_laravel?sslmode=disable
       ADMIN_DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench?sslmode=disable
+      BENCH_SEED_USERS: "${BENCH_SEED_USERS:-}"
+      BENCH_SEED_PROJECTS: "${BENCH_SEED_PROJECTS:-}"
       TARGET_DB: gombit_bench_laravel
       DB_CONNECTION: pgsql
       APP_ENV: production
@@ -294,6 +307,8 @@ services:
     environment:
       DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench_nestjs?sslmode=disable
       ADMIN_DATABASE_URL: postgres://gombit:gombit@postgres:5432/gombit_bench?sslmode=disable
+      BENCH_SEED_USERS: "${BENCH_SEED_USERS:-}"
+      BENCH_SEED_PROJECTS: "${BENCH_SEED_PROJECTS:-}"
       TARGET_DB: gombit_bench_nestjs
       NODE_ENV: production
       PORT: "8085"

--- a/benchmarks/scripts/benchmark-target_test.sh
+++ b/benchmarks/scripts/benchmark-target_test.sh
@@ -84,8 +84,36 @@ if grep -qE '^(benchmark-micro|benchmark-report)' "$REC"; then
   note "a stage ran after the failed one (chain did not abort)"
 fi
 
+# ---- 6. benchmark-smoke: build all six images, harness-test the two Go apps
+#         with tiny params, into a THROWAWAY dir (never results/latest) ----
+# A full argv-recording stub for the recursive $(MAKE) (the recmake above only
+# kept a few fields), and a docker stub so `docker compose build` no-ops.
+smokerec="$stubdir/smokelog"; : > "$smokerec"
+printf '#!/usr/bin/env bash\necho "$*" >> "%s"\nexit 0\n' "$smokerec" > "$stubdir/argmake"
+dockrec="$stubdir/dockerlog"; : > "$dockrec"
+printf '#!/usr/bin/env bash\necho "$*" >> "%s"\nexit 0\n' "$dockrec" > "$stubdir/docker"
+chmod +x "$stubdir/argmake" "$stubdir/docker"
+
+PATH="$stubdir:$PATH" make benchmark-smoke MAKE="$stubdir/argmake" >/dev/null 2>&1 \
+  || note "benchmark-smoke failed on a clean stub run"
+
+# Built all six: `docker compose … build` with NO trailing service name.
+grep -qE 'compose .*-f benchmarks/compose.yml build$' "$dockrec" \
+  || note "benchmark-smoke did not build all app images: $(cat "$dockrec")"
+
+smokeargs="$(cat "$smokerec")"
+case "$smokeargs" in
+  *"benchmark-crud-all"*"APPS=gin-gorm gombit"*"CONCURRENCY=1"*"TRIALS=1"*"DURATION_SECONDS=3"*"WARMUP_SECONDS=1"*) : ;;
+  *) note "benchmark-smoke did not run crud-all with the tiny two-Go-app params: $smokeargs" ;;
+esac
+case "$smokeargs" in
+  *"OUT_DIR=benchmarks/results/latest"*) note "benchmark-smoke targeted results/latest, not a throwaway dir: $smokeargs" ;;
+  *"OUT_DIR="*) : ;;
+  *) note "benchmark-smoke passed no OUT_DIR (would default to results/latest): $smokeargs" ;;
+esac
+
 if [ "$fail" -ne 0 ]; then
   echo "benchmark-target_test: FAILED" >&2
   exit 1
 fi
-echo "benchmark-target_test: default-goal, no-prereq composition, ordered stages, pin propagation, and fail-closed all pass"
+echo "benchmark-target_test: default-goal, no-prereq composition, ordered stages, pin propagation, fail-closed, and smoke (build-6/harness-2/throwaway) all pass"

--- a/benchmarks/scripts/benchmark-target_test.sh
+++ b/benchmarks/scripts/benchmark-target_test.sh
@@ -84,12 +84,14 @@ if grep -qE '^(benchmark-micro|benchmark-report)' "$REC"; then
   note "a stage ran after the failed one (chain did not abort)"
 fi
 
-# ---- 6. benchmark-smoke: build all six images, harness-test the two Go apps
-#         with tiny params, into a THROWAWAY dir (never results/latest) ----
-# A full argv-recording stub for the recursive $(MAKE) (the recmake above only
-# kept a few fields), and a docker stub so `docker compose build` no-ops.
+# ---- 6. benchmark-smoke (issue #141 §11): build all six images, run the
+#         containerized harness for ALL SIX with a tiny deterministic seed and
+#         tiny load, into a THROWAWAY dir (never results/latest) ----
+# A recording stub for the recursive $(MAKE) that captures both the argv and the
+# BENCH_SEED_* env the recipe exports, and a docker stub so `compose build`
+# no-ops.
 smokerec="$stubdir/smokelog"; : > "$smokerec"
-printf '#!/usr/bin/env bash\necho "$*" >> "%s"\nexit 0\n' "$smokerec" > "$stubdir/argmake"
+printf '#!/usr/bin/env bash\necho "$* SEED=${BENCH_SEED_USERS:-unset}/${BENCH_SEED_PROJECTS:-unset}" >> "%s"\nexit 0\n' "$smokerec" > "$stubdir/argmake"
 dockrec="$stubdir/dockerlog"; : > "$dockrec"
 printf '#!/usr/bin/env bash\necho "$*" >> "%s"\nexit 0\n' "$dockrec" > "$stubdir/docker"
 chmod +x "$stubdir/argmake" "$stubdir/docker"
@@ -102,9 +104,17 @@ grep -qE 'compose .*-f benchmarks/compose.yml build$' "$dockrec" \
   || note "benchmark-smoke did not build all app images: $(cat "$dockrec")"
 
 smokeargs="$(cat "$smokerec")"
+# All six apps, tiny load params, and a small deterministic seed passed through.
+for app in gin-gorm gombit django rails laravel nestjs; do
+  case "$smokeargs" in *"$app"*) : ;; *) note "benchmark-smoke did not run app '$app': $smokeargs" ;; esac
+done
 case "$smokeargs" in
-  *"benchmark-crud-all"*"APPS=gin-gorm gombit"*"CONCURRENCY=1"*"TRIALS=1"*"DURATION_SECONDS=3"*"WARMUP_SECONDS=1"*) : ;;
-  *) note "benchmark-smoke did not run crud-all with the tiny two-Go-app params: $smokeargs" ;;
+  *"benchmark-crud-all"*"CONCURRENCY=1"*"TRIALS=1"*"DURATION_SECONDS=3"*"WARMUP_SECONDS=1"*) : ;;
+  *) note "benchmark-smoke did not run crud-all with the tiny params: $smokeargs" ;;
+esac
+case "$smokeargs" in
+  *"SEED=20/100"*) : ;;
+  *) note "benchmark-smoke did not export the small deterministic seed (BENCH_SEED_*): $smokeargs" ;;
 esac
 case "$smokeargs" in
   *"OUT_DIR=benchmarks/results/latest"*) note "benchmark-smoke targeted results/latest, not a throwaway dir: $smokeargs" ;;
@@ -116,4 +126,4 @@ if [ "$fail" -ne 0 ]; then
   echo "benchmark-target_test: FAILED" >&2
   exit 1
 fi
-echo "benchmark-target_test: default-goal, no-prereq composition, ordered stages, pin propagation, fail-closed, and smoke (build-6/harness-2/throwaway) all pass"
+echo "benchmark-target_test: default-goal, no-prereq composition, ordered stages, pin propagation, fail-closed, and smoke (build-6/run-6/small-seed/throwaway) all pass"

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1748,31 +1748,41 @@ and the recurring "the README claims a CI gate that doesn't exist" review
 finding. Verified locally: clean on the committed README, fails (with the diff)
 on a hand-edited block.
 
-**Per-PR `benchmark-smoke` gate — done.** `make benchmark-smoke` and the
-`benchmark-smoke` CI job (needs: `test`) are in. The target builds **all six**
-app images with `docker compose build` — a broken Dockerfile fails here — then
-runs the harness end to end (compose up → migrate → seed → k6 → parse) against
-the **two Go reference apps** (`gin-gorm`, `gombit`) with a tiny 1-VU × 1
-short-trial load into a **throwaway `mktemp` dir**, so a route regression or a
-broken result parser fails CI while the run never touches
-`benchmarks/results/latest`. Coverage split (a deliberate speed/scope choice):
-`docker compose build` catches a broken image for **all six**, and the four
-ecosystem apps' routes are already exercised by their own suites in the
-`database-postgres` job, so the smoke proves the containerized harness path
-cheaply on the Go pair rather than re-seeding all six every PR (the 100 k seed
-is per-app and unparameterized across the six languages; a tiny-seed knob +
-all-six containerized run is the heavier follow-up variant). The
-`benchmark-target_test.sh` stub suite locks the target's contract without Docker
-(builds all six via `compose build`, runs crud-all with the two-Go-app tiny
-params, and — the safety property — passes a throwaway `OUT_DIR`, never
-`results/latest`; the last is regression-checked). **Still open in Phase 8:** the
-`benchmarks.yml` `workflow_dispatch` for the full/selected suites with artifact
-upload.
+**Per-PR `benchmark-smoke` gate — done (the issue #141 §11 smoke).**
+`make benchmark-smoke` and the `benchmark-smoke` CI job (needs: `test`) are in.
+The target builds **all six** app images with `docker compose build` — a broken
+Dockerfile fails here — then runs the **containerized** harness end to end
+(compose up → migrate → seed → k6 → parse) for **all six** apps with a **small
+deterministic seed** and a 1-VU × 1 short-trial load, into a **throwaway
+`mktemp` dir** so it never touches `benchmarks/results/latest`. That covers §11's
+required detections — broken builds, broken endpoints, schema/migration drift,
+orchestration failures, result-parser breakage — and, per §11, gates on
+correctness only (no perf assertion on noisy shared runners; numbers discarded).
+
+The small seed is what makes all-six affordable per PR, and it is a real
+cross-language capability, not a smoke-only hack: every seeder reads
+`BENCH_SEED_USERS` / `BENCH_SEED_PROJECTS` with identical semantics —
+`benchmarks/apps/shared.SeedCounts` (Go, unit-tested: unset → canonical, a
+positive integer overrides, a malformed value is fatal) and independent ports in
+the Django command, the Rails/Laravel `CanonicalSeed`, and the NestJS seeder;
+unset falls back to the canonical 1,000/100,000. compose passes them through to
+each app's `seed` container (`BENCH_SEED_*: "${BENCH_SEED_*:-}"`). The smoke uses
+20 users / 100 projects — tiny, but ≥ 20 projects so the read workload's
+asserted full 20-row first page still holds. An earlier iteration of this slice
+only harness-tested the two Go apps and leaned on `database-postgres` as the
+ecosystem apps' substitute; that was wrong (`database-postgres` tests their
+handlers **in-process**, never the container's `ENTRYPOINT`/migrate/serve path),
+so the smoke now runs the container path for all six. `benchmark-target_test.sh`
+locks the target's contract without Docker (builds all six via `compose build`,
+runs all six with the tiny params, exports the small seed, and — the safety
+property — passes a throwaway `OUT_DIR`, never `results/latest`; regression-
+checked). **Still open in Phase 8:** the `benchmarks.yml` `workflow_dispatch` for
+the full/selected suites with artifact upload.
 
 - ~~`ci.yml`: add a `benchmark-smoke` job (needs: `test`) running
-  `make benchmark-smoke` — 1 short trial, low concurrency, correctness-only, on
-  every PR.~~ **Done** (see above; the "tiny seed" reduction across all six
-  languages is folded into the deferred all-six variant).
+  `make benchmark-smoke` — small deterministic seed, 1 short trial, low
+  concurrency, correctness-only, all six apps, on every PR.~~ **Done** (see
+  above).
 - New `.github/workflows/benchmarks.yml`: `workflow_dispatch` with an input
   to select `micro | crud | auth | techempower | footprint | full`; uploads
   `metadata.json`, raw results, `results.json`, `results.csv`, `summary.md`

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1746,14 +1746,33 @@ no Docker, so it stays cheap on every PR. Regenerate-then-diff mirrors the
 hunk in the log. This closes the "README is regenerable, never hand-edited" AC
 and the recurring "the README claims a CI gate that doesn't exist" review
 finding. Verified locally: clean on the committed README, fails (with the diff)
-on a hand-edited block. **Still open in Phase 8:** the heavier `benchmark-smoke`
-job that builds the six app images and runs a correctness-only tiny run, and the
+on a hand-edited block.
+
+**Per-PR `benchmark-smoke` gate — done.** `make benchmark-smoke` and the
+`benchmark-smoke` CI job (needs: `test`) are in. The target builds **all six**
+app images with `docker compose build` — a broken Dockerfile fails here — then
+runs the harness end to end (compose up → migrate → seed → k6 → parse) against
+the **two Go reference apps** (`gin-gorm`, `gombit`) with a tiny 1-VU × 1
+short-trial load into a **throwaway `mktemp` dir**, so a route regression or a
+broken result parser fails CI while the run never touches
+`benchmarks/results/latest`. Coverage split (a deliberate speed/scope choice):
+`docker compose build` catches a broken image for **all six**, and the four
+ecosystem apps' routes are already exercised by their own suites in the
+`database-postgres` job, so the smoke proves the containerized harness path
+cheaply on the Go pair rather than re-seeding all six every PR (the 100 k seed
+is per-app and unparameterized across the six languages; a tiny-seed knob +
+all-six containerized run is the heavier follow-up variant). The
+`benchmark-target_test.sh` stub suite locks the target's contract without Docker
+(builds all six via `compose build`, runs crud-all with the two-Go-app tiny
+params, and — the safety property — passes a throwaway `OUT_DIR`, never
+`results/latest`; the last is regression-checked). **Still open in Phase 8:** the
 `benchmarks.yml` `workflow_dispatch` for the full/selected suites with artifact
 upload.
 
-- `ci.yml`: add a `benchmark-smoke` job (needs: `test`) running
-  `make benchmark-smoke` — tiny seed, 1 short trial, low concurrency,
-  correctness-only, on every PR.
+- ~~`ci.yml`: add a `benchmark-smoke` job (needs: `test`) running
+  `make benchmark-smoke` — 1 short trial, low concurrency, correctness-only, on
+  every PR.~~ **Done** (see above; the "tiny seed" reduction across all six
+  languages is folded into the deferred all-six variant).
 - New `.github/workflows/benchmarks.yml`: `workflow_dispatch` with an input
   to select `micro | crud | auth | techempower | footprint | full`; uploads
   `metadata.json`, raw results, `results.json`, `results.csv`, `summary.md`


### PR DESCRIPTION
## Summary

Phase 8 of BENCH-1: the per-PR **§11 correctness smoke** for the benchmark suite, alongside the existing `benchmark-report-drift` job.

`make benchmark-smoke` builds **all six** app images (`docker compose build` — a broken Dockerfile fails here), then runs the **containerized** harness end to end (compose up → migrate → seed → k6 → parse) for **all six** apps with a **small deterministic seed** (20 users / 100 projects) and a 1-VU × 1 short trial, into a **throwaway `mktemp` dir**. Per issue #141 §11 it detects broken builds, broken endpoints, schema/migration drift, orchestration failures, and result-parser breakage; it gates on correctness only (numbers discarded, no perf assertion on noisy shared runners) and never touches `results/latest`.

The small seed is what makes all-six affordable per PR, added as a real cross-language capability: every seeder reads `BENCH_SEED_USERS` / `BENCH_SEED_PROJECTS` with identical semantics (`benchmarks/apps/shared.SeedCounts` + independent ports in the Django command, Rails/Laravel `CanonicalSeed`, and the NestJS seeder; unset → canonical 1,000/100,000; a malformed value is fatal, never a silent fall back). compose passes them through to each app's `seed` container. 20 users / 100 projects is tiny but keeps the workload's asserted full 20-row first page.

**Review history:** an earlier iteration harness-tested only the two Go apps and leaned on `database-postgres` as the ecosystem apps' substitute — wrong, since that job tests their handlers *in-process*, never the container's `ENTRYPOINT`/migrate/serve path. This now runs the container path for all six.

Refs #141

## Acceptance criteria (§11)

- [x] `benchmark-smoke` CI job (`needs: test`) runs `make benchmark-smoke` on every PR.
- [x] Detects broken Docker builds — `docker compose build`, all six.
- [x] Detects broken endpoints / schema drift / orchestration failures / result-parser breakage — the containerized up→migrate→seed→k6→parse path, all six, with run-crud's `Validate`.
- [x] Small deterministic seed — `BENCH_SEED_*` across all six apps; 20/100.
- [x] Correctness-only, no perf gate on shared runners; `results/latest` never touched.
- Remaining Phase 8 item (separate slice): the `benchmarks.yml` `workflow_dispatch` for manual full/selected runs with artifact upload.

## Validation

- [x] **Ran `make benchmark-smoke` live**: exits 0; all six app DBs seeded exactly **20 users / 100 projects** (small seed reached every container — Go×2, Python, Ruby, PHP, Node); each app's k6 read validated with **0 errors**; `results/latest` + README untouched; throwaway dir cleaned up.
- [x] `go test ./benchmarks/apps/shared/` — new `SeedCounts` unit test (unset→canonical, positive override, empty→canonical, malformed→fatal).
- [x] `golangci-lint` on changed Go packages — 0 issues.
- [x] `benchmark-target_test.sh` — Docker-free stub asserts all six apps, tiny params, exported small seed, throwaway `OUT_DIR` (never `results/latest`).
- [x] `docker compose config` valid; the override propagates to every service.

## Working agreement checklist

- [x] New behavior has tests — shared `SeedCounts` unit test + stub-test contract; the live smoke is the cross-language integration proof
- [x] Stable features ship docs — benchmarks/README "Per-PR smoke" rewritten; plan Phase 8 updated; stale README bullet removed
- [x] Extraction preserves contracts — reuses the `run-crud-all` harness; seed `_n` functions unchanged (only the wrappers read the env)
- [ ] Generators / API / OpenAPI+TS — N/A
- [x] No secrets in frontend — N/A, still true
- [x] Scope stays in-milestone — BENCH-1 Phase 8, no M6 battery creep
- [x] Links its issue (`Refs #141`) and lists satisfied AC

🤖 Generated with [Claude Code](https://claude.com/claude-code)