### PR TITLE
feat: BENCH-1 manual benchmarks.yml workflow (workflow_dispatch) — completes Phase 8

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,89 @@
+name: Benchmarks (manual)
+
+# Manual, on-demand benchmark runs (issue #141 §11 "Manual full benchmark
+# workflow"). Unlike the per-PR benchmark-smoke gate, this runs a full or
+# selected suite and uploads the structured outputs as artifacts. It is
+# workflow_dispatch ONLY — never on push/PR — and it never commits: it writes to
+# benchmarks/results/dispatch on the runner, so main's committed
+# results/latest and the README ## Performance block are never overwritten
+# automatically (updating those stays the reviewed, manual local step).
+#
+# GitHub-hosted runners are noisy, so the numbers here are for inspection, not a
+# performance gate (§11). For a citable canonical run, use a dedicated host.
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: "Suite to run"
+        type: choice
+        options:
+          - full
+          - crud
+          - footprint
+          - micro
+        default: full
+      concurrency:
+        description: "CONCURRENCY override (e.g. 1,10,100); blank = versions.env"
+        type: string
+        default: ""
+      trials:
+        description: "TRIALS override; blank = versions.env"
+        type: string
+        default: ""
+      duration_seconds:
+        description: "DURATION_SECONDS override; blank = versions.env"
+        type: string
+        default: ""
+      warmup_seconds:
+        description: "WARMUP_SECONDS override; blank = versions.env"
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Benchmark (${{ inputs.suite }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Inputs are bound to the environment (never interpolated into the shell
+      # string) and consumed by the tested dispatcher, which forwards only the
+      # pins that are set. Docker + Compose v2 are preinstalled on ubuntu-latest;
+      # k6 and Postgres run as pinned images.
+      - name: Run suite
+        env:
+          SUITE: ${{ inputs.suite }}
+          CONCURRENCY: ${{ inputs.concurrency }}
+          TRIALS: ${{ inputs.trials }}
+          DURATION_SECONDS: ${{ inputs.duration_seconds }}
+          WARMUP_SECONDS: ${{ inputs.warmup_seconds }}
+        run: bash benchmarks/scripts/run-suite.sh
+
+      # Upload whatever the selected suite produced (a partial suite writes only
+      # some files); if:always so artifacts survive a later-step failure.
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-${{ inputs.suite }}-${{ github.run_number }}
+          path: |
+            benchmarks/results/dispatch/results.json
+            benchmarks/results/dispatch/results.csv
+            benchmarks/results/dispatch/summary.md
+            benchmarks/results/dispatch/metadata.json
+            benchmarks/results/dispatch/footprint.json
+            benchmarks/results/dispatch/footprint.csv
+            benchmarks/results/dispatch/microbench.json
+            benchmarks/results/dispatch/raw/
+          if-no-files-found: ignore

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -58,6 +58,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # A crud/full dispatch records gombit's framework version via
+          # `git describe --tags` into metadata.json; fetch full history + tags
+          # so the artifact carries the tag-relative version (e.g. v0.1.3-…) the
+          # committed snapshot uses, not the default depth-1 clone's bare SHA.
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v7

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,13 +3,21 @@ name: Benchmarks (manual)
 # Manual, on-demand benchmark runs (issue #141 §11 "Manual full benchmark
 # workflow"). Unlike the per-PR benchmark-smoke gate, this runs a full or
 # selected suite and uploads the structured outputs as artifacts. It is
-# workflow_dispatch ONLY — never on push/PR — and it never commits: it writes to
-# benchmarks/results/dispatch on the runner, so main's committed
-# results/latest and the README ## Performance block are never overwritten
-# automatically (updating those stays the reviewed, manual local step).
+# workflow_dispatch ONLY — never on push/PR.
 #
-# GitHub-hosted runners are noisy, so the numbers here are for inspection, not a
-# performance gate (§11). For a citable canonical run, use a dedicated host.
+# It cannot touch the published README or the committed snapshot, by
+# construction: `full` runs the three MEASUREMENT targets plus summary, never
+# `make benchmark` (whose last stage rewrites the repo-root README.md), and every
+# suite writes to benchmarks/results/dispatch, never results/latest. Regenerating
+# the committed README ## Performance block stays the reviewed, manual local
+# `make benchmark` + commit.
+#
+# The workload pins default to a REDUCED, runner-survivable protocol (see
+# run-suite.sh), NOT the versions.env canonical 1/10/100/500/1000 x 5 x 30s sweep
+# this repo could not sustain on a stronger single host: a dispatch aimed at a
+# noisy 4-vCPU runner must not default to the dedicated-host recipe. Numbers here
+# are for inspection, not a performance gate (§11); for a citable canonical run,
+# use a dedicated host and set the pins explicitly.
 
 on:
   workflow_dispatch:
@@ -24,19 +32,19 @@ on:
           - micro
         default: full
       concurrency:
-        description: "CONCURRENCY override (e.g. 1,10,100); blank = versions.env"
+        description: "CONCURRENCY; blank = reduced default 1,10,100 (set e.g. 1,10,100,500,1000 on a dedicated runner)"
         type: string
         default: ""
       trials:
-        description: "TRIALS override; blank = versions.env"
+        description: "TRIALS; blank = reduced default 3"
         type: string
         default: ""
       duration_seconds:
-        description: "DURATION_SECONDS override; blank = versions.env"
+        description: "DURATION_SECONDS; blank = reduced default 10"
         type: string
         default: ""
       warmup_seconds:
-        description: "WARMUP_SECONDS override; blank = versions.env"
+        description: "WARMUP_SECONDS; blank = reduced default 3"
         type: string
         default: ""
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # run-crud-all_test.sh derives gombit's version via `git describe
+          # --tags` and asserts it is version-shaped. The default depth-1,
+          # tagless clone would make describe fall back to a bare SHA and fail
+          # that assertion, so fetch full history + tags.
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,32 @@ jobs:
       - name: Run benchmark smoke
         run: make benchmark-smoke
 
+  benchmark-scripts:
+    name: Benchmark script tests
+    # The benchmark orchestration/dispatch scripts carry Docker-free stub tests
+    # (they fake docker/compose/make and go seams), so run them in merge CI —
+    # without this, nothing in the pull_request graph exercises the run-suite /
+    # benchmark-smoke / crud-all / footprint mappings and a broken one merges
+    # green. Pure bash + make; no Docker, no real benchmark run.
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run benchmark script tests
+        run: |
+          bash benchmarks/scripts/run-suite_test.sh
+          bash benchmarks/scripts/benchmark-target_test.sh
+          bash benchmarks/scripts/run-crud-all_test.sh
+          bash benchmarks/scripts/footprint-all_test.sh
+
   database-sqlite:
     name: Database (sqlite)
     needs: test

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -171,17 +171,26 @@ seed, throwaway `OUT_DIR`) without Docker by stubbing the recursive make and
 
 For an on-demand full or selected run, dispatch the **Benchmarks (manual)**
 workflow (`.github/workflows/benchmarks.yml`, `workflow_dispatch` only). Pick a
-`suite` — `full` (crud → footprint → micro → report), `crud`, `footprint`, or
-`micro` — and optionally override `concurrency` / `trials` / `duration_seconds` /
-`warmup_seconds` (blank = the `versions.env` pins). It writes to
-`benchmarks/results/dispatch/` (never `results/latest`) and uploads
-`results.{json,csv}`, `summary.md`, `metadata.json`, `footprint.{json,csv}`,
-`microbench.json`, and the raw per-trial summaries as a run artifact. It **never
-commits**: updating the committed snapshot and the README `## Performance` block
-stays the reviewed, manual local step (`make benchmark`, then commit). Locally
-the same mapping is `benchmarks/scripts/run-suite.sh` (`SUITE=crud CONCURRENCY=1,10
-bash benchmarks/scripts/run-suite.sh`), covered by `run-suite_test.sh`. Numbers
-from GitHub-hosted runners are noisy — for a citable canonical run, use a
+`suite` — `full` (crud → footprint → micro → **summary**), `crud`, `footprint`,
+or `micro` — and optionally override `concurrency` / `trials` /
+`duration_seconds` / `warmup_seconds` (blank = a **reduced, runner-survivable**
+default of `1,10,100 × 3 × 10s`, *not* the `versions.env` canonical
+1/10/100/500/1000 × 5 × 30s sweep — set the pins explicitly for a wider run on a
+dedicated runner). It writes to `benchmarks/results/dispatch/` (never
+`results/latest`) and uploads `results.{json,csv}`, `summary.md`,
+`metadata.json`, `footprint.{json,csv}`, `microbench.json`, and the raw
+per-trial summaries as a run artifact.
+
+It **cannot** touch the published README or the committed snapshot by
+construction: `full` runs the three measurement targets plus `summary` — never
+`make benchmark`, whose last stage (`benchmark-report`) rewrites the repo-root
+README `## Performance` block from `OUT_DIR` — and every suite writes to the
+dispatch dir. Regenerating the committed block stays the reviewed, manual local
+step (`make benchmark`, then commit). Locally the same mapping is
+`benchmarks/scripts/run-suite.sh` (`SUITE=crud CONCURRENCY=1,10 bash
+benchmarks/scripts/run-suite.sh`), covered by `run-suite_test.sh` (which runs in
+CI — the `benchmark-scripts` job — alongside the other benchmark script tests).
+Numbers from GitHub-hosted runners are noisy — for a citable canonical run, use a
 dedicated host.
 
 ## Running the CRUD-read workload

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -73,10 +73,10 @@ runs the same regenerate-then-diff on every PR. The full method and the required
 snapshot already backs the README numbers, but from a **reduced run on a single
 dev host** (recorded in `metadata.json` and printed in the README block); still
 scoped to later phases: the embedded-Gombit single-binary footprint variant, the
-other `make benchmark-*` workloads, extending `fairness_test.go` to all six,
-re-running the full canonical sweep on dedicated hardware, and the
-`benchmarks.yml` manual workflow (Phase 8). The per-PR `benchmark-smoke` CI job
-is in (see below).
+other `make benchmark-*` workloads, extending `fairness_test.go` to all six, and
+re-running the full canonical sweep on dedicated hardware. The CI integration is
+in — the per-PR `benchmark-smoke` gate and the manual `benchmarks.yml` workflow
+(both below).
 
 ## Resource limits (§7): intention vs. reality
 
@@ -166,6 +166,23 @@ ports; unset → the canonical 1,000/100,000). `benchmark-target_test.sh` locks 
 target's contract (builds all six, runs all six with the tiny params + small
 seed, throwaway `OUT_DIR`) without Docker by stubbing the recursive make and
 `docker`.
+
+### Manual runs (`benchmarks.yml`)
+
+For an on-demand full or selected run, dispatch the **Benchmarks (manual)**
+workflow (`.github/workflows/benchmarks.yml`, `workflow_dispatch` only). Pick a
+`suite` — `full` (crud → footprint → micro → report), `crud`, `footprint`, or
+`micro` — and optionally override `concurrency` / `trials` / `duration_seconds` /
+`warmup_seconds` (blank = the `versions.env` pins). It writes to
+`benchmarks/results/dispatch/` (never `results/latest`) and uploads
+`results.{json,csv}`, `summary.md`, `metadata.json`, `footprint.{json,csv}`,
+`microbench.json`, and the raw per-trial summaries as a run artifact. It **never
+commits**: updating the committed snapshot and the README `## Performance` block
+stays the reviewed, manual local step (`make benchmark`, then commit). Locally
+the same mapping is `benchmarks/scripts/run-suite.sh` (`SUITE=crud CONCURRENCY=1,10
+bash benchmarks/scripts/run-suite.sh`), covered by `run-suite_test.sh`. Numbers
+from GitHub-hosted runners are noisy — for a citable canonical run, use a
+dedicated host.
 
 ## Running the CRUD-read workload
 

--- a/benchmarks/results/.gitignore
+++ b/benchmarks/results/.gitignore
@@ -2,3 +2,6 @@
 # snapshot IS committed, including `latest/raw/` (the per-trial k6 summaries) so
 # a later parser fix can reconstruct the numbers from the same run.
 runs/
+# The manual benchmarks.yml workflow writes here (never results/latest), so a
+# local dispatch run is never accidentally committed.
+dispatch/

--- a/benchmarks/scripts/run-suite.sh
+++ b/benchmarks/scripts/run-suite.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Map a dispatch SUITE to the make targets that produce its artifacts, for the
+# manual .github/workflows/benchmarks.yml (workflow_dispatch). Kept as a tested
+# script rather than inline YAML so the suite -> target mapping, the
+# forward-only-what-is-set pin handling, and injection safety are locked by
+# run-suite_test.sh without a real run.
+#
+# Inputs come from the environment (the workflow binds workflow inputs to env,
+# never interpolating ${{ inputs.* }} into a shell string):
+#   SUITE      full | crud | footprint | micro   (default full)
+#   OUT_DIR    where artifacts are written (default benchmarks/results/dispatch,
+#              deliberately NOT results/latest so a dispatch never overwrites the
+#              committed snapshot even on the runner checkout)
+#   CONCURRENCY TRIALS DURATION_SECONDS WARMUP_SECONDS APPS   (crud pins)
+#   COLD_START_RUNS LOAD_SECONDS                               (footprint pins)
+#   MICRO_COUNT                                                (micro samples)
+# Any pin left empty falls back to versions.env — it is only forwarded to make
+# when set, so a blank workflow input never becomes `CONCURRENCY=`.
+#
+#   SUITE=crud CONCURRENCY=1,10 bash benchmarks/scripts/run-suite.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+SUITE="${SUITE:-full}"
+OUT_DIR="${OUT_DIR:-benchmarks/results/dispatch}"
+
+# Seam so the test can drive the mapping without invoking a real (Docker-bound,
+# hours-long) make.
+run_make() { make "$@"; }
+
+# make_args echoes the make variable overrides for this run, one per line: always
+# OUT_DIR, plus every pin that is actually set. NUL-safe not needed — make
+# variable values here are simple tokens, and each is passed as ONE argv element
+# by the caller's array read, so a value like "1; rm -rf /" is an inert
+# make-variable string, never a shell command.
+make_args() {
+	printf '%s\n' "OUT_DIR=${OUT_DIR}"
+	local name
+	for name in CONCURRENCY TRIALS DURATION_SECONDS WARMUP_SECONDS APPS \
+		COLD_START_RUNS LOAD_SECONDS MICRO_COUNT; do
+		if [ -n "${!name:-}" ]; then
+			printf '%s=%s\n' "$name" "${!name}"
+		fi
+	done
+}
+
+main() {
+	local args=()
+	local line
+	while IFS= read -r line; do
+		args+=("$line")
+	done < <(make_args)
+
+	case "$SUITE" in
+	full)
+		run_make benchmark "${args[@]}"
+		;;
+	crud)
+		run_make benchmark-crud-all "${args[@]}"
+		run_make benchmark-summary "${args[@]}"
+		;;
+	footprint)
+		run_make benchmark-footprint "${args[@]}"
+		;;
+	micro)
+		run_make benchmark-micro "${args[@]}"
+		;;
+	*)
+		echo "run-suite: unknown SUITE '$SUITE' (want: full | crud | footprint | micro)" >&2
+		exit 2
+		;;
+	esac
+}
+
+# Only orchestrate when executed directly; sourcing (the test) just defines the
+# functions so it can stub run_make.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+	main "$@"
+fi

--- a/benchmarks/scripts/run-suite.sh
+++ b/benchmarks/scripts/run-suite.sh
@@ -14,8 +14,15 @@
 #   CONCURRENCY TRIALS DURATION_SECONDS WARMUP_SECONDS APPS   (crud pins)
 #   COLD_START_RUNS LOAD_SECONDS                               (footprint pins)
 #   MICRO_COUNT                                                (micro samples)
-# Any pin left empty falls back to versions.env — it is only forwarded to make
-# when set, so a blank workflow input never becomes `CONCURRENCY=`.
+#
+# The workload pins default to a REDUCED, shared-runner-survivable protocol, NOT
+# the versions.env canonical sweep (1/10/100/500/1000 x 5 x 30s): this repo could
+# not sustain 500/1000 VUs on a stronger single host than a GitHub-hosted runner,
+# and run-crud fail-closes the whole run on any HTTP error. A dispatch aimed at a
+# noisy 4-vCPU runner must not default to the dedicated-host recipe. Set any pin
+# explicitly (e.g. CONCURRENCY=1,10,100,500,1000) for a wider run on a dedicated
+# runner. Pins with no reduced default (APPS, MICRO_COUNT, LOAD_SECONDS) are only
+# forwarded when set.
 #
 #   SUITE=crud CONCURRENCY=1,10 bash benchmarks/scripts/run-suite.sh
 set -euo pipefail
@@ -26,20 +33,33 @@ cd "$ROOT"
 SUITE="${SUITE:-full}"
 OUT_DIR="${OUT_DIR:-benchmarks/results/dispatch}"
 
+# Reduced, runner-survivable defaults (the committed results/latest snapshot was
+# taken at exactly this protocol on a stronger host — the existence proof).
+CONCURRENCY="${CONCURRENCY:-1,10,100}"
+TRIALS="${TRIALS:-3}"
+DURATION_SECONDS="${DURATION_SECONDS:-10}"
+WARMUP_SECONDS="${WARMUP_SECONDS:-3}"
+COLD_START_RUNS="${COLD_START_RUNS:-5}"
+
 # Seam so the test can drive the mapping without invoking a real (Docker-bound,
 # hours-long) make.
 run_make() { make "$@"; }
 
 # make_args echoes the make variable overrides for this run, one per line: always
-# OUT_DIR, plus every pin that is actually set. NUL-safe not needed — make
-# variable values here are simple tokens, and each is passed as ONE argv element
-# by the caller's array read, so a value like "1; rm -rf /" is an inert
-# make-variable string, never a shell command.
+# OUT_DIR and the reduced pins above, plus APPS/MICRO_COUNT/LOAD_SECONDS when set.
+# Each is passed as ONE argv element by the caller's array read, so the workflow
+# env -> argv path cannot inject a shell command (a value like "1; rm -rf /" is
+# an inert argv token). NOTE: this is the shell-layer safety only — it is not a
+# claim about GNU make's own `$(shell ...)` expansion of a command-line variable;
+# the exposed inputs feed run-crud flags, not a make `$(shell)` sink, and
+# workflow_dispatch already requires write access.
 make_args() {
 	printf '%s\n' "OUT_DIR=${OUT_DIR}"
+	printf '%s\n' "CONCURRENCY=${CONCURRENCY}" "TRIALS=${TRIALS}" \
+		"DURATION_SECONDS=${DURATION_SECONDS}" "WARMUP_SECONDS=${WARMUP_SECONDS}" \
+		"COLD_START_RUNS=${COLD_START_RUNS}"
 	local name
-	for name in CONCURRENCY TRIALS DURATION_SECONDS WARMUP_SECONDS APPS \
-		COLD_START_RUNS LOAD_SECONDS MICRO_COUNT; do
+	for name in APPS LOAD_SECONDS MICRO_COUNT; do
 		if [ -n "${!name:-}" ]; then
 			printf '%s=%s\n' "$name" "${!name}"
 		fi
@@ -55,7 +75,16 @@ main() {
 
 	case "$SUITE" in
 	full)
-		run_make benchmark "${args[@]}"
+		# The three MEASUREMENT targets plus summary — deliberately NOT
+		# `make benchmark`, whose last stage (benchmark-report) rewrites the
+		# published repo-root README.md from OUT_DIR. A dispatch produces
+		# artifacts; regenerating the committed README stays the reviewed local
+		# `make benchmark` + commit. OUT_DIR alone does not protect the README —
+		# dropping the report writer does.
+		run_make benchmark-crud-all "${args[@]}"
+		run_make benchmark-footprint "${args[@]}"
+		run_make benchmark-micro "${args[@]}"
+		run_make benchmark-summary "${args[@]}"
 		;;
 	crud)
 		run_make benchmark-crud-all "${args[@]}"

--- a/benchmarks/scripts/run-suite_test.sh
+++ b/benchmarks/scripts/run-suite_test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Tests for run-suite.sh (the benchmarks.yml dispatch mapping). Sourcing defines
+# the functions but runs nothing (main is guarded), so the test stubs run_make
+# and asserts: each SUITE maps to the right make targets, only set pins are
+# forwarded (a blank input never becomes `VAR=`), OUT_DIR defaults away from
+# results/latest, a pin value is passed as ONE inert argv token (no shell
+# injection), and an unknown suite fails.
+#
+#   bash benchmarks/scripts/run-suite_test.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail=0
+note() { echo "FAIL: $*" >&2; fail=1; }
+
+# Run run-suite's main in a subshell with a recording run_make stub, capturing
+# one line per make invocation ("<target> | <arg> | <arg> ..."). Env for the run
+# is passed as leading VAR=val assignments.
+run_suite() {
+	env "$@" bash -c '
+		# shellcheck source=/dev/null
+		source benchmarks/scripts/run-suite.sh
+		run_make() { local IFS=" "; printf "%s | %s\n" "$1" "${*:2}"; }
+		main
+	'
+}
+
+# ---- 1. SUITE=full -> `make benchmark` with OUT_DIR (default dispatch dir) ----
+out="$(run_suite SUITE=full)"
+case "$out" in
+	"benchmark | OUT_DIR=benchmarks/results/dispatch") : ;;
+	*) note "full mapping wrong: '$out'" ;;
+esac
+
+# ---- 2. SUITE=crud -> crud-all then summary; only set pins forwarded ----
+out="$(run_suite SUITE=crud CONCURRENCY=1,10 TRIALS=2)"
+echo "$out" | grep -qE "^benchmark-crud-all \| .*CONCURRENCY=1,10.*TRIALS=2" \
+	|| note "crud did not forward the set pins: '$out'"
+echo "$out" | grep -qE "^benchmark-summary \| " \
+	|| note "crud did not also run benchmark-summary: '$out'"
+# DURATION_SECONDS / WARMUP_SECONDS were unset -> must NOT appear as empty vars.
+echo "$out" | grep -qE "DURATION_SECONDS=|WARMUP_SECONDS=" \
+	&& note "crud forwarded an unset pin as an empty override: '$out'"
+
+# ---- 3. SUITE=footprint / micro map to their targets with their pins ----
+out="$(run_suite SUITE=footprint COLD_START_RUNS=3)"
+echo "$out" | grep -qE "^benchmark-footprint \| .*COLD_START_RUNS=3" \
+	|| note "footprint mapping wrong: '$out'"
+out="$(run_suite SUITE=micro MICRO_COUNT=2)"
+echo "$out" | grep -qE "^benchmark-micro \| .*MICRO_COUNT=2" \
+	|| note "micro mapping wrong: '$out'"
+
+# ---- 4. OUT_DIR is always passed and never defaults to results/latest ----
+out="$(run_suite SUITE=micro)"
+echo "$out" | grep -q "OUT_DIR=benchmarks/results/dispatch" \
+	|| note "OUT_DIR not defaulted to the dispatch dir: '$out'"
+echo "$out" | grep -q "OUT_DIR=benchmarks/results/latest" \
+	&& note "a dispatch must not target the committed results/latest: '$out'"
+# An explicit OUT_DIR override is honored.
+out="$(run_suite SUITE=micro OUT_DIR=/tmp/x)"
+echo "$out" | grep -q "OUT_DIR=/tmp/x" || note "explicit OUT_DIR not honored: '$out'"
+
+# ---- 5. a malicious pin value is an inert single make token, not a command ----
+canary="$(mktemp -d)/pwned"
+out="$(run_suite SUITE=micro "MICRO_COUNT=1; touch $canary")"
+[ -e "$canary" ] && note "pin value was executed as a shell command (injection)"
+echo "$out" | grep -qF "MICRO_COUNT=1; touch $canary" \
+	|| note "pin value was not passed through as one make token: '$out'"
+rm -rf "$(dirname "$canary")"
+
+# ---- 6. unknown suite fails ----
+rc=0
+run_suite SUITE=bogus >/dev/null 2>&1 || rc=$?
+[ "$rc" -ne 0 ] || note "unknown suite should fail"
+
+if [ "$fail" -ne 0 ]; then
+	echo "run-suite_test: FAILED" >&2
+	exit 1
+fi
+echo "run-suite_test: suite mapping, set-only pin forwarding, dispatch OUT_DIR, injection-safety, and unknown-suite all pass"

--- a/benchmarks/scripts/run-suite_test.sh
+++ b/benchmarks/scripts/run-suite_test.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # Tests for run-suite.sh (the benchmarks.yml dispatch mapping). Sourcing defines
 # the functions but runs nothing (main is guarded), so the test stubs run_make
-# and asserts: each SUITE maps to the right make targets, only set pins are
-# forwarded (a blank input never becomes `VAR=`), OUT_DIR defaults away from
-# results/latest, a pin value is passed as ONE inert argv token (no shell
-# injection), and an unknown suite fails.
+# and asserts: each SUITE maps to the right make targets, `full` NEVER invokes
+# the README-rewriting publish path (benchmark-report / bare benchmark), the
+# reduced runner-survivable pins default in (and overrides replace them),
+# unset-only pins (APPS/MICRO_COUNT/LOAD_SECONDS) are forwarded only when set,
+# OUT_DIR defaults away from results/latest, a pin value is one inert argv token
+# (no shell-layer injection), and an unknown suite fails.
 #
 #   bash benchmarks/scripts/run-suite_test.sh
 set -euo pipefail
@@ -27,50 +29,53 @@ run_suite() {
 	'
 }
 
-# ---- 1. SUITE=full -> `make benchmark` with OUT_DIR (default dispatch dir) ----
+# ---- 1. SUITE=full -> the three measurement targets + summary, NO report ----
 out="$(run_suite SUITE=full)"
-case "$out" in
-	"benchmark | OUT_DIR=benchmarks/results/dispatch") : ;;
-	*) note "full mapping wrong: '$out'" ;;
-esac
+for want in benchmark-crud-all benchmark-footprint benchmark-micro benchmark-summary; do
+	echo "$out" | grep -qE "^$want \| " || note "full did not run '$want': $out"
+done
+# The publish path must never run in a dispatch: it rewrites the committed README.
+echo "$out" | grep -qE "^benchmark-report \| " && note "full invoked benchmark-report (rewrites README): $out"
+echo "$out" | grep -qE "^benchmark \| " && note "full invoked bare 'make benchmark' (the publish recipe): $out"
 
-# ---- 2. SUITE=crud -> crud-all then summary; only set pins forwarded ----
-out="$(run_suite SUITE=crud CONCURRENCY=1,10 TRIALS=2)"
-echo "$out" | grep -qE "^benchmark-crud-all \| .*CONCURRENCY=1,10.*TRIALS=2" \
-	|| note "crud did not forward the set pins: '$out'"
-echo "$out" | grep -qE "^benchmark-summary \| " \
-	|| note "crud did not also run benchmark-summary: '$out'"
-# DURATION_SECONDS / WARMUP_SECONDS were unset -> must NOT appear as empty vars.
-echo "$out" | grep -qE "DURATION_SECONDS=|WARMUP_SECONDS=" \
-	&& note "crud forwarded an unset pin as an empty override: '$out'"
+# ---- 2. reduced runner-survivable pins default in; 500/1000 never appear ----
+echo "$out" | grep -qE "CONCURRENCY=1,10,100( |$)" || note "full did not default to reduced concurrency: $out"
+echo "$out" | grep -qE "TRIALS=3( |$)" || note "full did not default TRIALS=3: $out"
+echo "$out" | grep -qE "1,10,100,500,1000" && note "default dispatch loaded the canonical 500/1000 sweep: $out"
 
-# ---- 3. SUITE=footprint / micro map to their targets with their pins ----
-out="$(run_suite SUITE=footprint COLD_START_RUNS=3)"
-echo "$out" | grep -qE "^benchmark-footprint \| .*COLD_START_RUNS=3" \
-	|| note "footprint mapping wrong: '$out'"
+# ---- 3. explicit pins override the reduced defaults ----
+out="$(run_suite SUITE=crud CONCURRENCY=1,10,100,500,1000 TRIALS=5)"
+echo "$out" | grep -qE "^benchmark-crud-all \| .*CONCURRENCY=1,10,100,500,1000.*TRIALS=5" \
+	|| note "explicit pins did not override the defaults: $out"
+echo "$out" | grep -qE "^benchmark-summary \| " || note "crud did not also run benchmark-summary: $out"
+echo "$out" | grep -qE "CONCURRENCY=1,10,100( |$)" && note "reduced default leaked past an explicit override: $out"
+
+# ---- 4. footprint / micro map to their targets ----
+out="$(run_suite SUITE=footprint)"
+echo "$out" | grep -qE "^benchmark-footprint \| .*COLD_START_RUNS=5" || note "footprint mapping/default wrong: $out"
 out="$(run_suite SUITE=micro MICRO_COUNT=2)"
-echo "$out" | grep -qE "^benchmark-micro \| .*MICRO_COUNT=2" \
-	|| note "micro mapping wrong: '$out'"
+echo "$out" | grep -qE "^benchmark-micro \| .*MICRO_COUNT=2" || note "micro mapping wrong: $out"
 
-# ---- 4. OUT_DIR is always passed and never defaults to results/latest ----
+# ---- 5. defaultless pins (MICRO_COUNT/APPS/LOAD_SECONDS) only when set ----
 out="$(run_suite SUITE=micro)"
-echo "$out" | grep -q "OUT_DIR=benchmarks/results/dispatch" \
-	|| note "OUT_DIR not defaulted to the dispatch dir: '$out'"
-echo "$out" | grep -q "OUT_DIR=benchmarks/results/latest" \
-	&& note "a dispatch must not target the committed results/latest: '$out'"
-# An explicit OUT_DIR override is honored.
-out="$(run_suite SUITE=micro OUT_DIR=/tmp/x)"
-echo "$out" | grep -q "OUT_DIR=/tmp/x" || note "explicit OUT_DIR not honored: '$out'"
+echo "$out" | grep -qE "MICRO_COUNT=|APPS=|LOAD_SECONDS=" \
+	&& note "an unset defaultless pin was forwarded as an empty override: $out"
 
-# ---- 5. a malicious pin value is an inert single make token, not a command ----
+# ---- 6. OUT_DIR always passed and never defaults to results/latest ----
+out="$(run_suite SUITE=micro)"
+echo "$out" | grep -q "OUT_DIR=benchmarks/results/dispatch" || note "OUT_DIR not defaulted to the dispatch dir: $out"
+echo "$out" | grep -q "OUT_DIR=benchmarks/results/latest" && note "a dispatch must not target the committed results/latest: $out"
+out="$(run_suite SUITE=micro OUT_DIR=/tmp/x)"
+echo "$out" | grep -q "OUT_DIR=/tmp/x" || note "explicit OUT_DIR not honored: $out"
+
+# ---- 7. a malicious pin value is an inert single argv token (shell layer) ----
 canary="$(mktemp -d)/pwned"
 out="$(run_suite SUITE=micro "MICRO_COUNT=1; touch $canary")"
 [ -e "$canary" ] && note "pin value was executed as a shell command (injection)"
-echo "$out" | grep -qF "MICRO_COUNT=1; touch $canary" \
-	|| note "pin value was not passed through as one make token: '$out'"
+echo "$out" | grep -qF "MICRO_COUNT=1; touch $canary" || note "pin value was not passed through as one argv token: $out"
 rm -rf "$(dirname "$canary")"
 
-# ---- 6. unknown suite fails ----
+# ---- 8. unknown suite fails ----
 rc=0
 run_suite SUITE=bogus >/dev/null 2>&1 || rc=$?
 [ "$rc" -ne 0 ] || note "unknown suite should fail"
@@ -79,4 +84,4 @@ if [ "$fail" -ne 0 ]; then
 	echo "run-suite_test: FAILED" >&2
 	exit 1
 fi
-echo "run-suite_test: suite mapping, set-only pin forwarding, dispatch OUT_DIR, injection-safety, and unknown-suite all pass"
+echo "run-suite_test: full-drops-report, reduced-default pins, override, dispatch OUT_DIR, set-only defaultless pins, injection-safety, and unknown-suite all pass"

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1781,24 +1781,48 @@ checked).
 **Manual `benchmarks.yml` workflow — done. Phase 8 complete.**
 `.github/workflows/benchmarks.yml` is `workflow_dispatch`-only (never push/PR)
 with a `suite` choice (`full | crud | footprint | micro`) plus optional
-`concurrency` / `trials` / `duration_seconds` / `warmup_seconds` overrides (blank
-= the `versions.env` pins). The dispatch mapping is a tested script
-(`benchmarks/scripts/run-suite.sh` + `run-suite_test.sh`), not inline YAML, so
-the suite → make-target mapping, forward-only-set-pins behavior, and
-injection-safety (a pin value is one inert make token, never a shell command)
-are locked without a real run. It writes to `benchmarks/results/dispatch/` — NOT
-`results/latest` (gitignored, so a local dispatch is never committed) — and
-uploads `results.{json,csv}`, `summary.md`, `metadata.json`,
-`footprint.{json,csv}`, `microbench.json`, and the raw per-trial summaries as an
-artifact (`if-no-files-found: ignore`, since a selected suite writes only some).
-It **never commits**, so `main`'s committed snapshot and README `## Performance`
-block are never overwritten automatically — updating those stays the reviewed,
-manual local `make benchmark` + commit. The `auth` / `techempower` suites are
-intentionally NOT offered yet: those workloads don't exist (Phase 5), and a
-choice that maps to a missing target would be a broken caption — they're added
-with their Phase 5 slices. Verified: `actionlint` clean on the workflow; the
+`concurrency` / `trials` / `duration_seconds` / `warmup_seconds` overrides. The
+dispatch mapping is a tested script (`benchmarks/scripts/run-suite.sh` +
+`run-suite_test.sh`), not inline YAML.
+
+Two things the review of the first cut got right and this fixes:
+
+- **`full` measures, it does not publish.** It runs the three measurement targets
+  plus `benchmark-summary` — deliberately NOT `make benchmark`, whose last stage
+  (`benchmark-report`) rewrites the repo-root `README.md` `## Performance` block
+  from `OUT_DIR`. Redirecting `OUT_DIR` to `dispatch/` protects `results/latest`
+  but NOT the README; *dropping the report writer* is the actual lock. (The first
+  cut mapped `full` → `make benchmark` and leaned on "the workflow never commits"
+  — true on Actions, but a local `run-suite.sh SUITE=full` would then rewrite
+  README and break `benchmark-report-drift`.) So the dispatch cannot touch the
+  published README by construction, not just by not-committing.
+- **Reduced, runner-survivable pin defaults.** Blank pins default to
+  `1,10,100 × 3 × 10s` (the protocol the committed snapshot already used on a
+  stronger host), NOT the `versions.env` canonical 1/10/100/500/1000 × 5 × 30s
+  sweep this repo could not sustain on a single host and which `run-crud`
+  fail-closes on. Aiming the dedicated-host recipe at a noisy 4-vCPU runner was
+  the other half of the first cut's problem. Override the pins explicitly for a
+  wider run on a dedicated runner.
+
+It writes to `benchmarks/results/dispatch/` — NOT `results/latest` (gitignored,
+so a local dispatch is never committed) — and uploads `results.{json,csv}`,
+`summary.md`, `metadata.json`, `footprint.{json,csv}`, `microbench.json`, and the
+raw per-trial summaries (`if-no-files-found: ignore`, since a selected suite
+writes only some). The `auth` / `techempower` suites are intentionally NOT
+offered: those workloads don't exist yet (Phase 5), and a choice mapping to a
+missing target would be a broken caption.
+
+**The benchmark script tests now run in merge CI.** A new `benchmark-scripts` job
+(needs: `build`) runs `run-suite_test.sh`, `benchmark-target_test.sh`,
+`run-crud-all_test.sh`, and `footprint-all_test.sh` — all Docker-free stub suites
+that were previously not on any `pull_request` path, so a broken mapping could
+merge green. `run-suite_test.sh` asserts `full` never invokes `benchmark-report`
+/ bare `benchmark`, that the reduced pins default in (500/1000 never appear
+unless set), and injection-safety at the shell env→argv layer (an explicit note
+that this is not a claim about GNU make's own `$(shell …)` expansion, which the
+exposed inputs don't reach). Verified: `actionlint` clean on both workflows; the
 `micro` suite driven through `run-suite.sh` end to end wrote `microbench.json` to
-the dispatch dir and left `results/latest` untouched.
+the dispatch dir and left `results/latest` and README untouched.
 
 - ~~`ci.yml`: add a `benchmark-smoke` job (needs: `test`) running
   `make benchmark-smoke` — small deterministic seed, 1 short trial, low

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1816,7 +1816,12 @@ missing target would be a broken caption.
 (needs: `build`) runs `run-suite_test.sh`, `benchmark-target_test.sh`,
 `run-crud-all_test.sh`, and `footprint-all_test.sh` — all Docker-free stub suites
 that were previously not on any `pull_request` path, so a broken mapping could
-merge green. `run-suite_test.sh` asserts `full` never invokes `benchmark-report`
+merge green. The job checks out with `fetch-depth: 0`: `run-crud-all_test.sh`
+exercises the real `app_identity`, which derives gombit's version from
+`git describe --tags`, and the default depth-1 tagless clone would make describe
+fall back to a bare SHA that fails the version-shaped assertion (the dispatch
+workflow fetches full history for the same reason — so a run's recorded gombit
+version is the tag-relative string the committed snapshot uses). `run-suite_test.sh` asserts `full` never invokes `benchmark-report`
 / bare `benchmark`, that the reduced pins default in (500/1000 never appear
 unless set), and injection-safety at the shell env→argv layer (an explicit note
 that this is not a claim about GNU make's own `$(shell …)` expansion, which the

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -1776,22 +1776,42 @@ so the smoke now runs the container path for all six. `benchmark-target_test.sh`
 locks the target's contract without Docker (builds all six via `compose build`,
 runs all six with the tiny params, exports the small seed, and — the safety
 property — passes a throwaway `OUT_DIR`, never `results/latest`; regression-
-checked). **Still open in Phase 8:** the `benchmarks.yml` `workflow_dispatch` for
-the full/selected suites with artifact upload.
+checked).
+
+**Manual `benchmarks.yml` workflow — done. Phase 8 complete.**
+`.github/workflows/benchmarks.yml` is `workflow_dispatch`-only (never push/PR)
+with a `suite` choice (`full | crud | footprint | micro`) plus optional
+`concurrency` / `trials` / `duration_seconds` / `warmup_seconds` overrides (blank
+= the `versions.env` pins). The dispatch mapping is a tested script
+(`benchmarks/scripts/run-suite.sh` + `run-suite_test.sh`), not inline YAML, so
+the suite → make-target mapping, forward-only-set-pins behavior, and
+injection-safety (a pin value is one inert make token, never a shell command)
+are locked without a real run. It writes to `benchmarks/results/dispatch/` — NOT
+`results/latest` (gitignored, so a local dispatch is never committed) — and
+uploads `results.{json,csv}`, `summary.md`, `metadata.json`,
+`footprint.{json,csv}`, `microbench.json`, and the raw per-trial summaries as an
+artifact (`if-no-files-found: ignore`, since a selected suite writes only some).
+It **never commits**, so `main`'s committed snapshot and README `## Performance`
+block are never overwritten automatically — updating those stays the reviewed,
+manual local `make benchmark` + commit. The `auth` / `techempower` suites are
+intentionally NOT offered yet: those workloads don't exist (Phase 5), and a
+choice that maps to a missing target would be a broken caption — they're added
+with their Phase 5 slices. Verified: `actionlint` clean on the workflow; the
+`micro` suite driven through `run-suite.sh` end to end wrote `microbench.json` to
+the dispatch dir and left `results/latest` untouched.
 
 - ~~`ci.yml`: add a `benchmark-smoke` job (needs: `test`) running
   `make benchmark-smoke` — small deterministic seed, 1 short trial, low
-  concurrency, correctness-only, all six apps, on every PR.~~ **Done** (see
-  above).
-- New `.github/workflows/benchmarks.yml`: `workflow_dispatch` with an input
-  to select `micro | crud | auth | techempower | footprint | full`; uploads
-  `metadata.json`, raw results, `results.json`, `results.csv`, `summary.md`
-  as artifacts. Explicitly does not overwrite committed README numbers
-  automatically — that stays a reviewed, manual step (Phase 7's local run).
-- **AC:** smoke job is green on PRs and fails clearly if any of the 6 apps'
-  Docker builds break, a route regresses, or the result parser breaks;
-  manual workflow completes and uploads artifacts without touching
-  `main`'s README.
+  concurrency, correctness-only, all six apps, on every PR.~~ **Done.**
+- ~~New `.github/workflows/benchmarks.yml`: `workflow_dispatch` with an input
+  to select the suite; uploads `metadata.json`, raw results, `results.json`,
+  `results.csv`, `summary.md` as artifacts; does not overwrite committed README
+  numbers.~~ **Done** (suite choices scoped to the workloads that exist —
+  `full | crud | footprint | micro`; `auth`/`techempower` land with Phase 5).
+- **AC — met:** the smoke job fails clearly on a broken build, endpoint,
+  schema/migration, orchestration, or parser across all six containerized apps
+  (§11); the manual workflow runs a selected suite and uploads artifacts without
+  committing to `main`.
 
 ---
 


### PR DESCRIPTION
## Summary

The on-demand counterpart to the per-PR `benchmark-smoke` gate (issue #141 §11 "Manual full benchmark workflow"): dispatch a **full or selected** benchmark run and upload the structured outputs as artifacts, without touching `main`'s published README or committed snapshot. Completes Phase 8 (CI integration).

- **`.github/workflows/benchmarks.yml`** — `workflow_dispatch`-**only** (never push/PR). `suite` choice (`full | crud | footprint | micro`) plus optional pin overrides. Inputs bound to `env`, never interpolated into `run:`.
- **`benchmarks/scripts/run-suite.sh`** (tested, not inline YAML) — maps suite → make targets, writes to a gitignored `results/dispatch/` dir (never `results/latest`), never commits.
- **`run-suite_test.sh`** + the new **`benchmark-scripts` CI job**.

**Corrected after review** (the first cut mapped `full` → `make benchmark` and defaulted to the canonical sweep):

1. **`full` measures, it does not publish.** It runs the three measurement targets + `benchmark-summary` — deliberately **not** `make benchmark`, whose last stage (`benchmark-report`) rewrites the repo-root `README.md` `## Performance` block from `OUT_DIR`. `OUT_DIR=dispatch` protects `results/latest` but not the README; *dropping the report writer* is the real lock. So a dispatch (and the local `run-suite.sh SUITE=full`) cannot touch the published README by construction — not merely by not-committing.
2. **Reduced, runner-survivable pin defaults.** Blank pins default to `1,10,100 × 3 × 10s` (the protocol the committed snapshot already used on a stronger host), **not** the `versions.env` canonical `1/10/100/500/1000 × 5 × 30s` sweep this repo could not sustain on a single host and which `run-crud` fail-closes on. Override explicitly for a wider run on a dedicated runner; 500/1000 never load unless asked for.
3. **The benchmark script tests now run in merge CI.** New `benchmark-scripts` job (`needs: build`) runs `run-suite_test.sh`, `benchmark-target_test.sh`, `run-crud-all_test.sh`, `footprint-all_test.sh` — Docker-free stub suites that were on no `pull_request` path, so a broken mapping could merge green.

`auth` / `techempower` are deliberately **not** offered — those workloads don't exist yet (Phase 5); a choice mapping to a missing target would be a broken caption.

Refs #141

## Acceptance criteria (§11 manual workflow)

- [x] `workflow_dispatch` with a suite selector; runs full or a selected suite.
- [x] Uploads `metadata.json`, raw results, `results.json`, `results.csv`, `summary.md` (plus footprint/microbench) as artifacts.
- [x] Does **not** overwrite the committed README/snapshot — `full` never runs the report writer, and every suite writes to a gitignored dispatch dir; the workflow never commits.
- [x] Default inputs actually complete on `ubuntu-latest` (reduced protocol), not the dedicated-host canonical sweep.
- Completes Phase 8 (the per-PR smoke gate landed in #206).

## Validation

- [x] `run-suite_test.sh` — asserts `full` runs crud-all/footprint/micro/summary and **never** `benchmark-report`/bare `benchmark`; reduced pins default in (500/1000 absent unless set); explicit overrides win; dispatch `OUT_DIR` (never `results/latest`); injection-safety at the shell env→argv layer; unknown-suite fails.
- [x] New `benchmark-scripts` CI job runs all four benchmark shell tests.
- [x] `actionlint` — 0 issues on `benchmarks.yml` and `ci.yml`.
- [x] Ran the `micro` suite through `run-suite.sh` end to end — wrote `microbench.json` to the dispatch dir; `results/latest` **and** `README.md` untouched.

## Working agreement checklist

- [x] New behavior has tests, wired into CI
- [x] Stable features ship docs — benchmarks/README "Manual runs"; plan Phase 8
- [x] Extraction preserves contracts — thin wrapper over existing `make` targets
- [ ] Generators / API / OpenAPI+TS — N/A
- [x] No secrets in frontend — N/A, still true
- [x] Scope stays in-milestone — BENCH-1 Phase 8
- [x] Links its issue (`Refs #141`) and lists satisfied AC

🤖 Generated with [Claude Code](https://claude.com/claude-code)