### PR TITLE
fix: BENCH-1 measure cold-start elapsed monotonically (footprint no longer aborts on a garbage sample)

### DIFF
--- a/benchmarks/scripts/footprint-all.sh
+++ b/benchmarks/scripts/footprint-all.sh
@@ -151,11 +151,27 @@ measure_under_load() {
 # cold_start_samples APP LIVEZ_URL — echo COLD_START_RUNS comma-separated
 # start→ready samples (ms), stopping/starting the existing container each time.
 cold_start_samples() {
-  local app="$1" url="$2" samples="" ms
+  local app="$1" url="$2" samples="" ms attempt
   for _ in $(seq 1 "$COLD_START_RUNS"); do
-    "${COMPOSE[@]}" stop "$app" >/dev/null
-    "${COMPOSE[@]}" start "$app" >/dev/null
-    ms="$(wait_ready_ms "$url")" || { echo "footprint: $app cold-start did not become ready" >&2; return 1; }
+    ms=""
+    # wait_ready_ms polls for at most ~30s, so a valid start->ready sample is a
+    # non-negative integer well under 60000 ms. A negative or absurd value means
+    # the host wall clock stepped between the two `date` reads mid-measurement
+    # (an NTP adjustment / clock discontinuity — this ~20-iteration loop runs
+    # long enough to catch one on any host, WSL or bare metal). That's a bad
+    # *sample*, not a broken app, so redo the stop/start rather than fail-closing
+    # the entire multi-hour run on a transient clock step.
+    for attempt in 1 2 3 4 5; do
+      "${COMPOSE[@]}" stop "$app" >/dev/null
+      "${COMPOSE[@]}" start "$app" >/dev/null
+      ms="$(wait_ready_ms "$url")" || { echo "footprint: $app cold-start did not become ready" >&2; return 1; }
+      if [[ "$ms" =~ ^[0-9]+$ ]] && [ "$ms" -le 60000 ]; then
+        break
+      fi
+      echo "footprint: $app cold-start sample '$ms' out of range (clock skew?); retry $attempt/5" >&2
+      ms=""
+    done
+    [ -n "$ms" ] || { echo "footprint: $app cold-start kept producing an out-of-range sample" >&2; return 1; }
     samples="${samples:+$samples,}$ms"
   done
   printf '%s' "$samples"

--- a/benchmarks/scripts/footprint-all.sh
+++ b/benchmarks/scripts/footprint-all.sh
@@ -80,14 +80,23 @@ stats_sample() {
     | { read -r mem cpu; printf '%s %s\n' "$(printf '%s' "$mem" | to_bytes)" "$(printf '%s' "$cpu" | tr -d '% ')"; }
 }
 
-# wait_ready_ms URL — poll until HTTP 200, echo elapsed milliseconds (or fail).
+# now_ms — MONOTONIC milliseconds (CLOCK_MONOTONIC via /proc/uptime, ~10ms
+# resolution). Elapsed timing uses this, NOT `date +%s%3N` (CLOCK_REALTIME):
+# two realtime reads can straddle a wall-clock adjustment and yield a garbage
+# difference (a real run produced -1609081096361592473, the shape of an ms read
+# minus a nanosecond-epoch read). /proc/uptime never runs backwards, so
+# start->ready elapsed is always a sane non-negative number.
+now_ms() { awk '{printf "%d", $1 * 1000}' /proc/uptime; }
+
+# wait_ready_ms URL — poll until HTTP 200, echo elapsed monotonic milliseconds
+# (or fail).
 wait_ready_ms() {
   local url="$1" start now code
-  start="$(date +%s%3N)"
+  start="$(now_ms)"
   for _ in $(seq 1 600); do
     code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$url" 2>/dev/null || true)"
     if [ "$code" = "200" ]; then
-      now="$(date +%s%3N)"
+      now="$(now_ms)"
       echo "$((now - start))"
       return 0
     fi
@@ -154,13 +163,13 @@ cold_start_samples() {
   local app="$1" url="$2" samples="" ms attempt
   for _ in $(seq 1 "$COLD_START_RUNS"); do
     ms=""
-    # wait_ready_ms polls for at most ~30s, so a valid start->ready sample is a
-    # non-negative integer well under 60000 ms. A negative or absurd value means
-    # the host wall clock stepped between the two `date` reads mid-measurement
-    # (an NTP adjustment / clock discontinuity — this ~20-iteration loop runs
-    # long enough to catch one on any host, WSL or bare metal). That's a bad
-    # *sample*, not a broken app, so redo the stop/start rather than fail-closing
-    # the entire multi-hour run on a transient clock step.
+    # wait_ready_ms measures elapsed from the MONOTONIC clock (now_ms), so a
+    # sample can't be corrupted by a wall-clock step. This is defense in depth on
+    # top of that: a well-formed sample is a non-negative integer <= 60000 ms
+    # (wait_ready_ms polls at most ~30s), and anything else — a malformed reading
+    # from some other cause — is neither recorded nor allowed to fail-close the
+    # whole run; we REDO the stop/start (a fresh cold start), up to 5 times, then
+    # fail. It is a garbage filter, not clock-step detection.
     for attempt in 1 2 3 4 5; do
       "${COMPOSE[@]}" stop "$app" >/dev/null
       "${COMPOSE[@]}" start "$app" >/dev/null
@@ -168,10 +177,10 @@ cold_start_samples() {
       if [[ "$ms" =~ ^[0-9]+$ ]] && [ "$ms" -le 60000 ]; then
         break
       fi
-      echo "footprint: $app cold-start sample '$ms' out of range (clock skew?); retry $attempt/5" >&2
+      echo "footprint: $app cold-start sample '$ms' malformed; redoing stop/start ($attempt/5)" >&2
       ms=""
     done
-    [ -n "$ms" ] || { echo "footprint: $app cold-start kept producing an out-of-range sample" >&2; return 1; }
+    [ -n "$ms" ] || { echo "footprint: $app cold-start kept producing a malformed sample" >&2; return 1; }
     samples="${samples:+$samples,}$ms"
   done
   printf '%s' "$samples"

--- a/benchmarks/scripts/footprint-all_test.sh
+++ b/benchmarks/scripts/footprint-all_test.sh
@@ -57,6 +57,35 @@ fi
 grep -qF '{{.Config.Image}}' benchmarks/scripts/footprint-all.sh \
   || note "image-size no longer inspects the app image by tag (.Config.Image)"
 
+# ---- cold_start_samples retries an out-of-range (clock-step) sample instead of
+#      fail-closing the whole run. A wall-clock step between wait_ready_ms's two
+#      `date` reads yields a negative/absurd elapsed (a real canonical run hit
+#      "-1609081096361592473"); that's a bad sample, not a broken app. ----
+cs_noop() { :; } # stop/start are no-ops here
+COMPOSE=(cs_noop)
+PORT=8081
+# Count calls via a file: wait_ready_ms runs in its own command-substitution
+# subshell each time, so a shell var would reset. First reading is the real
+# garbage a canonical run hit; the retry is clean.
+cs_count="$(mktemp)"; echo 0 > "$cs_count"
+wait_ready_ms() {
+  local n; n=$(( $(cat "$cs_count") + 1 )); echo "$n" > "$cs_count"
+  if [ "$n" -eq 1 ]; then echo "-1609081096361592473"; else echo "120"; fi
+}
+got="$(COLD_START_RUNS=1 cold_start_samples gin-gorm http://x/livez 2>/dev/null)"
+[ "$got" = "120" ] || note "cold_start_samples did not retry past a clock-step sample: '$got'"
+rm -f "$cs_count"
+# A persistently out-of-range sample fails, never records the garbage.
+wait_ready_ms() { echo "-1609081096361592473"; }
+if COLD_START_RUNS=1 cold_start_samples gin-gorm http://x/livez >/dev/null 2>&1; then
+  note "cold_start_samples recorded a persistently out-of-range sample instead of failing"
+fi
+# A huge positive (clock stepped forward) is also rejected.
+wait_ready_ms() { echo "1609081096361592473"; }
+if COLD_START_RUNS=1 cold_start_samples gin-gorm http://x/livez >/dev/null 2>&1; then
+  note "cold_start_samples accepted an absurdly large sample"
+fi
+
 # ---- fakes for the measure_container control-flow tests ----
 CALLS=()
 fake_compose() { if [ "$1" = ps ]; then echo "cid-$3"; return 0; fi; CALLS+=("compose $*"); }

--- a/benchmarks/scripts/footprint-all_test.sh
+++ b/benchmarks/scripts/footprint-all_test.sh
@@ -57,34 +57,51 @@ fi
 grep -qF '{{.Config.Image}}' benchmarks/scripts/footprint-all.sh \
   || note "image-size no longer inspects the app image by tag (.Config.Image)"
 
-# ---- cold_start_samples retries an out-of-range (clock-step) sample instead of
-#      fail-closing the whole run. A wall-clock step between wait_ready_ms's two
-#      `date` reads yields a negative/absurd elapsed (a real canonical run hit
-#      "-1609081096361592473"); that's a bad sample, not a broken app. ----
-cs_noop() { :; } # stop/start are no-ops here
-COMPOSE=(cs_noop)
+# ---- now_ms is monotonic + non-negative: elapsed timing can't go backward on a
+#      wall-clock step (that's why cold starts aren't timed with date +%s%3N,
+#      whose two reads produced -1609081096361592473 on a real run) ----
+a="$(now_ms)"; sleep 0.02; b="$(now_ms)"
+[[ "$a" =~ ^[0-9]+$ ]] || note "now_ms is not a non-negative integer: '$a'"
+[ "$b" -ge "$a" ] 2>/dev/null || note "now_ms went backwards: $a -> $b"
+
+# ---- cold_start_samples: a malformed sample is rejected, and the fix REDOES the
+#      stop/start (a fresh cold start), never a warm re-poll of the up container;
+#      it neither records garbage nor fail-closes the whole run on a transient
+#      one. The COMPOSE recorder counts start calls so the restart invariant is
+#      actually tested, not just the value. ----
+COLD_START_RUNS=1
 PORT=8081
-# Count calls via a file: wait_ready_ms runs in its own command-substitution
-# subshell each time, so a shell var would reset. First reading is the real
-# garbage a canonical run hit; the retry is clean.
-cs_count="$(mktemp)"; echo 0 > "$cs_count"
+cs_starts=0
+cs_count="$(mktemp)"
+# COMPOSE recorder runs in THIS shell (not a $()), so cs_starts survives.
+cs_rec() { case "$1" in start) cs_starts=$((cs_starts + 1)) ;; esac; return 0; }
+COMPOSE=(cs_rec)
+# wait_ready_ms runs in its own $() each call, so it counts via a file.
 wait_ready_ms() {
   local n; n=$(( $(cat "$cs_count") + 1 )); echo "$n" > "$cs_count"
   if [ "$n" -eq 1 ]; then echo "-1609081096361592473"; else echo "120"; fi
 }
-got="$(COLD_START_RUNS=1 cold_start_samples gin-gorm http://x/livez 2>/dev/null)"
-[ "$got" = "120" ] || note "cold_start_samples did not retry past a clock-step sample: '$got'"
-rm -f "$cs_count"
-# A persistently out-of-range sample fails, never records the garbage.
+
+# One malformed reading then a good one: retries to 120 AND restarts twice.
+echo 0 > "$cs_count"; cs_starts=0; csout="$(mktemp)"
+cold_start_samples gin-gorm http://x/livez > "$csout" 2>/dev/null || note "cold_start_samples failed on a recoverable sample"
+[ "$(cat "$csout")" = "120" ] || note "cold_start_samples did not retry to the good sample: '$(cat "$csout")'"
+[ "$cs_starts" -eq 2 ] || note "a rejected sample did not trigger a second stop/start (starts=$cs_starts, want 2)"
+
+# Persistently malformed: fails, restarts all 5 attempts, records nothing.
 wait_ready_ms() { echo "-1609081096361592473"; }
-if COLD_START_RUNS=1 cold_start_samples gin-gorm http://x/livez >/dev/null 2>&1; then
-  note "cold_start_samples recorded a persistently out-of-range sample instead of failing"
+cs_starts=0
+if cold_start_samples gin-gorm http://x/livez >/dev/null 2>&1; then
+  note "cold_start_samples recorded a persistently malformed sample instead of failing"
 fi
-# A huge positive (clock stepped forward) is also rejected.
+[ "$cs_starts" -eq 5 ] || note "persistent-malformed path did not restart 5 times (starts=$cs_starts, want 5)"
+
+# A huge positive (ms-minus-ns shape) is rejected too.
 wait_ready_ms() { echo "1609081096361592473"; }
-if COLD_START_RUNS=1 cold_start_samples gin-gorm http://x/livez >/dev/null 2>&1; then
+if cold_start_samples gin-gorm http://x/livez >/dev/null 2>&1; then
   note "cold_start_samples accepted an absurdly large sample"
 fi
+rm -f "$cs_count" "$csout"
 
 # ---- fakes for the measure_container control-flow tests ----
 CALLS=()


### PR DESCRIPTION
## Summary

A canonical `make benchmark` run crashed the **footprint** stage after a clean load:

```
k6load: 1449 requests, 0 errors over 10.0s — clean
footprint: -cold-start-ms: "-1609081096361592473" is negative
```

`wait_ready_ms` timed a container's start→ready with two `date +%s%3N` (CLOCK_REALTIME) reads and returned their difference; a garbage value flowed into `record_footprint -cold-start-ms`, which correctly refused a negative — and, being `|| return 1`, **fail-closed the entire multi-hour run** after k6 had already succeeded.

**The real fix (per review):** stop timing elapsed with the realtime clock. `wait_ready_ms` now measures from a **monotonic** source (`now_ms`, `/proc/uptime`), which cannot run backward on a wall-clock adjustment — so the garbage-difference class is eliminated at the source, not filtered after the fact.

The range check + stop/start retry stays as **defense in depth**, described honestly (a garbage filter for a malformed sample, not clock-step detection), and its real invariant is now **tested**.

## What the first cut got wrong (and this corrects)

- The value `-1609081096361592473` is **not** an NTP step — it's the shape of an ms-timestamp minus a nanosecond-epoch read (`0 - $(date +%s%N)`; it decodes to 2020-12-27). The comment invented a clock-step story.
- A magic-number `<= 60000` bound would **not** catch a real few-second clock step — a +2 s step on a 120 ms start becomes 2120 ms, looks like a plausible cold start, and gets recorded. So the bound was never clock-step handling.
- The tests proved the *value* filter but not the **restart invariant** — a "simplify" that re-polls `wait_ready_ms` without a fresh stop/start would record a warm ~few-ms hit as a cold start and stay green.

## Validation

- `now_ms` asserted monotonic + non-negative.
- `cold_start_samples` tests now drive `COMPOSE` with a recorder and assert the **stop/start count** (2 on the recover path, 5 on persistent-fail) — verified the assertion **fails** if the stop/start is hoisted out of the retry loop (the exact regression called out).
- Value cases (retry-past-one-bad, fail-on-persistent, reject-huge-positive) still pass and fail on the pre-fix single-shot.
- A real `gin-gorm` footprint run records a 120 ms median cold start with monotonic timing.

Refs #141

## Working agreement checklist

- [x] New behavior has tests — monotonic assertion + restart-count invariant + value cases
- [x] Bugfix: root cause (realtime→monotonic elapsed), not a wrapper
- [x] Scope stays in-milestone — BENCH-1
- [x] Links its issue (`Refs #141`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)