### PR TITLE
fix: admin create no longer masks type-coercion errors as "is required"

### DIFF
--- a/admin/resources.go
+++ b/admin/resources.go
@@ -286,9 +286,13 @@ func applyWrite(ctx context.Context, m *registered, inst any, body map[string]an
 			if !f.Required || f.ReadOnly {
 				continue
 			}
-			if _, ok := seen[f.Name]; !ok {
-				fields[f.Name] = []string{"is required"}
+			if _, ok := seen[f.Name]; ok {
+				continue
 			}
+			if _, ok := fields[f.Name]; ok {
+				continue
+			}
+			fields[f.Name] = []string{"is required"}
 		}
 	}
 	if len(fields) > 0 {

--- a/admin/resources_test.go
+++ b/admin/resources_test.go
@@ -422,6 +422,56 @@ func TestResourceValidation(t *testing.T) {
 	assertError(t, unknown, http.StatusUnprocessableEntity, contract.CodeValidationError)
 }
 
+func TestResourceCreateInvalidRequiredFieldReportsCoercionError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app, func(o *admin.Options) {
+		for i := range o.Fields {
+			if o.Fields[i].Name == "price" {
+				o.Fields[i].Required = true
+			}
+		}
+	})
+	jar := loginSuperuser(t, app)
+
+	rec := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/widgets",
+		`{"name":"X","price":"not-a-number"}`)
+	assertError(t, rec, http.StatusUnprocessableEntity, contract.CodeValidationError)
+
+	env := decodeError(t, rec)
+	got := env.Fields["price"]
+	if len(got) != 1 || got[0] != "must be an integer" {
+		t.Fatalf("fields.price = %#v, want [\"must be an integer\"]", got)
+	}
+}
+
+func TestResourceCreateMixedMissingAndInvalidRequiredFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	registerWidgets(t, app, func(o *admin.Options) {
+		for i := range o.Fields {
+			if o.Fields[i].Name == "price" {
+				o.Fields[i].Required = true
+			}
+		}
+	})
+	jar := loginSuperuser(t, app)
+
+	// "name" is required and absent; "price" is required and present but
+	// invalid. Each must keep its own distinct message.
+	rec := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/widgets",
+		`{"price":"not-a-number"}`)
+	assertError(t, rec, http.StatusUnprocessableEntity, contract.CodeValidationError)
+
+	env := decodeError(t, rec)
+	if got := env.Fields["name"]; len(got) != 1 || got[0] != "is required" {
+		t.Fatalf("fields.name = %#v, want [\"is required\"]", got)
+	}
+	if got := env.Fields["price"]; len(got) != 1 || got[0] != "must be an integer" {
+		t.Fatalf("fields.price = %#v, want [\"must be an integer\"]", got)
+	}
+}
+
 func TestResourceListPaginationSearchOrderFilter(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	app := newCookieApp(t)


### PR DESCRIPTION
## Summary

- `admin/resources.go`'s `applyWrite` unconditionally overwrote a required
  field's real coercion error with the generic `"is required"` message on
  create, whenever that field wasn't in `seen` — including when it failed
  type coercion rather than being absent.
- Fix: skip the "is required" pass when the field already carries an error
  in `fields`, not only when it was successfully set (`seen`).

Closes #198

## Acceptance criteria

(the issue is a bug report without a formal AC checklist; derived from its
"What happened" / "Root cause" sections)

- [x] A required field present in the body but failing type coercion
      reports its real coercion error (e.g. `"must be an integer"`),
      not `"is required"`.
- [x] A required field genuinely absent from the body still reports
      `"is required"` (regression-checked in combination with the above,
      in the same request).

## Scope notes

Nothing deferred — this is a single logic fix contained to `applyWrite`.

## Validation

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [x] Project `code-review` skill run against this diff (APPROVE)
- [x] Confirmed both new tests fail against the pre-fix code (reproducing
      the exact bug) and pass with the fix

## Working agreement checklist

- [x] New behavior has tests. DB-touching matrix N/A: `applyWrite` is pure
      in-memory validation that runs before any persistence call, with no
      driver-specific behavior.
- [ ] Docs + example — N/A, bugfix to existing validated behavior, not a
      new stable feature.
- [ ] Extraction preserves contracts — N/A, not an extraction.
- [ ] Generators — N/A, no generator touched.
- [ ] API changes regenerate OpenAPI + TS client — N/A, the D10
      `error.fields` shape is unchanged; only the runtime message content
      for one already-dynamic field is corrected.
- [ ] No secrets in generated frontend — N/A, no frontend touched.
- [x] Scope stays inside this issue's milestone — single logic fix, no M6
      battery creep.
- [x] This PR links its issue and states which acceptance criteria it
      satisfies.