### PR TITLE
fix: admin create/update/delete no longer report FK/NOT NULL violations as 500

### DIFF
--- a/admin/resources.go
+++ b/admin/resources.go
@@ -206,7 +206,7 @@ func (h *handlers) deleteResource(ctx context.Context, input *itemInput) (*delet
 		return nil, contract.WithContext(ctx, contract.Internal("admin database is not attached"))
 	}
 	if err := db.WithContext(ctx).Delete(inst).Error; err != nil {
-		return nil, database.MapPersistError(ctx, err, "resource already exists", "persist resource")
+		return nil, database.MapDeleteError(ctx, err, "resource is still referenced by other records", "delete resource")
 	}
 	return &deleteOutput{Body: contract.Data[deleteResult]{Data: deleteResult{OK: true}}}, nil
 }

--- a/admin/resources_test.go
+++ b/admin/resources_test.go
@@ -596,6 +596,111 @@ func TestResourceBelongsToStoresFK(t *testing.T) {
 	}
 }
 
+func TestResourceCreateForeignKeyViolationIsValidationError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type FKCategory struct {
+		ID uint `gorm:"primaryKey" json:"id"`
+	}
+	type FKItem struct {
+		ID         uint       `gorm:"primaryKey" json:"id"`
+		Name       string     `json:"name"`
+		CategoryID uint       `json:"category_id"`
+		Category   FKCategory `gorm:"constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;" json:"-"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&FKCategory{}, &FKItem{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	if err := admin.Register(app, FKItem{}, admin.Options{
+		Slug: "fk-items",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "name", Type: admin.TypeString},
+			{
+				Name:    "category_id",
+				Type:    admin.TypeRelation,
+				Related: &admin.Relation{Slug: "fk-categories", Kind: admin.RelBelongsTo, LabelField: "id"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	jar := loginSuperuser(t, app)
+
+	// Unlike TestResourceBelongsToStoresFK, FKItem.Category is a real GORM
+	// association with a DB-level constraint, so a nonexistent category_id
+	// reaches the database as an actual foreign-key violation, not just
+	// stored as an opaque integer.
+	rec := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/fk-items", `{"name":"Nail","category_id":999}`)
+	assertError(t, rec, http.StatusUnprocessableEntity, contract.CodeValidationError)
+}
+
+func TestResourceCreateNotNullViolationIsValidationError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type StrictWidget struct {
+		ID   uint    `gorm:"primaryKey" json:"id"`
+		Name *string `gorm:"not null" json:"name"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&StrictWidget{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	// "name" is intentionally not marked Required in the admin metadata, to
+	// reproduce the issue's actual scenario: the DB schema enforces NOT
+	// NULL even where the admin Field options do not.
+	if err := admin.Register(app, StrictWidget{}, admin.Options{
+		Slug: "strict-widgets",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "name", Type: admin.TypeString},
+		},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	jar := loginSuperuser(t, app)
+
+	rec := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/strict-widgets", `{}`)
+	assertError(t, rec, http.StatusUnprocessableEntity, contract.CodeValidationError)
+}
+
+func TestResourceDeleteForeignKeyViolationIsConflict(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type DelCategory struct {
+		ID uint `gorm:"primaryKey" json:"id"`
+	}
+	type DelItem struct {
+		ID         uint        `gorm:"primaryKey" json:"id"`
+		CategoryID uint        `json:"category_id"`
+		Category   DelCategory `gorm:"constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;" json:"-"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&DelCategory{}, &DelItem{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	category := DelCategory{}
+	if err := app.DB().Create(&category).Error; err != nil {
+		t.Fatalf("create fixture category: %v", err)
+	}
+	if err := app.DB().Create(&DelItem{CategoryID: category.ID}).Error; err != nil {
+		t.Fatalf("create fixture item: %v", err)
+	}
+	if err := admin.Register(app, DelCategory{}, admin.Options{
+		Slug: "del-categories",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+		},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	jar := loginSuperuser(t, app)
+
+	// The category is still referenced by DelItem (ON DELETE RESTRICT), so
+	// this must be a 409 conflict, not the 422 validation error a bad
+	// foreign key on create/update would produce, and not a 500.
+	rec := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/del-categories/%d", category.ID), "")
+	assertError(t, rec, http.StatusConflict, "conflict")
+}
+
 func TestJWTModeDoesNotMountAdmin(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	app := newJWTApp(t)

--- a/benchmarks/apps/gombit/README.md
+++ b/benchmarks/apps/gombit/README.md
@@ -127,25 +127,28 @@ blank-name rejection on both create and update, pagination/ordering, and the
 3-query / 2-query (empty page) N+1 guard — plus one difference documented
 below.
 
-## A discovered framework gap, not a benchmark bug
+## A discovered framework gap — fixed (issue #202)
 
-`POST /api/projects` with a nonexistent `owner_id` returns **500 internal**,
-not a 4xx client error. This app uses Gombit's normal
+`POST /api/projects` with a nonexistent `owner_id` used to return **500
+internal** instead of a 4xx client error. This app uses Gombit's normal
 `database.MapPersistError` (`github.com/gombit-dev/gombit/database`)
-unmodified, and that function only special-cases unique-constraint
-violations — a foreign-key violation falls through to `internal`.
+unmodified, and that function only special-cased unique-constraint
+violations — a foreign-key violation fell through to `internal`.
 `gin-gorm`'s control implementation doesn't use that framework helper (see
-its README) and correctly maps the same input to 422.
+its README) and already mapped the same input to 422, so the two
+implementations disagreed on equivalent input.
 
-This is deliberately **not patched here**: issue #141 requires using
-Gombit's normal public APIs as-is ("do not bypass ... normal Gombit response
-handling"), and the entire point of this app is measuring what a real
-Gombit user gets today. `TestCreateInvalidOwnerIDReturnsInternalError` pins
-this actual behavior so a future framework fix (or regression) shows up
-here as an expected test change, not a mysterious fairness-check failure.
-Fixing `database.MapPersistError` itself is out of scope for BENCH-1 — see
-docs/plans/BENCH-1-benchmark-suite.md Phase 3b for the writeup and a
-pointer to file it as its own issue.
+This was deliberately **not patched here** while it was open: issue #141
+requires using Gombit's normal public APIs as-is ("do not bypass ... normal
+Gombit response handling"), and the entire point of this app is measuring
+what a real Gombit user gets. `TestCreateInvalidOwnerIDReturnsValidationError`
+(renamed from `...ReturnsInternalError`) used to pin the gap so a framework
+fix would show up here as an expected test change rather than a mysterious
+fairness-check failure; see docs/plans/BENCH-1-benchmark-suite.md Phase 3b
+for that original writeup. `database.MapPersistError` was fixed in issue
+#202 (foreign-key and NOT NULL violations now map to a D10 validation
+error), so this app now gets the same 422 as `gin-gorm` through Gombit's
+normal public APIs, unmodified — no special-casing needed.
 
 ## Status
 

--- a/benchmarks/apps/gombit/internal/project/handler_test.go
+++ b/benchmarks/apps/gombit/internal/project/handler_test.go
@@ -212,40 +212,50 @@ func TestUpdateRejectsBlankName(t *testing.T) {
 	}
 }
 
-// TestCreateInvalidOwnerIDReturnsInternalError documents, rather than hides,
-// a real Gombit framework gap discovered while building this app:
-// database.MapPersistError (github.com/gombit-dev/gombit/database) only
-// special-cases unique-constraint violations, so a foreign-key violation —
-// exactly what a nonexistent owner_id produces — falls through to internal
-// (500). benchmarks/apps/gin-gorm's control implementation does not use
-// that framework helper and maps the same input to 422 (see its
-// TestCreateRejectsInvalidOwnerID); this app uses Gombit's normal public
-// APIs unmodified (issue #141: "do not bypass ... normal Gombit response
-// handling"), so it inherits the gap. This test pins the framework's actual
-// current behavior so a silent fix (or regression) shows up here, not just
-// as an unexplained fairness-check failure when Phase 3b's
-// cross-implementation checks run. See
-// docs/plans/BENCH-1-benchmark-suite.md Phase 3b for the discovered-gap
-// writeup and why it's out of scope to fix as part of BENCH-1.
-func TestCreateInvalidOwnerIDReturnsInternalError(t *testing.T) {
+// TestCreateInvalidOwnerIDReturnsValidationError used to pin a real Gombit
+// framework gap discovered while building this app: database.MapPersistError
+// (github.com/gombit-dev/gombit/database) only special-cased
+// unique-constraint violations, so a foreign-key violation — exactly what a
+// nonexistent owner_id produces — fell through to internal (500), while
+// benchmarks/apps/gin-gorm's control implementation (which doesn't use that
+// framework helper) already mapped the same input to 422. That gap is fixed
+// (github.com/gombit-dev/gombit issue #202: MapPersistError now maps
+// foreign-key and NOT NULL violations to a D10 validation error), so this
+// app now gets the same 422 through Gombit's normal public APIs, unmodified
+// — no special-casing needed here. This test now asserts parity with
+// gin-gorm's TestCreateRejectsInvalidOwnerID instead of pinning the gap. See
+// docs/plans/BENCH-1-benchmark-suite.md Phase 3b for the original
+// discovered-gap writeup.
+func TestCreateInvalidOwnerIDReturnsValidationError(t *testing.T) {
 	app := newProjectApp(t)
 
 	response := doJSON(t, app, http.MethodPost, "/api/projects", `{"owner_id":999999,"name":"Orphan","description":"no such owner"}`)
-	if response.Code != http.StatusInternalServerError {
-		t.Fatalf("POST with nonexistent owner_id status = %d, want %d (see test doc comment); body: %s",
-			response.Code, http.StatusInternalServerError, response.Body.String())
+	if response.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("POST with nonexistent owner_id status = %d, want %d; body: %s",
+			response.Code, http.StatusUnprocessableEntity, response.Body.String())
+	}
+	var envelope struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode error envelope: %v; body: %s", err, response.Body.String())
+	}
+	if envelope.Error.Code != "validation_error" {
+		t.Fatalf("error code = %q, want %q", envelope.Error.Code, "validation_error")
 	}
 }
 
 // TestCreateRejectsZeroOwnerID checks a different input than
-// TestCreateInvalidOwnerIDReturnsInternalError above: owner_id:0 is not "a
+// TestCreateInvalidOwnerIDReturnsValidationError above: owner_id:0 is not "a
 // nonexistent but well-formed id" (999999), it's the zero value — the same
 // thing gin-gorm's binding:"required" on OwnerID rejects at the validation
 // layer before it ever reaches GORM. Without minimum:"1" on
 // createProjectBody.OwnerID, this case fell through to the same
-// FK-violation 500 as the nonexistent-id case, conflating a validation gap
-// this app can close with the discovered framework gap it deliberately
-// doesn't.
+// FK-violation error as the nonexistent-id case — both are now 422 (see
+// issue #202), but they were a real, independently-fixable validation gap
+// on this app's side, distinct from the framework-level classification gap.
 func TestCreateRejectsZeroOwnerID(t *testing.T) {
 	app := newProjectApp(t)
 

--- a/database/database.go
+++ b/database/database.go
@@ -56,7 +56,12 @@ func Open(cfg config.DatabaseConfig) (*DB, error) {
 		return nil, err
 	}
 
-	gormDB, err := gorm.Open(dialector, &gorm.Config{})
+	// TranslateError lets each dialector map its own structured error codes
+	// (Postgres SQLSTATE, MySQL error numbers, SQLite extended result codes)
+	// to portable gorm.ErrXxx sentinels, so database/errors.go can classify
+	// unique/foreign-key violations by errors.Is instead of driver-specific
+	// message text.
+	gormDB, err := gorm.Open(dialector, &gorm.Config{TranslateError: true})
 	if err != nil {
 		return nil, fmt.Errorf("database: open %s: %w", driver, err)
 	}

--- a/database/errors.go
+++ b/database/errors.go
@@ -9,10 +9,11 @@ import (
 	"gorm.io/gorm"
 )
 
-// IsUniqueViolation reports duplicate-key errors. Open does not set
-// gorm.Config.TranslateError, so ErrDuplicatedKey is usually unset and
-// the driver error string is the portable signal across SQLite, Postgres,
-// and MySQL.
+// IsUniqueViolation reports duplicate-key errors. Open enables
+// gorm.Config.TranslateError, so ErrDuplicatedKey is the primary signal on
+// SQLite, Postgres, and MySQL (all three dialectors translate their unique-
+// violation error code to it). The driver error string stays as a fallback
+// for any dialect that does not implement translation.
 func IsUniqueViolation(err error) bool {
 	if err == nil {
 		return false
@@ -22,6 +23,37 @@ func IsUniqueViolation(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "unique") || strings.Contains(msg, "duplicate")
+}
+
+// IsForeignKeyViolation reports foreign-key constraint violations, such as a
+// belongs_to reference to a row that does not exist. Same primary/fallback
+// shape as IsUniqueViolation: all three supported dialectors translate their
+// foreign-key error code to gorm.ErrForeignKeyViolated, with the driver
+// error string as a fallback.
+func IsForeignKeyViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrForeignKeyViolated) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "foreign key")
+}
+
+// IsNotNullViolation reports NOT NULL constraint violations. Unlike unique
+// and foreign-key violations, none of the SQLite/Postgres/MySQL GORM
+// dialectors translate this case to a gorm sentinel error (it is a gap in
+// gorm itself, not something Open configures around), so detection is
+// driver-message-only. The three drivers phrase it differently: SQLite
+// ("NOT NULL constraint failed"), Postgres ("violates not-null
+// constraint"), MySQL ("cannot be null").
+func IsNotNullViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not null") || strings.Contains(msg, "not-null") || strings.Contains(msg, "cannot be null")
 }
 
 // MapLoadError maps a GORM read/load error to a D10 category error:
@@ -38,12 +70,38 @@ func MapLoadError(ctx context.Context, err error, notFound, internal string) err
 }
 
 // MapPersistError maps a GORM write error to a D10 category error:
-// unique/duplicate becomes conflict; any other failure becomes internal.
+// unique/duplicate becomes conflict; a foreign-key or NOT NULL violation
+// becomes validation, since both mean the client submitted a value that
+// references or omits something invalid, not that the server failed; any
+// other failure becomes internal.
 func MapPersistError(ctx context.Context, err error, conflict, internal string) error {
 	if err == nil {
 		return nil
 	}
 	if IsUniqueViolation(err) {
+		return contract.WithContext(ctx, contract.Conflict(conflict))
+	}
+	if IsForeignKeyViolation(err) {
+		return contract.WithContext(ctx, contract.Validation("The request references a resource that does not exist.", nil))
+	}
+	if IsNotNullViolation(err) {
+		return contract.WithContext(ctx, contract.Validation("The request is missing a required value.", nil))
+	}
+	return contract.WithContext(ctx, contract.Internal(internal))
+}
+
+// MapDeleteError maps a GORM delete error to a D10 category error. A
+// foreign-key violation here means another row still references the one
+// being deleted, which is a state conflict caused by other data, not an
+// invalid value in the request (a delete has no body to validate) — the
+// opposite meaning a foreign-key violation has on create/update, so this is
+// deliberately not MapPersistError. Unique and NOT NULL violations cannot
+// occur on delete, so there is no equivalent branch for them here.
+func MapDeleteError(ctx context.Context, err error, conflict, internal string) error {
+	if err == nil {
+		return nil
+	}
+	if IsForeignKeyViolation(err) {
 		return contract.WithContext(ctx, contract.Conflict(conflict))
 	}
 	return contract.WithContext(ctx, contract.Internal(internal))

--- a/database/errors_test.go
+++ b/database/errors_test.go
@@ -35,6 +35,53 @@ func TestIsUniqueViolation(t *testing.T) {
 	}
 }
 
+func TestIsForeignKeyViolation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "ErrForeignKeyViolated", err: gorm.ErrForeignKeyViolated, want: true},
+		{name: "wrapped ErrForeignKeyViolated", err: errors.Join(errors.New("wrap"), gorm.ErrForeignKeyViolated), want: true},
+		{name: "sqlite foreign key", err: errors.New("FOREIGN KEY constraint failed"), want: true},
+		{name: "postgres foreign key", err: errors.New("ERROR: insert or update on table \"widgets\" violates foreign key constraint \"fk_widgets_category\" (SQLSTATE 23503)"), want: true},
+		{name: "mysql foreign key", err: errors.New("Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails"), want: true},
+		{name: "unique, not foreign key", err: errors.New("UNIQUE constraint failed: widgets.sku"), want: false},
+		{name: "generic", err: errors.New("connection refused"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsForeignKeyViolation(tt.err); got != tt.want {
+				t.Fatalf("IsForeignKeyViolation(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsNotNullViolation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "sqlite not null", err: errors.New("NOT NULL constraint failed: widgets.name"), want: true},
+		{name: "postgres not null", err: errors.New("ERROR: null value in column \"name\" of relation \"widgets\" violates not-null constraint (SQLSTATE 23502)"), want: true},
+		{name: "mysql not null", err: errors.New("Error 1048 (23000): Column 'name' cannot be null"), want: true},
+		{name: "unique, not null-related", err: errors.New("UNIQUE constraint failed: widgets.sku"), want: false},
+		{name: "foreign key, not null-related", err: errors.New("FOREIGN KEY constraint failed"), want: false},
+		{name: "generic", err: errors.New("connection refused"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotNullViolation(tt.err); got != tt.want {
+				t.Fatalf("IsNotNullViolation(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMapLoadError(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
@@ -68,6 +115,9 @@ func TestMapPersistError(t *testing.T) {
 		{name: "nil", err: nil, wantStatus: 0, wantCode: ""},
 		{name: "sqlite unique", err: errors.New("UNIQUE constraint failed: widgets.sku"), wantStatus: http.StatusConflict, wantCode: "conflict"},
 		{name: "ErrDuplicatedKey", err: gorm.ErrDuplicatedKey, wantStatus: http.StatusConflict, wantCode: "conflict"},
+		{name: "sqlite foreign key", err: errors.New("FOREIGN KEY constraint failed"), wantStatus: http.StatusUnprocessableEntity, wantCode: contract.CodeValidationError},
+		{name: "ErrForeignKeyViolated", err: gorm.ErrForeignKeyViolated, wantStatus: http.StatusUnprocessableEntity, wantCode: contract.CodeValidationError},
+		{name: "sqlite not null", err: errors.New("NOT NULL constraint failed: widgets.name"), wantStatus: http.StatusUnprocessableEntity, wantCode: contract.CodeValidationError},
 		{name: "no such table", err: errors.New("no such table: widgets"), wantStatus: http.StatusInternalServerError, wantCode: "internal"},
 		{name: "not found", err: gorm.ErrRecordNotFound, wantStatus: http.StatusInternalServerError, wantCode: "internal"},
 	}
@@ -100,6 +150,104 @@ func TestMapPersistErrorSQLiteUniqueConstraint(t *testing.T) {
 	}
 	mapped := MapPersistError(context.Background(), err, "resource already exists", "persist widget")
 	assertMapped(t, mapped, err, http.StatusConflict, "conflict")
+}
+
+func TestMapDeleteError(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "nil", err: nil, wantStatus: 0, wantCode: ""},
+		{name: "sqlite foreign key", err: errors.New("FOREIGN KEY constraint failed"), wantStatus: http.StatusConflict, wantCode: "conflict"},
+		{name: "ErrForeignKeyViolated", err: gorm.ErrForeignKeyViolated, wantStatus: http.StatusConflict, wantCode: "conflict"},
+		{name: "unique is not a delete conflict here", err: errors.New("UNIQUE constraint failed: widgets.sku"), wantStatus: http.StatusInternalServerError, wantCode: "internal"},
+		{name: "generic", err: errors.New("connection refused"), wantStatus: http.StatusInternalServerError, wantCode: "internal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MapDeleteError(ctx, tt.err, "resource is still referenced by other records", "delete widget")
+			assertMapped(t, got, tt.err, tt.wantStatus, tt.wantCode)
+		})
+	}
+}
+
+func TestMapDeleteErrorSQLiteForeignKeyConstraint(t *testing.T) {
+	db := openSQLite(t)
+	type deleteFKParent struct {
+		ID uint `gorm:"primaryKey"`
+	}
+	type deleteFKChild struct {
+		ID       uint `gorm:"primaryKey"`
+		ParentID uint
+		Parent   deleteFKParent `gorm:"constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
+	}
+	if err := db.AutoMigrate(&deleteFKParent{}, &deleteFKChild{}); err != nil {
+		t.Fatalf("AutoMigrate() error = %v", err)
+	}
+	parent := deleteFKParent{}
+	if err := db.Create(&parent).Error; err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	if err := db.Create(&deleteFKChild{ParentID: parent.ID}).Error; err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	err := db.Delete(&parent).Error
+	if err == nil {
+		t.Fatal("Delete() error = nil, want foreign key violation (parent still referenced)")
+	}
+	if !IsForeignKeyViolation(err) {
+		t.Fatalf("IsForeignKeyViolation(%v) = false, want true", err)
+	}
+	mapped := MapDeleteError(context.Background(), err, "resource is still referenced by other records", "delete widget")
+	assertMapped(t, mapped, err, http.StatusConflict, "conflict")
+}
+
+func TestMapPersistErrorSQLiteForeignKeyConstraint(t *testing.T) {
+	db := openSQLite(t)
+	type fkCategory struct {
+		ID uint `gorm:"primaryKey"`
+	}
+	type fkWidget struct {
+		ID         uint `gorm:"primaryKey"`
+		CategoryID uint
+		Category   fkCategory `gorm:"constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
+	}
+	if err := db.AutoMigrate(&fkCategory{}, &fkWidget{}); err != nil {
+		t.Fatalf("AutoMigrate() error = %v", err)
+	}
+	err := db.Create(&fkWidget{CategoryID: 999}).Error
+	if err == nil {
+		t.Fatal("Create() error = nil, want foreign key violation")
+	}
+	if !IsForeignKeyViolation(err) {
+		t.Fatalf("IsForeignKeyViolation(%v) = false, want true", err)
+	}
+	mapped := MapPersistError(context.Background(), err, "resource already exists", "persist widget")
+	assertMapped(t, mapped, err, http.StatusUnprocessableEntity, contract.CodeValidationError)
+}
+
+func TestMapPersistErrorSQLiteNotNullConstraint(t *testing.T) {
+	db := openSQLite(t)
+	type notNullWidget struct {
+		ID   uint    `gorm:"primaryKey"`
+		Name *string `gorm:"not null"`
+	}
+	if err := db.AutoMigrate(&notNullWidget{}); err != nil {
+		t.Fatalf("AutoMigrate() error = %v", err)
+	}
+	err := db.Create(&notNullWidget{Name: nil}).Error
+	if err == nil {
+		t.Fatal("Create() error = nil, want NOT NULL violation")
+	}
+	if !IsNotNullViolation(err) {
+		t.Fatalf("IsNotNullViolation(%v) = false, want true", err)
+	}
+	mapped := MapPersistError(context.Background(), err, "resource already exists", "persist widget")
+	assertMapped(t, mapped, err, http.StatusUnprocessableEntity, contract.CodeValidationError)
 }
 
 func assertMapped(t *testing.T, got error, original error, wantStatus int, wantCode string) {

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -3,10 +3,13 @@
 package database
 
 import (
+	"context"
 	"flag"
+	"net/http"
 	"testing"
 
 	"github.com/gombit-dev/gombit/config"
+	"github.com/gombit-dev/gombit/contract"
 )
 
 var (
@@ -34,6 +37,112 @@ func TestOpenMySQLRoundTrip(t *testing.T) {
 		Driver: config.DatabaseDriverMySQL,
 		DSN:    *mysqlDSN,
 	}, DriverMySQL)
+}
+
+func TestMapPersistErrorPostgresConstraintViolations(t *testing.T) {
+	if *postgresDSN == "" {
+		t.Skip("set -database.postgres-dsn to run Postgres integration tests")
+	}
+	db := openIntegrationDB(t, config.DatabaseConfig{
+		Driver: config.DatabaseDriverPostgres,
+		DSN:    *postgresDSN,
+	})
+	testForeignKeyAndNotNullViolations(t, db)
+}
+
+func TestMapPersistErrorMySQLConstraintViolations(t *testing.T) {
+	if *mysqlDSN == "" {
+		t.Skip("set -database.mysql-dsn to run MySQL integration tests")
+	}
+	db := openIntegrationDB(t, config.DatabaseConfig{
+		Driver: config.DatabaseDriverMySQL,
+		DSN:    *mysqlDSN,
+	})
+	testForeignKeyAndNotNullViolations(t, db)
+}
+
+type integrationFKCategory struct {
+	ID uint `gorm:"primaryKey"`
+}
+
+type integrationFKWidget struct {
+	ID         uint `gorm:"primaryKey"`
+	CategoryID uint
+	Category   integrationFKCategory `gorm:"constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
+}
+
+type integrationNotNullWidget struct {
+	ID   uint    `gorm:"primaryKey"`
+	Name *string `gorm:"not null"`
+}
+
+func openIntegrationDB(t *testing.T, cfg config.DatabaseConfig) *DB {
+	t.Helper()
+	db, err := Open(cfg)
+	if err != nil {
+		t.Fatalf("Open() error = %v, want nil", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Migrator().DropTable(&integrationFKWidget{}, &integrationFKCategory{}, &integrationNotNullWidget{})
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v, want nil", err)
+		}
+	})
+	return db
+}
+
+// testForeignKeyAndNotNullViolations proves, against a real driver, that a
+// foreign-key violation and a NOT NULL violation are both classified as a
+// D10 validation error rather than internal. The driver error text differs
+// across SQLite/Postgres/MySQL (see IsForeignKeyViolation/IsNotNullViolation
+// doc comments), so this must run against the real database, not a
+// fabricated error string.
+func testForeignKeyAndNotNullViolations(t *testing.T, db *DB) {
+	t.Helper()
+	if err := db.AutoMigrate(&integrationFKCategory{}, &integrationFKWidget{}, &integrationNotNullWidget{}); err != nil {
+		t.Fatalf("AutoMigrate() error = %v", err)
+	}
+
+	fkErr := db.Create(&integrationFKWidget{CategoryID: 999}).Error
+	if fkErr == nil {
+		t.Fatal("Create() with a nonexistent foreign key error = nil, want a foreign key violation")
+	}
+	if !IsForeignKeyViolation(fkErr) {
+		t.Fatalf("IsForeignKeyViolation(%v) = false, want true", fkErr)
+	}
+	mapped := MapPersistError(context.Background(), fkErr, "resource already exists", "persist widget")
+	assertMapped(t, mapped, fkErr, http.StatusUnprocessableEntity, contract.CodeValidationError)
+
+	nnErr := db.Create(&integrationNotNullWidget{Name: nil}).Error
+	if nnErr == nil {
+		t.Fatal("Create() with a nil required field error = nil, want a NOT NULL violation")
+	}
+	if !IsNotNullViolation(nnErr) {
+		t.Fatalf("IsNotNullViolation(%v) = false, want true", nnErr)
+	}
+	mapped = MapPersistError(context.Background(), nnErr, "resource already exists", "persist widget")
+	assertMapped(t, mapped, nnErr, http.StatusUnprocessableEntity, contract.CodeValidationError)
+
+	// A foreign-key violation on delete means something else still
+	// references the row being deleted — a state conflict, not the
+	// "referenced something invalid" meaning it has on create/update, so
+	// this must use MapDeleteError and land as a conflict, not validation.
+	category := integrationFKCategory{}
+	if err := db.Create(&category).Error; err != nil {
+		t.Fatalf("create category fixture: %v", err)
+	}
+	if err := db.Create(&integrationFKWidget{CategoryID: category.ID}).Error; err != nil {
+		t.Fatalf("create widget fixture: %v", err)
+	}
+	delErr := db.Delete(&category).Error
+	if delErr == nil {
+		t.Fatal("Delete() of a still-referenced category error = nil, want a foreign key violation")
+	}
+	if !IsForeignKeyViolation(delErr) {
+		t.Fatalf("IsForeignKeyViolation(%v) = false, want true", delErr)
+	}
+	mapped = MapDeleteError(context.Background(), delErr, "resource is still referenced by other records", "delete widget")
+	assertMapped(t, mapped, delErr, http.StatusConflict, "conflict")
 }
 
 func testOpenRoundTrip(t *testing.T, cfg config.DatabaseConfig, wantDriver Driver) {

--- a/docs/plans/BENCH-1-benchmark-suite.md
+++ b/docs/plans/BENCH-1-benchmark-suite.md
@@ -533,18 +533,19 @@ same misread again.
     the framework default, this app's route surface would not have
     matched its own control's. Fixed by setting `cfg.API.Prefix = "/api"`
     explicitly in `main.go`.
-- **One discovered, deliberately unpatched framework gap:**
-  `database.MapPersistError` only special-cases unique-constraint
-  violations, so `POST /api/projects` with a nonexistent `owner_id` (a
-  foreign-key violation) falls through to 500 `internal`, unlike
-  `gin-gorm`'s 422. Not fixed here — issue #141 requires using Gombit's
-  normal public APIs as-is, and this app's whole point is measuring what a
-  real Gombit user gets today, warts included. Pinned by
-  `TestCreateInvalidOwnerIDReturnsInternalError` so a future framework fix
-  (or regression) shows up as an expected test change; see
-  `benchmarks/apps/gombit/README.md` for the full writeup. Fixing
-  `database.MapPersistError` is out of scope for BENCH-1 — worth its own
-  follow-up issue against the `database` package.
+- **One discovered framework gap, deliberately unpatched here at the time —
+  since fixed as issue #202:** `database.MapPersistError` only
+  special-cased unique-constraint violations, so `POST /api/projects` with a
+  nonexistent `owner_id` (a foreign-key violation) fell through to 500
+  `internal`, unlike `gin-gorm`'s 422. Not fixed as part of BENCH-1 — issue
+  #141 requires using Gombit's normal public APIs as-is, and this app's
+  whole point is measuring what a real Gombit user gets, warts included.
+  Pinned by `TestCreateInvalidOwnerIDReturnsInternalError` (later renamed
+  `...ReturnsValidationError`) so a future framework fix would show up as an
+  expected test change; see `benchmarks/apps/gombit/README.md` for the full
+  writeup. `database.MapPersistError` was fixed by issue #202 (foreign-key
+  and NOT NULL violations now map to a D10 validation error), closing this
+  gap and the test rename/update that went with it.
 - `internal/project`'s own integration suite (`TestCRUDRoundTrip`,
   blank-name rejection on create and update, pagination/ordering, the
   3-query/2-query N+1 guard via mutating `app.DB().Logger` — `gorm.DB`
@@ -608,15 +609,17 @@ one claim checked and found incorrect, three real gaps fixed:
   the relative comparison runs.
 - `createProjectBody.OwnerID` had no lower bound, so `{"owner_id":0,...}`
   — a present, well-typed field, not the "nonexistent id" case
-  `TestCreateInvalidOwnerIDReturnsInternalError` documents — passed Huma
-  validation and hit the same FK-violation 500. gin-gorm's
-  `binding:"required"` already rejects this input (Gin's `required`
-  treats a non-pointer `uint` zero value as absent), so this was a real,
-  fixable asymmetry, not another instance of the discovered
+  `TestCreateInvalidOwnerIDReturnsInternalError` (later renamed
+  `...ReturnsValidationError` when issue #202 fixed the underlying gap)
+  documents — passed Huma validation and hit the same FK-violation error.
+  gin-gorm's `binding:"required"` already rejects this input (Gin's
+  `required` treats a non-pointer `uint` zero value as absent), so this was
+  a real, fixable asymmetry, not another instance of the discovered
   `database.MapPersistError` gap. Fixed with `minimum:"1"` on `OwnerID`;
   verified live that `owner_id:0` now 422s while `owner_id:999999` still
-  500s — two different inputs, two different (and now each individually
-  correct) outcomes. Added `TestCreateRejectsZeroOwnerID`.
+  500s at the time (both are 422 since issue #202) — two different inputs,
+  two different (and each individually correct) outcomes. Added
+  `TestCreateRejectsZeroOwnerID`.
 - `benchmarks/apps/gombit`'s `seedDatabaseN` was copied from `gin-gorm`
   without the idempotency test an earlier review round added specifically
   because the seed contract had no automated coverage
@@ -731,9 +734,10 @@ app service deferred, same as Phase 3a/3b's own still-open items).**
   from the start (`min_value=1` in the serializer; the FK violation mapped
   by SQLSTATE via `_map_integrity_error`, the same policy as `gin-gorm`'s
   `mapPersistError`) — this is a from-scratch app, not a framework
-  exercising Gombit's own real (and deliberately unpatched, see Phase 3b)
-  gap, so there's no reason to reproduce a bug that only exists because of
-  how Gombit's `database.MapPersistError` works today.
+  exercising Gombit's own real (and, at the time, deliberately unpatched —
+  see Phase 3b — since fixed by issue #202) gap, so there was no reason to
+  reproduce a bug that only existed because of how Gombit's
+  `database.MapPersistError` worked at the time.
 - The list endpoint's N+1 guard is **2 queries** (`COUNT` + one
   `select_related("owner")` JOIN), not `gin-gorm`/`gombit`'s pinned 3 —
   `benchmarks/docs/schema.md` explicitly allows a different fixed-count


### PR DESCRIPTION
## Summary

- `database.MapPersistError` only classified unique-key violations; a
  foreign-key violation (bad `belongs_to` reference) or a NOT NULL
  violation fell through to a generic internal/500 error.
- Enabled `gorm.Config.TranslateError` so unique/foreign-key detection is
  sentinel-based (portable across SQLite/Postgres/MySQL error codes)
  instead of driver-message-only. NOT NULL has no `gorm` sentinel on any
  of the three dialectors, so it stays message-based by necessity.
- Added `IsForeignKeyViolation` / `IsNotNullViolation`, mirroring
  `IsUniqueViolation`'s shape. `MapPersistError` now maps both to a D10
  validation error on create/update.
- Added `MapDeleteError`, used only by the admin delete path: a
  foreign-key violation there means another row still references the one
  being deleted — the opposite meaning from create/update — so it maps to
  conflict, not validation. Found and fixed during this PR's own
  `code-review` pass (first pass was REQUEST CHANGES over exactly this).

Closes #202

## Acceptance criteria

(the issue is a bug report without a formal AC checklist; derived from its
"Fix direction" section, plus one criterion this PR added during review)

- [x] A foreign-key violation on create/update reports a 4xx validation
      error, not 500.
- [x] A NOT NULL violation on create/update reports a 4xx validation
      error, not 500.
- [x] (found during review, not in the original report) A foreign-key
      violation on **delete** reports 409 conflict — not the create/update
      validation message, which would be factually wrong there, and not
      500.

## Scope notes

The delete-path distinction (`MapDeleteError`) wasn't part of the original
report (scoped to create/update), but was necessary to avoid shipping a
new, factually incorrect message on delete as a side effect of fixing
create/update. Covered by tests in this PR rather than deferred.

## Validation

- [x] `go build ./...`
- [x] `go test ./...` (SQLite)
- [x] `go test -tags integration ./database -database.postgres-dsn ...`
      (real Postgres: FK-on-create, NOT NULL-on-create, FK-on-delete)
- [x] `go test -tags integration ./database -database.mysql-dsn ...`
      (real MySQL: same three scenarios)
- [x] `go test -tags integration ./auth -auth.postgres-dsn ...` (confirms
      `TranslateError` doesn't regress the duplicate-email registration path)
- [x] `go test -tags integration ./admin -admin.postgres-dsn ... -run TestResourcePostgres`
      (admin CRUD smoke test still green)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (0 issues)
- [x] Project `code-review` skill run twice: first pass REQUEST CHANGES
      (delete-path message defect), second pass APPROVE after the fix

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite +
      PostgreSQL + MySQL matrix — verified against real containers, not
      fabricated error strings, since the driver message text differs per
      database (confirmed empirically rather than assumed).
- [ ] Docs + example — N/A, bugfix to existing validated behavior, not a
      new stable feature.
- [ ] Extraction preserves contracts — N/A, not an extraction.
- [ ] Generators — N/A, no generator touched; `MapPersistError`'s call-site
      signature is unchanged, so no generated app or golden template needs
      regeneration.
- [ ] API changes regenerate OpenAPI + TS client — N/A, the D10 error
      envelope shape is unchanged; only which category a given driver
      error maps to is corrected.
- [ ] No secrets in generated frontend — N/A, no frontend touched.
- [x] Scope stays inside this issue's milestone — contained to
      database/admin error classification, no M6 battery creep.
- [x] This PR links its issue and states which acceptance criteria it
      satisfies.