### PR TITLE
docs: refresh AGENTS.md "Current state" for REL-1..9 and BENCH-1 (#212)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@ a generated React+TypeScript frontend, Atlas-backed migrations. Module path
 
 ## Current state
 
-This repo has completed M0–M5 and **ADMIN-1 through ADMIN-3**. It has typed
+This repo has completed M0–M5, **ADMIN-1 through ADMIN-3**, the **REL-1..9**
+release-readiness track, and **BENCH-1** (the benchmark suite). It has typed
 `config.Config`, `framework.App` lifecycle and routing, Huma contract/OpenAPI/
 TypeScript client generation, Atlas-backed migrations, a Cobra `gombit`
 command tree (`new`, `dev`, `build --embed`, `make resource`, `make command`,
@@ -15,10 +16,19 @@ command tree (`new`, `dev`, `build --embed`, `make resource`, `make command`,
 (M5-3), the MUI preset (M5-4, `--ui mui`), and optional `gombit build --embed`
 (M5-5) are in. **ADMIN-0 (ADR-013) is accepted**, **ADMIN-1** ships
 `admin.Register`, `GET /api/v1/admin/meta`, and the generic
-`/api/v1/admin/resources/{slug}` data plane, and **ADMIN-2** ships the
-framework-owned SPA under `/admin/` (`internal/adminui`, cookie-only embed).
-ADMIN-3 adds direct/group permission enforcement with a superuser bypass.
-Other M6 batteries are not here yet.
+`/api/v1/admin/resources/{slug}` data plane, **ADMIN-2** ships the
+framework-owned SPA under `/admin/` (`internal/adminui`, cookie-only embed),
+and **ADMIN-3** adds direct/group permission enforcement with a superuser
+bypass. **REL-1..9** covers release readiness: the README rewrite with badges
+and quickstart, contributor and community-health files, issue templates,
+`gombit version` plus the release workflow, the installation guide, the
+tutorial and its example app, the docs index/changelog/release runbook, and
+scaffolded apps resolving a published framework version. **BENCH-1** adds the
+`benchmarks/` tree — Go micro-benchmarks (`benchmarks/micro`), the operational
+footprint/cold-start harness, k6 load workloads, the canonical results
+snapshot behind the README performance table, and a manual `benchmarks.yml`
+workflow — plus the per-PR `benchmark-report-drift` and `benchmark-smoke`
+gates in `ci.yml`. Other M6 batteries are not here yet.
 Don't assume generated apps are committed in-tree; `gombit new` writes them
 on demand. Check `git log` / `ls` before describing "how the code works."
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,9 @@
   docs/GOMBIT_BUILD_PLAN.md §5 and the change's claimed contract. Invoke with
   `/code-review` or ask to review a PR/diff; it overrides the bundled
   `/code-review` for this repo.
-- This repo has completed M0–M3 and started M4 CLI (see AGENTS.md
-  "Current state").
+- For what has shipped, defer to AGENTS.md "Current state" (kept current
+  there) rather than a milestone number duplicated here that drifts out of
+  date — as of this writing that is M0–M5, ADMIN-1..3, REL-1..9, and BENCH-1.
   Prefer a direct `Read` of `docs/GOMBIT_BUILD_PLAN.md` over spawning an
   Explore subagent for backlog/dependency lookups. Runtime packages and the
   Cobra `gombit` tree (`new`, `db`, `openapi`, `client`) exist; generated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,12 @@
   docs/GOMBIT_BUILD_PLAN.md §5 and the change's claimed contract. Invoke with
   `/code-review` or ask to review a PR/diff; it overrides the bundled
   `/code-review` for this repo.
-- For what has shipped, defer to AGENTS.md "Current state" (kept current
-  there) rather than a milestone number duplicated here that drifts out of
-  date — as of this writing that is M0–M5, ADMIN-1..3, REL-1..9, and BENCH-1.
+- For what has shipped — milestones, the Cobra command tree, runtime
+  packages — defer to AGENTS.md "Current state", the single place kept
+  current; don't restate a snapshot of it here, which is what drifts stale.
   Prefer a direct `Read` of `docs/GOMBIT_BUILD_PLAN.md` over spawning an
-  Explore subagent for backlog/dependency lookups. Runtime packages and the
-  Cobra `gombit` tree (`new`, `db`, `openapi`, `client`) exist; generated
-  apps are written by `gombit new`, not committed in-tree.
+  Explore subagent for backlog/dependency lookups. Generated apps are written
+  by `gombit new`, not committed in-tree.
 - When creating or editing GitHub issues, keep the `[ID]` title prefix and the
   milestone/label mapping from build plan §6. Don't rename, re-bucket, or
   merge existing issues without being asked.


### PR DESCRIPTION
## Summary

AGENTS.md's "Current state" paragraph had fallen behind again — it described the repo as M0–M5 + ADMIN-1..3 with "other M6 batteries not here yet", omitting two tracks that have since closed. This updates it and corrects the companion staleness the issue calls out.

- **REL-1..9** (#79–#87, all closed) — release readiness: README/badges/quickstart, contributor & community-health files, issue templates, `gombit version` + release workflow, installation guide, tutorial + its example app, docs index/changelog/release runbook, and scaffolded apps resolving a published framework version.
- **BENCH-1** (#141, closed) — the `benchmarks/` tree (micro-benchmarks under `benchmarks/micro`, footprint/cold-start harness, k6 workloads, the canonical `results/latest` snapshot behind the README performance table, manual `benchmarks.yml` workflow) plus the per-PR `benchmark-report-drift` and `benchmark-smoke` gates in `ci.yml`.

## Closes

Closes #212

## Acceptance criteria

- [x] AGENTS.md "Current state" reflects REL-1..9 as closed
- [x] AGENTS.md "Current state" reflects BENCH-1 as closed and mentions the `benchmarks/` tree
- [x] Docs-only — no new scope or architecture decision

## Scope notes

- The issue's AC is AGENTS.md-only, but the issue body explicitly cites the recurring pattern via **CLAUDE.md** still claiming *"completed M0–M3 and started M4 CLI"* — the more egregious of the two. I fixed that line in the same docs-only PR: it now **defers to AGENTS.md "Current state"** (the single place kept current) rather than duplicating a milestone number that keeps drifting, which is the actual root cause of this recurring issue. Happy to split it out if you'd rather keep the PR strictly to AGENTS.md.
- All claims verified against `gh issue` state (REL-1..9 and #141 CLOSED), the `benchmarks/` tree, `benchmarks.yml`, and the `ci.yml` gate jobs — not asserted from memory.

## Validation

- [x] Facts cross-checked against issue states, workflow files, and the repo tree
- N/A — docs-only; no code, no tests, no generated artifacts affected

## Working agreement checklist

- [ ] New behavior has tests — N/A; docs-only, no behavior change.
- [x] Stable features ship docs — this *is* the docs correction; the referenced features already shipped.
- [x] Extraction preserves contracts — N/A; no code.
- [ ] Generators — N/A.
- [ ] API changes regenerate OpenAPI + TS client — N/A; no API change.
- [x] No secrets in generated frontend source — N/A/unaffected.
- [x] Scope stays inside milestone — docs-only; see Scope notes for the one deliberate companion edit.
- [x] Links its issue — Closes #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)