### PR TITLE
feat: WithRawBodyPaths — webhooks skip XSS body re-encoding (raw-body HMAC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ version.
 
 ### Added
 
+- `framework.WithRawBodyPaths` — mark webhook / server-to-server paths whose
+  request body must reach the handler byte-for-byte, for signature verification
+  (e.g. GitHub `X-Hub-Signature-256`). The XSS sanitizer, which re-encodes JSON
+  bodies, is skipped for these paths, and they are CSRF-exempt too (so a
+  signature-verifying webhook needs only this one option). Fixes webhooks that
+  failed HMAC checks because the body was re-encoded before the handler saw it
+  ([#232](https://github.com/gombit-dev/gombit/issues/232)).
+
 - Admin many-to-many relationships end to end
   ([#223](https://github.com/gombit-dev/gombit/issues/223)): a `many_to_many`
   relation field round-trips as a list of related primary keys — list/detail
@@ -19,8 +27,13 @@ version.
   validation; a missing id is a 422; an empty list clears it), and
   auto-derivation (`FieldsFrom`) emits the relation instead of dropping the
   association. The framework admin SPA renders it as a multi-select backed by
-  the related model's list endpoint. `belongs_to`/`has_many` picker widgets and
-  belongs_to auto-derivation remain follow-ups on the same issue.
+  the related model's list endpoint.
+- Admin `belongs_to` picker
+  ([#223](https://github.com/gombit-dev/gombit/issues/223)): auto-derivation
+  renders a foreign-key column as a relation field (target `slug` = the related
+  table, label = its `name` column), and the SPA shows a single-select picker
+  backed by the related model's list endpoint that stores the selected primary
+  key — instead of a bare integer input. `has_many` stays read-only.
 - `gombit make resource` field grammar now supports `decimal`, `decimal(p,s)`,
   `time`, and `enum(a,b,c)` in addition to the existing scalars. `decimal` uses
   the new framework `types.Decimal` (a `shopspring/decimal` wrapper that carries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ version.
   signature-verifying webhook needs only this one option). Fixes webhooks that
   failed HMAC checks because the body was re-encoded before the handler saw it
   ([#232](https://github.com/gombit-dev/gombit/issues/232)).
-
 - Admin many-to-many relationships end to end
   ([#223](https://github.com/gombit-dev/gombit/issues/223)): a `many_to_many`
   relation field round-trips as a list of related primary keys — list/detail
@@ -27,13 +26,8 @@ version.
   validation; a missing id is a 422; an empty list clears it), and
   auto-derivation (`FieldsFrom`) emits the relation instead of dropping the
   association. The framework admin SPA renders it as a multi-select backed by
-  the related model's list endpoint.
-- Admin `belongs_to` picker
-  ([#223](https://github.com/gombit-dev/gombit/issues/223)): auto-derivation
-  renders a foreign-key column as a relation field (target `slug` = the related
-  table, label = its `name` column), and the SPA shows a single-select picker
-  backed by the related model's list endpoint that stores the selected primary
-  key — instead of a bare integer input. `has_many` stays read-only.
+  the related model's list endpoint. `belongs_to`/`has_many` picker widgets and
+  belongs_to auto-derivation remain follow-ups on the same issue.
 - `gombit make resource` field grammar now supports `decimal`, `decimal(p,s)`,
   `time`, and `enum(a,b,c)` in addition to the existing scalars. `decimal` uses
   the new framework `types.Decimal` (a `shopspring/decimal` wrapper that carries

--- a/auth/cookie_handlers_test.go
+++ b/auth/cookie_handlers_test.go
@@ -405,6 +405,12 @@ func TestRawBodyPathThroughNew(t *testing.T) {
 	if got != raw {
 		t.Fatalf("handler received %q, want the body unmodified %q", got, raw)
 	}
+
+	// A neighbor path is not raw-body: CSRF is still enforced. Guards against a
+	// regression that disables CSRF globally whenever any raw-body path is set.
+	app.Router().POST("/api/v1/other", func(c *gin.Context) { c.Status(http.StatusOK) })
+	rec = doRequest(app, nil, http.MethodPost, "/api/v1/other", raw)
+	assertCSRFRejected(t, rec)
 }
 
 func TestCSRFSafeMethodsAreExempt(t *testing.T) {

--- a/auth/cookie_handlers_test.go
+++ b/auth/cookie_handlers_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -360,6 +361,50 @@ func TestCSRFExemptPathThroughNew(t *testing.T) {
 		rec := doRequest(app, nil, http.MethodPost, "/api/v1/webhooks/other", "{}")
 		assertCSRFRejected(t, rec)
 	})
+}
+
+// TestRawBodyPathThroughNew verifies WithRawBodyPaths end to end: a raw-body
+// path is CSRF-exempt (no token needed) AND its JSON body reaches the handler
+// unmodified — the XSS sanitizer, which otherwise re-encodes JSON bodies, is
+// skipped — so a webhook can verify a signature over the raw body.
+func TestRawBodyPathThroughNew(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := openSQLite(t)
+	if err := auth.Migrate(db.DB); err != nil {
+		t.Fatalf("auth.Migrate() error = %v", err)
+	}
+	cfg := config.DefaultFor(config.EnvironmentTest)
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.Auth.JWTSecret = testJWTSecret
+	cfg.Auth.Mode = config.AuthModeCookie
+
+	app, err := framework.New(
+		framework.WithConfig(cfg),
+		framework.WithDatabase(db),
+		framework.WithLogger(zap.NewNop()),
+		framework.WithRawBodyPaths("/api/v1/webhooks/github"),
+	)
+	if err != nil {
+		t.Fatalf("framework.New() error = %v", err)
+	}
+
+	// A body json-re-encoding would change (< / & escaped, <b> stripped).
+	const raw = `{"tag":"v1","body":"<b>x</b> a < b & c"}`
+	var got string
+	app.Router().POST("/api/v1/webhooks/github", func(c *gin.Context) {
+		b, _ := io.ReadAll(c.Request.Body)
+		got = string(b)
+		c.Status(http.StatusOK)
+	})
+
+	// No CSRF token attached (jar == nil): raw-body paths are CSRF-exempt too.
+	rec := doRequest(app, nil, http.MethodPost, "/api/v1/webhooks/github", raw)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (CSRF-exempt raw-body path); body: %s", rec.Code, rec.Body.String())
+	}
+	if got != raw {
+		t.Fatalf("handler received %q, want the body unmodified %q", got, raw)
+	}
 }
 
 func TestCSRFSafeMethodsAreExempt(t *testing.T) {

--- a/docs/auth-cookie.md
+++ b/docs/auth-cookie.md
@@ -89,20 +89,27 @@ token is mirrored in both the `Set-Cookie` header and the JSON body
 
 A **webhook** or other server-to-server `POST` cannot participate in the
 double-submit defense — the caller has no `gombit_csrf` cookie to echo — so in
-cookie mode it would always 403. Opt those exact paths out with
-`framework.WithCSRFExemptPaths`:
+cookie mode it would always 403. It also usually verifies a **signature over
+the raw request body** (e.g. GitHub's `X-Hub-Signature-256` HMAC), and the XSS
+input sanitizer re-encodes JSON bodies, which would break that check. Use
+`framework.WithRawBodyPaths` for these endpoints — it exempts them from **both**
+CSRF and body sanitization:
 
 ```go
 app, err := framework.New(
     framework.WithConfig(cfg),
     framework.WithDatabase(db),
-    framework.WithCSRFExemptPaths("/api/v1/webhooks/github"),
+    framework.WithRawBodyPaths("/api/v1/webhooks/github"),
 )
 ```
 
-Paths match the request path **exactly**, including the API prefix. On an
-exempt path the middleware skips CSRF enforcement for unsafe methods (safe
-methods still mint the cookie).
+Paths match the request path **exactly**, including the API prefix. On such a
+path CSRF enforcement is skipped for unsafe methods (safe methods still mint
+the cookie) and the request body reaches the handler byte-for-byte unmodified.
+
+`WithCSRFExemptPaths` is the narrower option: it skips CSRF only, leaving the
+body sanitizer in place. Use it for a non-browser endpoint that does **not**
+hash its raw body; use `WithRawBodyPaths` for signature-verifying webhooks.
 
 **Exempting a path removes a protection; it does not make the route
 credential-free.** The session cookies (`gombit_access` / `gombit_refresh`)

--- a/docs/router.md
+++ b/docs/router.md
@@ -85,7 +85,12 @@ Other behavior notes:
   path is JSON/Huma. Form/multipart coverage can land before browser/admin
   session work if needed.
 - Sanitization re-marshals JSON, so key order and whitespace may change.
-  Callers that hash the raw body must hash the bytes handlers actually see.
+  Callers that hash the raw body must hash the bytes handlers actually see —
+  which a webhook can't, since it verifies a signature over the *original*
+  bytes. Mark such paths with
+  [`framework.WithRawBodyPaths`](auth-cookie.md#exempting-non-browser-endpoints-webhooks):
+  they skip sanitization entirely (and the 8MiB cap below), so the body reaches
+  the handler byte-for-byte, and they are CSRF-exempt too.
 - Unclosed dangerous elements (for example a truncated `<script>...`) discard
   the remainder of the string (fail-closed).
 - Incomplete angle brackets that are not a complete HTML tag (no closing

--- a/framework/app.go
+++ b/framework/app.go
@@ -54,6 +54,7 @@ type App struct {
 	shutdownTimeout  time.Duration
 	embeddedFrontend fs.FS
 	csrfExemptPaths  []string
+	rawBodyPaths     []string
 
 	mu     sync.RWMutex
 	server *http.Server
@@ -107,7 +108,7 @@ func New(options ...Option) (*App, error) {
 		})
 	}
 	if app.router == nil {
-		router, err := newRouter(app.cfg, app.csrfExemptPaths)
+		router, err := newRouter(app.cfg, app.csrfExemptPaths, app.rawBodyPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -251,6 +252,25 @@ func WithShutdownTimeout(timeout time.Duration) Option {
 func WithCSRFExemptPaths(paths ...string) Option {
 	return func(app *App) error {
 		app.csrfExemptPaths = append(app.csrfExemptPaths, paths...)
+		return nil
+	}
+}
+
+// WithRawBodyPaths marks exact request paths whose request body must reach the
+// handler byte-for-byte unmodified — webhooks and other server-to-server
+// endpoints that verify a signature over the raw body (e.g. GitHub's
+// X-Hub-Signature-256 HMAC). The XSS input sanitizer, which otherwise
+// re-encodes JSON request bodies, is skipped for these paths.
+//
+// Such an endpoint also cannot participate in the cookie CSRF double-submit, so
+// raw-body paths are additionally CSRF-exempt (the union with
+// WithCSRFExemptPaths) — declaring a webhook path here is enough. The handler
+// must authenticate the caller itself. Paths match the request path exactly,
+// including the API prefix, e.g. "/api/v1/webhooks/github". No effect when a
+// custom router is supplied via WithRouter.
+func WithRawBodyPaths(paths ...string) Option {
+	return func(app *App) error {
+		app.rawBodyPaths = append(app.rawBodyPaths, paths...)
 		return nil
 	}
 }
@@ -522,7 +542,7 @@ func syncLogger(logger *zap.Logger) error {
 	return nil
 }
 
-func newRouter(cfg config.Config, csrfExemptPaths []string) (*gin.Engine, error) {
+func newRouter(cfg config.Config, csrfExemptPaths, rawBodyPaths []string) (*gin.Engine, error) {
 	router := gin.New()
 	enableMethodNotAllowed(router)
 	if err := configureTrustedProxies(router, cfg.HTTP.TrustedProxies); err != nil {
@@ -530,7 +550,7 @@ func newRouter(cfg config.Config, csrfExemptPaths []string) (*gin.Engine, error)
 	}
 
 	metrics := newHTTPMetrics()
-	router.Use(middlewareHandlers(runtimeMiddlewareStack(cfg, metrics, csrfExemptPaths))...)
+	router.Use(middlewareHandlers(runtimeMiddlewareStack(cfg, metrics, csrfExemptPaths, rawBodyPaths))...)
 	router.GET("/livez", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"data": gin.H{
@@ -562,7 +582,7 @@ func configureTrustedProxies(engine *gin.Engine, proxies []string) error {
 	return nil
 }
 
-func runtimeMiddlewareStack(cfg config.Config, metrics *httpMetrics, csrfExemptPaths []string) []namedMiddleware {
+func runtimeMiddlewareStack(cfg config.Config, metrics *httpMetrics, csrfExemptPaths, rawBodyPaths []string) []namedMiddleware {
 	stack := []namedMiddleware{
 		{name: "recovery", handler: gin.Recovery()},
 		{name: "request_context", handler: requestContextMiddleware()},
@@ -571,14 +591,18 @@ func runtimeMiddlewareStack(cfg config.Config, metrics *httpMetrics, csrfExemptP
 			name:    "security_headers",
 			handler: securityHeadersMiddleware(cfg.Environment == config.EnvironmentProduction),
 		},
-		{name: "xss", handler: xssMiddleware()},
+		// Raw-body paths (webhooks) skip input sanitization so their body reaches
+		// the handler unmodified for signature verification (WithRawBodyPaths).
+		{name: "xss", handler: xssMiddleware(rawBodyPaths...)},
 	}
 	// CSRF must run as global Gin middleware, not just on the auth Huma
 	// routes: it covers every state-changing request (M5-3), including
 	// application feature routes registered later via app.Router(). See
-	// docs/auth-cookie.md.
+	// docs/auth-cookie.md. Raw-body paths are also CSRF-exempt: a webhook that
+	// needs its raw body cannot do the double-submit either.
 	if cfg.Auth.Enabled() && cfg.Auth.EffectiveMode() == config.AuthModeCookie {
-		stack = append(stack, namedMiddleware{name: "csrf", handler: auth.CSRFMiddleware(cfg, csrfExemptPaths...)})
+		csrfExempt := append(append([]string{}, csrfExemptPaths...), rawBodyPaths...)
+		stack = append(stack, namedMiddleware{name: "csrf", handler: auth.CSRFMiddleware(cfg, csrfExempt...)})
 	}
 	stack = append(stack, namedMiddleware{name: "request_timeout", handler: requestTimeoutMiddleware(cfg.HTTP.RequestTimeout)})
 	return stack

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestDefaultRuntimeMiddlewareOrder(t *testing.T) {
-	stack := runtimeMiddlewareStack(config.Default(), newHTTPMetrics(), nil)
+	stack := runtimeMiddlewareStack(config.Default(), newHTTPMetrics(), nil, nil)
 	got := make([]string, 0, len(stack))
 	for _, middleware := range stack {
 		got = append(got, middleware.name)

--- a/framework/xss.go
+++ b/framework/xss.go
@@ -49,9 +49,22 @@ var completeHTMLTag = regexp.MustCompile(`(?i)<\s*/?[a-z][a-z0-9:-]*(?:\s[^>]*)?
 // unchanged. Non-JSON bodies (form/multipart) pass through unchanged.
 //
 // Re-encoding JSON may change key order and whitespace; callers that hash
-// the raw body must hash the sanitized bytes handlers actually receive.
-func xssMiddleware() gin.HandlerFunc {
+// the raw body must hash the sanitized bytes handlers actually receive — which
+// a webhook can't, since it signs the original bytes. exemptPaths (exact request
+// paths, from framework.WithRawBodyPaths) therefore skip sanitization entirely,
+// so their body reaches the handler unmodified for signature verification.
+func xssMiddleware(exemptPaths ...string) gin.HandlerFunc {
+	exempt := make(map[string]struct{}, len(exemptPaths))
+	for _, path := range exemptPaths {
+		if path = strings.TrimSpace(path); path != "" {
+			exempt[path] = struct{}{}
+		}
+	}
 	return func(c *gin.Context) {
+		if _, ok := exempt[c.Request.URL.Path]; ok {
+			c.Next()
+			return
+		}
 		switch c.Request.Method {
 		case http.MethodGet:
 			sanitizeQuery(c)

--- a/framework/xss_test.go
+++ b/framework/xss_test.go
@@ -269,3 +269,42 @@ func TestSanitizeJSONBodyPreservesComparisonText(t *testing.T) {
 		t.Fatalf("name = %#v, want a<b (not truncated)", payload["name"])
 	}
 }
+
+func TestXSSMiddlewareRawBodyPathSkipsSanitization(t *testing.T) {
+	// A body that json re-encoding would change (< / & escaped, <b> stripped).
+	const raw = `{"tag":"v1","body":"<b>notes</b> a < b & c"}`
+
+	newEngine := func() (*gin.Engine, *string) {
+		var got string
+		eng := gin.New()
+		eng.Use(xssMiddleware("/api/v1/webhooks/github"))
+		read := func(c *gin.Context) {
+			b, _ := io.ReadAll(c.Request.Body)
+			got = string(b)
+			c.Status(http.StatusOK)
+		}
+		eng.POST("/api/v1/webhooks/github", read)
+		eng.POST("/api/v1/other", read)
+		return eng, &got
+	}
+
+	// Exempt raw-body path: the handler receives the original bytes verbatim.
+	eng, got := newEngine()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/github", strings.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	eng.ServeHTTP(rec, req)
+	if *got != raw {
+		t.Fatalf("exempt-path body = %q, want unmodified %q", *got, raw)
+	}
+
+	// Non-exempt path: the body is sanitized/re-encoded (control).
+	eng2, got2 := newEngine()
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/other", strings.NewReader(raw))
+	req2.Header.Set("Content-Type", "application/json")
+	eng2.ServeHTTP(rec2, req2)
+	if *got2 == raw {
+		t.Fatalf("non-exempt path body was not sanitized: %q", *got2)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #232. The XSS sanitizer re-marshals every `application/json` body and replaces it, so a handler's `RawBody` != the bytes the client sent — breaking HMAC signature verification for webhooks (GitHub signs the original body and sends `Content-Type: application/json`). `WithCSRFExemptPaths` (#226) got the request to the handler but the body was still mutated.

`framework.WithRawBodyPaths(paths...)` marks exact webhook paths whose body must reach the handler unmodified: the XSS middleware skips them, and they're CSRF-exempt too (union), so a signature-verifying webhook needs only this one option.

## Changes

- `WithRawBodyPaths`; threaded `rawBodyPaths` through `newRouter` → `runtimeMiddlewareStack` → `xssMiddleware(rawBodyPaths...)`, and unioned into the CSRF exempt set.
- `xssMiddleware(exemptPaths...)` skips exact-path matches.
- `WithCSRFExemptPaths` stays as the narrower CSRF-only option.

## Tests

- `framework`: `TestXSSMiddlewareRawBodyPathSkipsSanitization` — exempt path body verbatim; non-exempt path re-encoded (control).
- `auth`: `TestRawBodyPathThroughNew` — through `framework.New`: CSRF-exempt (no token → 200) **and** body unmodified.
- `go test ./...` passes.

## Docs

`docs/auth-cookie.md` webhook section now recommends `WithRawBodyPaths`; `CHANGELOG.md` under `[Unreleased]`.

Found dogfooding the framework to build the GitHub-release webhook in gombit-dev/gombit-website.

🤖 Generated with [Claude Code](https://claude.com/claude-code)