### PR TITLE
fix: BENCH-1 footprint inspects app image by tag, not the dangling image ID

### DIFF
--- a/benchmarks/scripts/footprint-all.sh
+++ b/benchmarks/scripts/footprint-all.sh
@@ -183,7 +183,14 @@ do_measure() {
   loaded="${loaded_cpu% *}"
   cpu="${loaded_cpu#* }"
 
-  image="$(docker image inspect "$(docker inspect "$cid" --format '{{.Image}}')" --format '{{.Size}}')" || return 1
+  # Inspect the app image by the TAG the container was created with
+  # (.Config.Image, e.g. bench-gin-gorm:local), not the resolved image ID
+  # (.Image). measure_container rebuilds the image just above; a rebuild retags
+  # to a new ID and can leave the old ID (which a reused container still pins via
+  # .Image) dangling/removed, so `docker image inspect <old-id>` fails with "No
+  # such image". The tag always resolves to the current app image, which is what
+  # the footprint's image-size measures anyway.
+  image="$(docker image inspect "$(docker inspect "$cid" --format '{{.Config.Image}}')" --format '{{.Size}}')" || return 1
 
   record_footprint \
     -framework "$app" -framework-version "$FRAMEWORK_VERSION" \

--- a/benchmarks/scripts/footprint-all_test.sh
+++ b/benchmarks/scripts/footprint-all_test.sh
@@ -45,6 +45,18 @@ got="$(aggregate_load_samples "$f")"
 [ "$got" = "25 2.5" ] || note "aggregate_load_samples(3 samples) = '$got', want '25 2.5'"
 rm -f "$f"
 
+# ---- static: image size is inspected by TAG (.Config.Image), never the
+#      resolved image ID (.Image). measure_container rebuilds the image, which
+#      retags to a new ID and can leave the old ID a reused container pins
+#      dangling; `docker image inspect <old-id>` then fails "No such image" and
+#      aborts the whole run after a clean load (seen on a real canonical run).
+#      The runtime docker is stubbed below, so this source check is what locks it.
+if grep -qE "docker inspect [^|]*'\{\{\.Image\}\}'" benchmarks/scripts/footprint-all.sh; then
+  note "image-size inspects the resolved .Image ID (dangles after rebuild); use .Config.Image (the tag)"
+fi
+grep -qF '{{.Config.Image}}' benchmarks/scripts/footprint-all.sh \
+  || note "image-size no longer inspects the app image by tag (.Config.Image)"
+
 # ---- fakes for the measure_container control-flow tests ----
 CALLS=()
 fake_compose() { if [ "$1" = ps ]; then echo "cid-$3"; return 0; fi; CALLS+=("compose $*"); }


### PR DESCRIPTION
## Summary

A canonical `make benchmark` run crashed the **footprint** stage right after a clean load, on the first app:

```
k6load: 1268 requests, 0 errors over 10.0s — clean
Error response from daemon: No such image: sha256:ec3353abb80a…
make[1]: *** [Makefile:113: benchmark-footprint] Error 1
```

`do_measure` resolved the image size via the container's `.Image` (the resolved image **ID**), then `docker image inspect <id>`. `measure_container` rebuilds the image just before measuring; a rebuild retags `bench-<app>:local` to a new ID and can leave the old ID — which a reused container still pins via `.Image` — dangling/removed, so inspecting that ID fails `No such image`. Because the line is `|| return 1`, it **fail-closes the entire multi-hour run** after the load already succeeded.

**Fix:** inspect by the tag the container was created with (`.Config.Image`, e.g. `bench-gin-gorm:local`) instead of the resolved ID. The tag always resolves to the current app image, which is what the footprint's image-size measures anyway.

Refs #141

## Root cause / validation

- Reproduced the `.Image` dangling failure and confirmed `.Config.Image` yields the same size (`22139667`) on Docker 29 (containerd image store).
- Ran a reduced footprint run (`COLD_START_RUNS=3 LOAD_SECONDS=5 APPS=gin-gorm`) → it now records the row past the inspect (image 21.1 MB, cold-start 124 ms, idle 7.1 MB).
- Source-level regression guard added to `footprint-all_test.sh` (the runtime `docker` is stubbed, so the guard asserts the script inspects by `.Config.Image` and not the fragile `.Image`) — verified it fails on a revert.

## Working agreement checklist

- [x] New behavior has tests — regression guard in `footprint-all_test.sh`; reproduced + verified live
- [x] Bugfix: root cause only (image reference), no rewrite
- [x] Stable features ship docs — N/A (behavior-preserving fix; the fix is self-documented in the script)
- [ ] Generators / API / OpenAPI+TS — N/A
- [x] Scope stays in-milestone — BENCH-1
- [x] Links its issue (`Refs #141`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)