### PR TITLE
feat: CSRF exemption for non-browser endpoints (WithCSRFExemptPaths)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ version.
 
 ### Added
 
+- `framework.WithCSRFExemptPaths` — opt specific request paths out of
+  cookie-mode CSRF enforcement, for non-browser endpoints (webhooks,
+  server-to-server callbacks) that cannot echo a double-submit token and
+  authenticate themselves instead (e.g. HMAC signature verification). Safe
+  methods still bootstrap the cookie; exempt handlers must verify the caller.
+  See [`docs/auth-cookie.md`](docs/auth-cookie.md)
+  ([#226](https://github.com/gombit-dev/gombit/issues/226)).
 - `gombit version` (and `--version`), reporting version, commit, build date, Go
   toolchain, and platform. Release binaries are stamped via ldflags; `go install`
   builds fall back to module build info.

--- a/auth/cookie_handlers_test.go
+++ b/auth/cookie_handlers_test.go
@@ -321,6 +321,47 @@ func TestCSRFRejectsStateChangingRequests(t *testing.T) {
 	})
 }
 
+// TestCSRFExemptPathThroughNew exercises WithCSRFExemptPaths end-to-end through
+// framework.New (not CSRFMiddleware directly), so dropping app.csrfExemptPaths
+// at the newRouter -> runtimeMiddlewareStack seam would fail this test.
+func TestCSRFExemptPathThroughNew(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := openSQLite(t)
+	if err := auth.Migrate(db.DB); err != nil {
+		t.Fatalf("auth.Migrate() error = %v", err)
+	}
+	cfg := config.DefaultFor(config.EnvironmentTest)
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.Auth.JWTSecret = testJWTSecret
+	cfg.Auth.Mode = config.AuthModeCookie
+
+	app, err := framework.New(
+		framework.WithConfig(cfg),
+		framework.WithDatabase(db),
+		framework.WithLogger(zap.NewNop()),
+		framework.WithCSRFExemptPaths("/api/v1/webhooks/github"),
+	)
+	if err != nil {
+		t.Fatalf("framework.New() error = %v", err)
+	}
+	// An exempt webhook and a non-exempt neighbor, both registered on the raw
+	// engine (as an app would via app.Router()).
+	ok := func(c *gin.Context) { c.Status(http.StatusOK) }
+	app.Router().POST("/api/v1/webhooks/github", ok)
+	app.Router().POST("/api/v1/webhooks/other", ok)
+
+	t.Run("exempt path skips CSRF", func(t *testing.T) {
+		rec := doRequest(app, nil, http.MethodPost, "/api/v1/webhooks/github", "{}")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("exempt POST status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+		}
+	})
+	t.Run("non-exempt neighbor still enforced", func(t *testing.T) {
+		rec := doRequest(app, nil, http.MethodPost, "/api/v1/webhooks/other", "{}")
+		assertCSRFRejected(t, rec)
+	})
+}
+
 func TestCSRFSafeMethodsAreExempt(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	app := newCookieAuthApp(t)

--- a/auth/csrf.go
+++ b/auth/csrf.go
@@ -31,12 +31,29 @@ const csrfTokenBytes = 32
 //
 // framework.New wires this into the runtime middleware stack automatically
 // when cfg.Auth.Enabled() and cfg.Auth.EffectiveMode() == AuthModeCookie.
-func CSRFMiddleware(cfg config.Config) gin.HandlerFunc {
+//
+// exemptPaths are exact request paths that opt out of CSRF enforcement on
+// unsafe methods — for non-browser endpoints (webhooks, server-to-server
+// callbacks) that cannot participate in the double-submit defense and must
+// authenticate themselves by other means (e.g. HMAC signature verification).
+// Safe methods still bootstrap the cookie on those paths. See
+// framework.WithCSRFExemptPaths and docs/auth-cookie.md.
+func CSRFMiddleware(cfg config.Config, exemptPaths ...string) gin.HandlerFunc {
 	secret := []byte(cfg.Auth.JWTSecret)
 	authCfg := cfg.Auth
+	exempt := make(map[string]struct{}, len(exemptPaths))
+	for _, path := range exemptPaths {
+		if path = strings.TrimSpace(path); path != "" {
+			exempt[path] = struct{}{}
+		}
+	}
 	return func(c *gin.Context) {
 		if isSafeCSRFMethod(c.Request.Method) {
 			ensureCSRFCookie(c, secret, authCfg)
+			c.Next()
+			return
+		}
+		if _, ok := exempt[c.Request.URL.Path]; ok {
 			c.Next()
 			return
 		}

--- a/auth/csrf_test.go
+++ b/auth/csrf_test.go
@@ -1,0 +1,86 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gombit-dev/gombit/auth"
+	"github.com/gombit-dev/gombit/config"
+	"github.com/gin-gonic/gin"
+)
+
+// csrfTestEngine builds a gin engine guarded by CSRFMiddleware with the given
+// exempt paths and two POST routes plus a GET route to exercise bootstrap.
+func csrfTestEngine(exempt ...string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	cfg := config.DefaultFor(config.EnvironmentTest)
+	cfg.Auth.JWTSecret = testJWTSecret
+
+	engine := gin.New()
+	engine.Use(auth.CSRFMiddleware(cfg, exempt...))
+	ok := func(c *gin.Context) { c.Status(http.StatusOK) }
+	engine.POST("/api/v1/webhooks/github", ok)
+	engine.POST("/api/v1/products", ok)
+	engine.GET("/api/v1/products", ok)
+	return engine
+}
+
+func TestCSRFMiddlewareExemptPathSkipsEnforcement(t *testing.T) {
+	engine := csrfTestEngine("/api/v1/webhooks/github")
+
+	// An exempt POST with no CSRF cookie/header is allowed through so the route
+	// handler (which does its own auth) can run.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/github", strings.NewReader("{}"))
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("exempt POST status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestCSRFMiddlewareNonExemptPathStillEnforced(t *testing.T) {
+	engine := csrfTestEngine("/api/v1/webhooks/github")
+
+	// A non-exempt POST with no CSRF token is still rejected.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/products", strings.NewReader("{}"))
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-exempt POST status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestCSRFMiddlewareNoExemptionsRejectsAll(t *testing.T) {
+	engine := csrfTestEngine() // no exemptions
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/github", strings.NewReader("{}"))
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("unexempted webhook POST status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestCSRFMiddlewareSafeMethodBootstrapsCookie(t *testing.T) {
+	engine := csrfTestEngine("/api/v1/webhooks/github")
+
+	// GET is a safe method: it passes and mints the double-submit cookie, even
+	// on an exempt path.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/products", nil)
+	engine.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	var found bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == auth.CSRFCookieName && c.Value != "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("GET did not set %s cookie", auth.CSRFCookieName)
+	}
+}

--- a/auth/csrf_test.go
+++ b/auth/csrf_test.go
@@ -66,8 +66,7 @@ func TestCSRFMiddlewareNoExemptionsRejectsAll(t *testing.T) {
 func TestCSRFMiddlewareSafeMethodBootstrapsCookie(t *testing.T) {
 	engine := csrfTestEngine("/api/v1/webhooks/github")
 
-	// GET is a safe method: it passes and mints the double-submit cookie, even
-	// on an exempt path.
+	// GET is a safe method: it passes and mints the double-submit cookie.
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/products", nil)
 	engine.ServeHTTP(rec, req)

--- a/docs/auth-cookie.md
+++ b/docs/auth-cookie.md
@@ -84,6 +84,31 @@ token is mirrored in both the `Set-Cookie` header and the JSON body
 (`{"data": {"csrf_token": "..."}}`) so the SPA does not need to parse
 `document.cookie` itself.
 
+### Exempting non-browser endpoints (webhooks)
+
+A **webhook** or other server-to-server `POST` cannot participate in the
+double-submit defense — the caller has no `gombit_csrf` cookie to echo — so in
+cookie mode it would always 403. Opt those exact paths out with
+`framework.WithCSRFExemptPaths`:
+
+```go
+app, err := framework.New(
+    framework.WithConfig(cfg),
+    framework.WithDatabase(db),
+    framework.WithCSRFExemptPaths("/api/v1/webhooks/github"),
+)
+```
+
+Paths match the request path **exactly**, including the API prefix. On an
+exempt path the middleware skips enforcement for unsafe methods (safe methods
+still mint the cookie). CSRF is a defense against *ambient-credential* forgery
+by a browser; an exempt endpoint carries no session cookie, so dropping CSRF
+there loses nothing — **but it now has no authentication of its own**, so the
+handler **must** authenticate the caller another way, e.g. verifying an
+HMAC signature over the raw body (`X-Hub-Signature-256` for GitHub). Keep the
+exempt list to the specific webhook paths; never exempt a route that relies on
+the session cookie.
+
 ## Endpoints
 
 Same paths and D10 envelopes as Bearer mode, but the request/response shape

--- a/docs/auth-cookie.md
+++ b/docs/auth-cookie.md
@@ -28,7 +28,7 @@ instead of asking every mutating handler to re-implement it.
 | Threat | Mitigation |
 | --- | --- |
 | XSS reads the session token | Access/refresh cookies are `HttpOnly`; page JavaScript cannot read them via `document.cookie`. |
-| Cross-site request forges a mutating request | Every `POST`/`PUT`/`PATCH`/`DELETE` must echo the `gombit_csrf` cookie value as the `X-CSRF-Token` header (double-submit). A cross-origin page can trigger a cookie-bearing request but cannot read the CSRF cookie's value (browsers do not expose `Set-Cookie`/`document.cookie` across origins) or set a custom header on a simple cross-origin form submission, so it cannot produce a matching header. |
+| Cross-site request forges a mutating request | Every `POST`/`PUT`/`PATCH`/`DELETE` must echo the `gombit_csrf` cookie value as the `X-CSRF-Token` header (double-submit), **except** paths opted out via `framework.WithCSRFExemptPaths` (see [Exempting non-browser endpoints](#exempting-non-browser-endpoints-webhooks)), which must authenticate the caller themselves and must not trust the session cookie. A cross-origin page can trigger a cookie-bearing request but cannot read the CSRF cookie's value (browsers do not expose `Set-Cookie`/`document.cookie` across origins) or set a custom header on a simple cross-origin form submission, so it cannot produce a matching header. |
 | Cookie value is guessed or brute-forced | The CSRF token is 32 random bytes (`crypto/rand`) plus an HMAC-SHA256 signature over the token using `Config.Auth.JWTSecret`. `validCSRFTokenValue` checks the signature, not just cookie/header equality, so an attacker who can set *some* cookie on a subdomain ("cookie tossing") still cannot forge a token that verifies without the server secret. |
 | Session cookie is stolen off the wire | `Secure` is required in production (enforced by `config.Validate` / `gombit doctor`, see [Config](#config)) so cookies are never sent over plain HTTP once deployed. |
 | Session cookie is replayed after logout | Logout revokes the refresh token server-side ([`auth.Service.RevokeRefresh`](../auth/service.go)) and clears both cookies; a captured access JWT still fails once its short TTL (`GOMBIT_JWT_ACCESS_TTL`, default `15m`) expires, same as Bearer mode. |
@@ -60,8 +60,9 @@ headers from the endpoints below.
 auth routes) whenever `Config.Auth.Enabled()` and `EffectiveMode() ==
 AuthModeCookie`, so it covers every state-changing request in the
 app — including feature routes added later via `app.Router()` — not just
-`/auth/*`. See [`framework/app.go`](../framework/app.go)'s
-`runtimeMiddlewareStack`.
+`/auth/*`, except the exact paths passed to `framework.WithCSRFExemptPaths`
+(see [below](#exempting-non-browser-endpoints-webhooks)). See
+[`framework/app.go`](../framework/app.go)'s `runtimeMiddlewareStack`.
 
 - **Safe methods** (`GET`, `HEAD`, `OPTIONS`): the middleware ensures a
   signed `gombit_csrf` cookie exists, minting one if missing. It never
@@ -100,14 +101,23 @@ app, err := framework.New(
 ```
 
 Paths match the request path **exactly**, including the API prefix. On an
-exempt path the middleware skips enforcement for unsafe methods (safe methods
-still mint the cookie). CSRF is a defense against *ambient-credential* forgery
-by a browser; an exempt endpoint carries no session cookie, so dropping CSRF
-there loses nothing — **but it now has no authentication of its own**, so the
-handler **must** authenticate the caller another way, e.g. verifying an
-HMAC signature over the raw body (`X-Hub-Signature-256` for GitHub). Keep the
-exempt list to the specific webhook paths; never exempt a route that relies on
-the session cookie.
+exempt path the middleware skips CSRF enforcement for unsafe methods (safe
+methods still mint the cookie).
+
+**Exempting a path removes a protection; it does not make the route
+credential-free.** The session cookies (`gombit_access` / `gombit_refresh`)
+are scoped `Path=/`, so a same-site request — including one a cross-site page
+triggers — still delivers them to the exempt path. CSRF is exactly what stops a
+cross-origin page from riding those *ambient* session cookies on an unsafe
+method; drop it and any handler that trusts the session is exposed to forgery
+again.
+
+So an exempt handler **must not authenticate via the session cookie**. It must
+verify the caller by other means — e.g. an HMAC signature over the raw body
+(`X-Hub-Signature-256` for GitHub) — and ignore session identity. CSRF was
+never authentication, and exemption is safe **only** for a handler that does
+not rely on ambient session auth. Keep the exempt list to the specific
+non-browser paths, and never exempt a route that authenticates users by cookie.
 
 ## Endpoints
 

--- a/framework/app.go
+++ b/framework/app.go
@@ -53,6 +53,7 @@ type App struct {
 	stopHooks        []Hook
 	shutdownTimeout  time.Duration
 	embeddedFrontend fs.FS
+	csrfExemptPaths  []string
 
 	mu     sync.RWMutex
 	server *http.Server
@@ -106,7 +107,7 @@ func New(options ...Option) (*App, error) {
 		})
 	}
 	if app.router == nil {
-		router, err := newRouter(app.cfg)
+		router, err := newRouter(app.cfg, app.csrfExemptPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -236,6 +237,20 @@ func WithShutdownTimeout(timeout time.Duration) Option {
 			return errors.New("framework: shutdown timeout must be positive")
 		}
 		app.shutdownTimeout = timeout
+		return nil
+	}
+}
+
+// WithCSRFExemptPaths marks exact request paths that opt out of cookie-mode
+// CSRF enforcement on unsafe methods. Use it for non-browser endpoints that
+// cannot participate in the double-submit defense — webhooks, server-to-server
+// callbacks — which must authenticate themselves by other means (e.g. HMAC
+// signature verification). Paths match the request path exactly, including the
+// API prefix, e.g. "/api/v1/webhooks/github". No effect in JWT mode or when a
+// custom router is supplied via WithRouter.
+func WithCSRFExemptPaths(paths ...string) Option {
+	return func(app *App) error {
+		app.csrfExemptPaths = append(app.csrfExemptPaths, paths...)
 		return nil
 	}
 }
@@ -482,14 +497,14 @@ func syncLogger(logger *zap.Logger) error {
 	return nil
 }
 
-func newRouter(cfg config.Config) (*gin.Engine, error) {
+func newRouter(cfg config.Config, csrfExemptPaths []string) (*gin.Engine, error) {
 	router := gin.New()
 	if err := configureTrustedProxies(router, cfg.HTTP.TrustedProxies); err != nil {
 		return nil, err
 	}
 
 	metrics := newHTTPMetrics()
-	router.Use(middlewareHandlers(runtimeMiddlewareStack(cfg, metrics))...)
+	router.Use(middlewareHandlers(runtimeMiddlewareStack(cfg, metrics, csrfExemptPaths))...)
 	router.GET("/livez", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"data": gin.H{
@@ -521,7 +536,7 @@ func configureTrustedProxies(engine *gin.Engine, proxies []string) error {
 	return nil
 }
 
-func runtimeMiddlewareStack(cfg config.Config, metrics *httpMetrics) []namedMiddleware {
+func runtimeMiddlewareStack(cfg config.Config, metrics *httpMetrics, csrfExemptPaths []string) []namedMiddleware {
 	stack := []namedMiddleware{
 		{name: "recovery", handler: gin.Recovery()},
 		{name: "request_context", handler: requestContextMiddleware()},
@@ -537,7 +552,7 @@ func runtimeMiddlewareStack(cfg config.Config, metrics *httpMetrics) []namedMidd
 	// application feature routes registered later via app.Router(). See
 	// docs/auth-cookie.md.
 	if cfg.Auth.Enabled() && cfg.Auth.EffectiveMode() == config.AuthModeCookie {
-		stack = append(stack, namedMiddleware{name: "csrf", handler: auth.CSRFMiddleware(cfg)})
+		stack = append(stack, namedMiddleware{name: "csrf", handler: auth.CSRFMiddleware(cfg, csrfExemptPaths...)})
 	}
 	stack = append(stack, namedMiddleware{name: "request_timeout", handler: requestTimeoutMiddleware(cfg.HTTP.RequestTimeout)})
 	return stack

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestDefaultRuntimeMiddlewareOrder(t *testing.T) {
-	stack := runtimeMiddlewareStack(config.Default(), newHTTPMetrics())
+	stack := runtimeMiddlewareStack(config.Default(), newHTTPMetrics(), nil)
 	got := make([]string, 0, len(stack))
 	for _, middleware := range stack {
 		got = append(got, middleware.name)


### PR DESCRIPTION
## Summary

Adds `framework.WithCSRFExemptPaths(paths ...string)` so non-browser endpoints — webhooks, server-to-server callbacks — can opt out of cookie-mode CSRF enforcement. Before this, `auth.CSRFMiddleware` was global with no exemption, so any such `POST` 403'd before its handler ran (and routes added via `app.Router()` inherit the middleware, so there was no app-side workaround).

Closes #226.

## Changes

- `framework.WithCSRFExemptPaths` option; threads `csrfExemptPaths` through `newRouter` → `runtimeMiddlewareStack` → `auth.CSRFMiddleware(cfg, exempt...)`.
- Middleware skips enforcement on an **exact-path** match for unsafe methods; safe methods still bootstrap the `gombit_csrf` cookie.
- Exempt handlers must authenticate the caller themselves (documented) — CSRF protects ambient-credential forgery, which a cookie-less webhook doesn't carry.

## Tests

`auth/csrf_test.go`: exempt path passes without a token, non-exempt path still 403s, no exemptions rejects all, safe method still bootstraps the cookie. Full `framework` + `auth` suites and `go test ./...` pass.

## Docs

`docs/auth-cookie.md` gains an "Exempting non-browser endpoints (webhooks)" section; `CHANGELOG.md` under `[Unreleased]`.

## Validation

```bash
go test ./framework/... ./auth/... ./...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)