### PR TITLE
fix: bound metrics method label to prevent unbounded-cardinality DoS (#197)

### DIFF
--- a/docs/router.md
+++ b/docs/router.md
@@ -121,10 +121,15 @@ OpenTelemetry exporter wiring remains future runtime work; M1-7 preserves the
 runtime seam and parity tests.
 
 `/metrics` exposes Prometheus text-format request counters, active request
-gauge, and request-duration sums for the runtime router. The text renderer is
-intentionally minimal for M1 runtime parity; a later observability issue can
-swap in `prometheus/client_golang` or full OpenTelemetry exporter wiring
-without changing the route contract. Trusted proxies are configured through
+gauge, and request-duration sums for the runtime router, labelled by `method`,
+`route`, and `status`. All three labels are bounded so a remote caller cannot
+inflate series cardinality: `route` is the matched route pattern (or
+`unmatched`), and `method` is limited to the standard HTTP methods with any
+other token bucketed as `other` (the raw request method is otherwise an
+unbounded client-supplied value). The text renderer is intentionally minimal
+for M1 runtime parity; a later observability issue can swap in
+`prometheus/client_golang` or full OpenTelemetry exporter wiring without
+changing the route contract. Trusted proxies are configured through
 `config.Config.HTTP.TrustedProxies` or
 `GOMBIT_HTTP_TRUSTED_PROXIES`; when unset, Gin ignores forwarded-client IP
 headers and uses the direct TCP peer.

--- a/framework/http_middleware.go
+++ b/framework/http_middleware.go
@@ -119,6 +119,37 @@ type metricsKey struct {
 	status int
 }
 
+// knownHTTPMethods bounds the cardinality of the metrics `method` label. The
+// raw request method is an arbitrary RFC 7230 token that an unauthenticated
+// client can vary without limit, and the metrics maps are never evicted, so
+// recording it verbatim lets a remote caller mint unbounded distinct series
+// and exhaust memory (issue #197). The metrics middleware runs on every
+// request — including unmatched routes and unregistered methods — so any
+// method outside this set collapses to metricsMethodOther.
+var knownHTTPMethods = map[string]struct{}{
+	http.MethodGet:     {},
+	http.MethodHead:    {},
+	http.MethodPost:    {},
+	http.MethodPut:     {},
+	http.MethodPatch:   {},
+	http.MethodDelete:  {},
+	http.MethodOptions: {},
+	http.MethodConnect: {},
+	http.MethodTrace:   {},
+}
+
+const metricsMethodOther = "other"
+
+// normalizeMetricsMethod maps any non-standard HTTP method to a single bucket
+// so the metrics `method` label stays bounded by a small constant. See
+// knownHTTPMethods.
+func normalizeMetricsMethod(method string) string {
+	if _, ok := knownHTTPMethods[method]; ok {
+		return method
+	}
+	return metricsMethodOther
+}
+
 func newHTTPMetrics() *httpMetrics {
 	return &httpMetrics{
 		requests: make(map[metricsKey]int64),
@@ -139,7 +170,7 @@ func metricsMiddleware(metrics *httpMetrics) gin.HandlerFunc {
 			route = "unmatched"
 		}
 		metrics.observe(metricsKey{
-			method: c.Request.Method,
+			method: normalizeMetricsMethod(c.Request.Method),
 			route:  route,
 			status: c.Writer.Status(),
 		}, time.Since(start))

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -372,6 +373,61 @@ func TestDefaultRouterMetricsUsesBoundedLabelForUnmatchedRoutes(t *testing.T) {
 		if strings.Contains(body, rawPath) {
 			t.Fatalf("GET /metrics body = %q, want no raw unmatched path %q", body, rawPath)
 		}
+	}
+}
+
+// TestMetricsMiddlewareBoundsMethodLabelCardinality is the regression test for
+// issue #197: the metrics `method` label is derived from the client-supplied
+// HTTP method, which is an unbounded RFC 7230 token. Recording it verbatim
+// into the never-evicted metrics maps let an unauthenticated remote caller
+// mint unlimited distinct series (a slow OOM). Arbitrary methods must collapse
+// to a single "other" bucket, keeping cardinality bounded.
+func TestMetricsMiddlewareBoundsMethodLabelCardinality(t *testing.T) {
+	metrics := newHTTPMetrics()
+	engine := gin.New()
+	engine.Use(metricsMiddleware(metrics))
+	engine.GET("/livez", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	// Global middleware runs on 404s too, so unregistered methods still reach
+	// observe — exactly the attack path in the issue.
+	for i := 0; i < 1000; i++ {
+		req := httptest.NewRequest(fmt.Sprintf("EVILMETHOD%d", i), "/livez", nil)
+		engine.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	if got := len(metrics.requests); got != 1 {
+		t.Fatalf("distinct metric series after 1000 arbitrary methods = %d, want 1 (bounded)", got)
+	}
+
+	body := metrics.render()
+	if !strings.Contains(body, `method="other"`) {
+		t.Fatalf("metrics body = %q, want non-standard methods bucketed as method=\"other\"", body)
+	}
+	if strings.Contains(body, "EVILMETHOD") {
+		t.Fatalf("metrics body = %q, want no raw client method token recorded", body)
+	}
+}
+
+// TestMetricsMiddlewareKeepsStandardMethodLabels confirms the bounding does not
+// flatten legitimate, standard methods into the "other" bucket.
+func TestMetricsMiddlewareKeepsStandardMethodLabels(t *testing.T) {
+	metrics := newHTTPMetrics()
+	engine := gin.New()
+	engine.Use(metricsMiddleware(metrics))
+	engine.Any("/thing", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		engine.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(method, "/thing", nil))
+	}
+
+	body := metrics.render()
+	for _, method := range []string{"GET", "POST", "PUT", "PATCH", "DELETE"} {
+		if !strings.Contains(body, fmt.Sprintf(`method=%q`, method)) {
+			t.Fatalf("metrics body = %q, want standard method label %q preserved", body, method)
+		}
+	}
+	if strings.Contains(body, `method="other"`) {
+		t.Fatalf("metrics body = %q, want no \"other\" bucket for standard methods", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

The runtime metrics middleware (`framework/http_middleware.go`) recorded one Prometheus series per `(method, route, status)` tuple in never-evicted in-memory maps, using the **raw client-supplied HTTP method** as the `method` label:

```go
metrics.observe(metricsKey{
    method: c.Request.Method,   // attacker-controlled, unbounded RFC 7230 token
    route:  route,              // matched pattern or "unmatched" — bounded
    status: c.Writer.Status(),  // bounded
}, time.Since(start))
```

The middleware is wired unconditionally into every app and runs on **every** request — including unmatched routes and unregistered methods, before auth. An unauthenticated remote caller could mint unlimited distinct method strings (`curl -X EVILMETHOD$i …`), each adding a permanent series, forcing unbounded memory growth — a slow OOM / DoS.

`route` already collapses to a bounded set and `status` is a handful of codes, so `method` was the cardinality-explosion vector.

## Fix

Allowlist the standard HTTP methods (GET/HEAD/POST/PUT/PATCH/DELETE/OPTIONS/CONNECT/TRACE) for the `method` label and bucket anything else as a single constant `"other"` (`normalizeMetricsMethod`). Cardinality is now bounded by a small constant. Pure label-normalization — standard methods are recorded exactly as before.

This matches the issue's suggested fix. Not an exposition-format injection (render already uses `%q`); the issue was purely cardinality.

## Closes

Closes #197

## Acceptance criteria

- [x] Non-standard / arbitrary HTTP methods no longer create distinct metric series — bucketed as `method="other"`
- [x] Standard HTTP methods keep their own labels (no over-collapsing)
- [x] No raw client method token reaches the exposed `/metrics` output

## Scope notes

- Only the `method` label is normalized. `route` was already bounded (`unmatched` for 404s, verified by an existing test); left as-is.
- The minimal in-house text renderer is unchanged — swapping in `prometheus/client_golang` remains a separate future observability issue.

## Validation

- [x] `go test ./...` — all pass (exit 0), including the goldentest matrix
- [x] `go test ./framework/ -run Metrics -v` — new + existing metrics tests pass
- [ ] golangci-lint — not run locally
- [ ] Project `code-review` skill — not run against this diff

New tests:
- `TestMetricsMiddlewareBoundsMethodLabelCardinality` — 1000 arbitrary methods collapse to **one** series; no raw token in output. (Fails without the fix: 1000 series.)
- `TestMetricsMiddlewareKeepsStandardMethodLabels` — GET/POST/PUT/PATCH/DELETE stay distinct, no spurious `"other"`.

## Working agreement checklist

- [x] New behavior has tests. No DB-touching change, so the SQLite/PostgreSQL/MySQL matrix is N/A.
- [x] Stable features ship docs — `docs/router.md` now documents the bounded `method`/`route`/`status` labels. No example-app change needed (metrics are framework-owned, always on).
- [x] Extraction preserves contracts — behavior-preserving for all standard methods; only unbounded tokens change bucket.
- [ ] Generators — N/A; no generator code touched.
- [ ] API changes regenerate OpenAPI + TS client — N/A; `/metrics` is text-format, not part of the Huma contract.
- [x] No secrets in generated frontend source — N/A/unaffected.
- [x] Scope stays inside milestone — targeted security fix, no M6 battery creep.
- [x] Links its issue — Closes #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)