### PR TITLE
[feature] make resource relations: belongs_to / has_many / many_to_many (#222 part b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ version.
   `name:many_to_many:Target` generate the foreign key / association on the model
   (and the `many2many:` join table), importing the target feature-package. The
   thin CRUD handler exposes `belongs_to` as its foreign key (`engine_id`);
-  `has_many` / `many_to_many` are model-only and edited through the admin's
-  relation widgets. A `has_many` child must carry the parent foreign key itself.
+  `has_many` / `many_to_many` are model-only — in the admin, `many_to_many` is
+  editable and `has_many` is shown read-only. A `has_many` child must carry the
+  parent foreign key itself. A `belongs_to` may be self-referential (a tree
+  parent), rendering the local type with no self-import; a self-referential
+  `has_many` / `many_to_many` is rejected, as is a `belongs_to` whose synthesized
+  `<name>_id` foreign key collides with another field.
 - Admin read-only `has_many` view
   ([#223](https://github.com/gombit-dev/gombit/issues/223)): a `has_many`
   association now auto-derives to a read-only relation field — list/detail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ version.
 
 ### Added
 
+- `gombit make resource` relation fields
+  ([#222](https://github.com/gombit-dev/gombit/issues/222) part b):
+  `name:belongs_to:Target`, `name:has_many:Target`, and
+  `name:many_to_many:Target` generate the foreign key / association on the model
+  (and the `many2many:` join table), importing the target feature-package. The
+  thin CRUD handler exposes `belongs_to` as its foreign key (`engine_id`);
+  `has_many` / `many_to_many` are model-only and edited through the admin's
+  relation widgets. A `has_many` child must carry the parent foreign key itself.
 - Admin read-only `has_many` view
   ([#223](https://github.com/gombit-dev/gombit/issues/223)): a `has_many`
   association now auto-derives to a read-only relation field — list/detail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ version.
   thin CRUD handler exposes `belongs_to` as its foreign key (`engine_id`);
   `has_many` / `many_to_many` are model-only — in the admin, `many_to_many` is
   editable and `has_many` is shown read-only. A `has_many` child must carry the
-  parent foreign key itself. A `belongs_to` may be self-referential (a tree
-  parent), rendering the local type with no self-import; a self-referential
-  `has_many` / `many_to_many` is rejected, as is a `belongs_to` whose synthesized
-  `<name>_id` foreign key collides with another field.
+  parent foreign key itself. Self-referential relations (a target equal to the
+  resource itself) are rejected for now — they need a nullable foreign key /
+  explicit join keys — as is a `belongs_to` whose synthesized `<name>_id` foreign
+  key collides with another field.
 - Admin read-only `has_many` view
   ([#223](https://github.com/gombit-dev/gombit/issues/223)): a `has_many`
   association now auto-derives to a read-only relation field — list/detail

--- a/cli/make.go
+++ b/cli/make.go
@@ -48,18 +48,32 @@ Field grammar (design §27 subset):
 
   name:type[:required][,unique][,index]
 
-Supported types: string, text, int, int64, bool, uint, decimal, time, enum.
+Supported types: string, text, int, int64, bool, uint, decimal, time, enum,
+belongs_to, has_many, many_to_many.
 
   decimal            money/exact numeric (types.Decimal; decimal(19,4) column).
   decimal(p,s)       pin precision/scale, e.g. decimal(10,2).
   time               time.Time (RFC3339 in JSON).
   enum(a,b,c)        string column validated against the listed values.
 
+Relations use name:kind:Target, where Target is a model in internal/<target>/:
+
+  engine:belongs_to:Engine        FK (EngineID) + Engine association; the API
+                                  DTO exposes engine_id.
+  parts:has_many:Part             Parts []part.Part; read via the admin. The
+                                  child (Part) must carry the RentalID FK.
+  warehouses:many_to_many:Warehouse  join table + Warehouses association.
+
+The generated CRUD handler stays thin: belongs_to is exposed as its FK; a
+many_to_many / has_many is generated on the model (and picked up by the admin's
+relation widgets), not in the REST handler.
+
 Examples:
 
   gombit make resource Widget name:string:required price:int
   gombit make resource Rental price:decimal:required starts_at:time \
-    status:enum(requested,confirmed,active,returned,cancelled)
+    status:enum(requested,confirmed,active,returned,cancelled) \
+    engine:belongs_to:Engine warehouses:many_to_many:Warehouse
   gombit make resource Invoice --service --repo --dry-run
   gombit make resource Widget --force
 

--- a/cli/make.go
+++ b/cli/make.go
@@ -64,9 +64,13 @@ Relations use name:kind:Target, where Target is a model in internal/<target>/:
                                   child (Part) must carry the RentalID FK.
   warehouses:many_to_many:Warehouse  join table + Warehouses association.
 
-The generated CRUD handler stays thin: belongs_to is exposed as its FK; a
-many_to_many / has_many is generated on the model (and picked up by the admin's
-relation widgets), not in the REST handler.
+The generated CRUD handler stays thin: belongs_to is exposed as its FK;
+many_to_many / has_many are generated on the model, not in the REST handler.
+The admin picks them up — many_to_many is editable through a relation widget,
+has_many is shown read-only. A belongs_to may target the resource itself
+(a self-referential FK, e.g. a tree parent); a self-referential
+has_many / many_to_many is rejected (it needs join/foreign keys the generator
+does not emit).
 
 Examples:
 

--- a/cli/make.go
+++ b/cli/make.go
@@ -67,10 +67,9 @@ Relations use name:kind:Target, where Target is a model in internal/<target>/:
 The generated CRUD handler stays thin: belongs_to is exposed as its FK;
 many_to_many / has_many are generated on the model, not in the REST handler.
 The admin picks them up — many_to_many is editable through a relation widget,
-has_many is shown read-only. A belongs_to may target the resource itself
-(a self-referential FK, e.g. a tree parent); a self-referential
-has_many / many_to_many is rejected (it needs join/foreign keys the generator
-does not emit).
+has_many is shown read-only. Self-referential relations (a target equal to the
+resource itself) are not supported yet and are rejected: they need a nullable
+foreign key / explicit join keys. Point relations at a different package.
 
 Examples:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -369,10 +369,18 @@ added (portable across SQLite/PostgreSQL/MySQL).
 `internal/<target>/` (imported as `target.Target`). `belongs_to` generates the
 foreign key (`EngineID uint`) plus the association and exposes `engine_id` in
 the REST DTO; `has_many` and `many_to_many` generate the association on the model
-(the join table for m2m) and are edited through the admin's relation widgets, not
-the thin REST handler. A `has_many` child model must carry the parent foreign
-key itself (e.g. `RentalID`); the generator does not edit the child (that would
-be an import cycle).
+(the join table for m2m), not in the thin REST handler. In the admin,
+`many_to_many` is editable through a relation widget and `has_many` is shown
+read-only. A `has_many` child model must carry the parent foreign key itself
+(e.g. `RentalID`); the generator does not edit the child (that would be an
+import cycle).
+
+A `belongs_to` may target the resource itself — a self-referential foreign key,
+e.g. `parent:belongs_to:Category` on `Category`, which renders the local pointer
+type (`Parent *Category`, avoiding an invalid recursive struct) and imports
+nothing. A self-referential `has_many` /
+`many_to_many` is rejected at parse time: it needs explicit join / foreign keys
+this generator does not emit.
 
 Example:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -351,6 +351,9 @@ accepted as the opposite of `required`.
 | `decimal(p,s)` | `types.Decimal` | `decimal(p,s)`, e.g. `decimal(10,2)` |
 | `time` | `time.Time` | RFC3339 date-time in JSON |
 | `enum(a,b,c)` | `string` | sized varchar; validated against the listed values (Huma `enum` tag) |
+| `belongs_to:Target` | FK `TargetID uint` + `Target target.Target` | DTO exposes `target_id`; admin renders a picker |
+| `has_many:Target` | `[]target.Target` | model-only, read via the admin; the child must carry the parent FK |
+| `many_to_many:Target` | `[]target.Target` (`many2many:` join) | model-only, edited via the admin |
 
 `types.Decimal` is the framework money/decimal type. Because a single Go type
 flows through the model, the handler DTO, the OpenAPI/TS contract, and GORM,
@@ -360,9 +363,16 @@ field **without** `:required` becomes a pointer (`*time.Time` / `*types.Decimal`
 on the model and DTO, because those value types cannot be submitted empty — the
 generated forms send `null` for a blank optional value. Enum values are
 case-sensitive and validated at the API layer; no database CHECK constraint is
-added (portable across SQLite/PostgreSQL/MySQL). Relationships
-(`belongs_to`/`has_many`/`many_to_many`) are tracked separately in
-[#222](https://github.com/gombit-dev/gombit/issues/222) part (b).
+added (portable across SQLite/PostgreSQL/MySQL).
+
+**Relations** use `name:kind:Target`, where `Target` is a model in
+`internal/<target>/` (imported as `target.Target`). `belongs_to` generates the
+foreign key (`EngineID uint`) plus the association and exposes `engine_id` in
+the REST DTO; `has_many` and `many_to_many` generate the association on the model
+(the join table for m2m) and are edited through the admin's relation widgets, not
+the thin REST handler. A `has_many` child model must carry the parent foreign
+key itself (e.g. `RentalID`); the generator does not edit the child (that would
+be an import cycle).
 
 Example:
 
@@ -370,7 +380,9 @@ Example:
 gombit make resource Rental \
   price:decimal:required \
   starts_at:time \
-  status:enum(requested,confirmed,active,returned,cancelled)
+  status:enum(requested,confirmed,active,returned,cancelled) \
+  engine:belongs_to:Engine \
+  warehouses:many_to_many:Warehouse
 ```
 
 ### Idempotency

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -375,12 +375,12 @@ read-only. A `has_many` child model must carry the parent foreign key itself
 (e.g. `RentalID`); the generator does not edit the child (that would be an
 import cycle).
 
-A `belongs_to` may target the resource itself — a self-referential foreign key,
-e.g. `parent:belongs_to:Category` on `Category`, which renders the local pointer
-type (`Parent *Category`, avoiding an invalid recursive struct) and imports
-nothing. A self-referential `has_many` /
-`many_to_many` is rejected at parse time: it needs explicit join / foreign keys
-this generator does not emit.
+Self-referential relations (a target equal to the resource itself, e.g.
+`parent:belongs_to:Category` on `Category`) are not supported yet and are
+rejected at parse time: a self-referential `belongs_to` needs a nullable foreign
+key so a tree root stores `NULL` rather than `0` (which references no row and
+fails the self-FK), and `has_many` / `many_to_many` onto the same model need
+explicit join keys. Point relations at a different feature-package for now.
 
 Example:
 

--- a/goldentest/golden_test.go
+++ b/goldentest/golden_test.go
@@ -216,6 +216,43 @@ func TestMakeResourceScalarTypesCompiles(t *testing.T) {
 	})
 }
 
+// TestMakeResourceRelationsCompiles exercises the #222(b) relation grammar end
+// to end: it generates the target models, then a resource with belongs_to /
+// has_many / many_to_many fields, and compiles the app (the generated model
+// imports the target feature-packages and references their types).
+func TestMakeResourceRelationsCompiles(t *testing.T) {
+	appDir := scaffoldDemo(t)
+	gen := func(name string, fields ...string) {
+		t.Helper()
+		stdout := new(bytes.Buffer)
+		if err := resourcegen.Generate(context.Background(), resourcegen.Options{
+			WorkDir:  appDir,
+			Name:     name,
+			Fields:   fields,
+			AtlasBin: missingAtlas,
+			Stdout:   stdout,
+			Stderr:   io.Discard,
+		}); err != nil {
+			t.Fatalf("gombit make resource %s: %v\nstdout=%s", name, err, stdout.String())
+		}
+	}
+	// Target models first, so the relation imports resolve.
+	gen("Engine", "name:string:required")
+	gen("Warehouse", "name:string:required")
+	// The has_many child carries the back-reference FK as a plain column (no
+	// import, so no cycle): rental_id -> RentalID, which GORM's has_many uses.
+	gen("Part", "name:string:required", "rental_id:uint")
+	gen("Rental",
+		"price:decimal:required",
+		"engine:belongs_to:Engine",
+		"parts:has_many:Part",
+		"warehouses:many_to_many:Warehouse",
+	)
+	t.Run("compile", func(t *testing.T) {
+		compileBackend(t, appDir)
+	})
+}
+
 func TestMakeCommandGolden(t *testing.T) {
 	appDir := scaffoldDemo(t)
 	stdout := new(bytes.Buffer)

--- a/goldentest/golden_test.go
+++ b/goldentest/golden_test.go
@@ -248,10 +248,6 @@ func TestMakeResourceRelationsCompiles(t *testing.T) {
 		"parts:has_many:Part",
 		"warehouses:many_to_many:Warehouse",
 	)
-	// A self-referential belongs_to (tree parent) must render the local type and
-	// import nothing — a self-import would not compile. This case is invisible to
-	// a test that only generates *other* target packages first (#222 review).
-	gen("Category", "name:string:required", "parent:belongs_to:Category")
 	t.Run("compile", func(t *testing.T) {
 		compileBackend(t, appDir)
 	})

--- a/goldentest/golden_test.go
+++ b/goldentest/golden_test.go
@@ -248,6 +248,10 @@ func TestMakeResourceRelationsCompiles(t *testing.T) {
 		"parts:has_many:Part",
 		"warehouses:many_to_many:Warehouse",
 	)
+	// A self-referential belongs_to (tree parent) must render the local type and
+	// import nothing — a self-import would not compile. This case is invisible to
+	// a test that only generates *other* target packages first (#222 review).
+	gen("Category", "name:string:required", "parent:belongs_to:Category")
 	t.Run("compile", func(t *testing.T) {
 		compileBackend(t, appDir)
 	})

--- a/resourcegen/fields.go
+++ b/resourcegen/fields.go
@@ -33,8 +33,10 @@ type Field struct {
 
 // parseRelationField builds a belongs_to / has_many / many_to_many field from
 // its target model. The target is a PascalCase model living in
-// internal/<target>/ (imported as <target>.<Target>).
-func parseRelationField(name, jsonName, goName string, kind FieldType, target string) (Field, error) {
+// internal/<target>/ (imported as <target>.<Target>), or the resource itself
+// for a self-referential belongs_to. resourcePkg is the package being
+// generated, used to detect same-package targets.
+func parseRelationField(name, jsonName, goName string, kind FieldType, target, resourcePkg string) (Field, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		return Field{}, fmt.Errorf("resourcegen: relation field %q is missing a target model", name)
@@ -50,6 +52,13 @@ func parseRelationField(name, jsonName, goName string, kind FieldType, target st
 	if _, kw := goKeywords[targetPkg]; kw {
 		return Field{}, fmt.Errorf("resourcegen: relation target %q maps to Go keyword %q", target, targetPkg)
 	}
+	// A same-package target is legal only for belongs_to (a self-referential FK,
+	// e.g. a tree parent). has_many / many_to_many onto the same model need
+	// explicit join / foreign keys that this generator does not emit, so refuse
+	// rather than write Go that fails to migrate.
+	if targetPkg == resourcePkg && kind != FieldBelongsTo {
+		return Field{}, fmt.Errorf("resourcegen: %s relation %q cannot target the resource itself (self-referential %s needs explicit join/foreign keys; only belongs_to self-references are supported)", strings.ToLower(string(kind)), name, strings.ToLower(string(kind)))
+	}
 	f := Field{
 		Name:      name,
 		JSONName:  jsonName,
@@ -58,13 +67,39 @@ func parseRelationField(name, jsonName, goName string, kind FieldType, target st
 		Target:    targetType,
 		TargetPkg: targetPkg,
 	}
+	// A self-referential belongs_to uses the local type name and imports nothing;
+	// a cross-package target is qualified as <pkg>.<Type>.
+	selfRef := targetPkg == resourcePkg
+	qualified := targetPkg + "." + targetType
+	if selfRef {
+		qualified = targetType
+	}
 	switch kind {
 	case FieldBelongsTo:
-		f.GoType = targetPkg + "." + targetType // the association struct field
+		// A self-referential association must be a pointer: an embedded value of
+		// the same struct is an invalid recursive type. A cross-package target is
+		// a distinct struct, so it stays a value.
+		if selfRef {
+			f.GoType = "*" + qualified
+		} else {
+			f.GoType = qualified
+		}
 	case FieldHasMany, FieldManyToMany:
-		f.GoType = "[]" + targetPkg + "." + targetType
+		f.GoType = "[]" + qualified
 	}
 	return f, nil
+}
+
+// reservedJSONKeys returns the lowercased JSON identifiers this field claims in
+// the generated output, used for duplicate detection. A belongs_to occupies both
+// its own name (the association Go field) and its synthesized foreign key
+// (<name>_id), so both must be reserved — otherwise engine:belongs_to:Engine
+// plus engine_id:uint would emit the EngineID field twice.
+func (f Field) reservedJSONKeys() []string {
+	if f.Type == FieldBelongsTo {
+		return []string{f.JSONName, f.fkJSONName()}
+	}
+	return []string{f.JSONName}
 }
 
 // fkGoName / fkJSONName are the foreign-key field names for a belongs_to (the
@@ -110,7 +145,8 @@ func (f Field) joinTable(resourcePkg string) string { return resourcePkg + "_" +
 
 // dtoFields projects the fields as they appear in the generated handler DTO and
 // frontend: belongs_to becomes its uint foreign key; many_to_many / has_many are
-// dropped (model-only, edited through the admin).
+// dropped from the REST DTO (model-only — many_to_many is edited and has_many is
+// shown read-only through the admin).
 func dtoFields(fields []Field) []Field {
 	out := make([]Field, 0, len(fields))
 	for _, f := range fields {
@@ -144,7 +180,8 @@ func (f Field) isRelation() bool {
 
 // inDTO reports whether the field appears in the generated handler DTO. The thin
 // generated CRUD exposes belongs_to as its foreign key; many_to_many / has_many
-// are model-only (edited through the admin), not in the REST DTO.
+// are model-only — not in the REST DTO — with many_to_many edited and has_many
+// shown read-only through the admin.
 func (f Field) inDTO() bool {
 	return !f.isRelation() || f.Type == FieldBelongsTo
 }
@@ -184,25 +221,30 @@ var supportedTypes = []FieldType{
 // decimalGoType is the fully qualified generated Go type for a decimal field.
 const decimalGoType = "types.Decimal"
 
-func parseFields(specs []string) ([]Field, error) {
+func parseFields(specs []string, resourcePkg string) ([]Field, error) {
 	seen := make(map[string]struct{}, len(specs))
 	fields := make([]Field, 0, len(specs))
 	for _, spec := range specs {
-		field, err := parseField(spec)
+		field, err := parseField(spec, resourcePkg)
 		if err != nil {
 			return nil, err
 		}
-		key := strings.ToLower(field.JSONName)
-		if _, ok := seen[key]; ok {
-			return nil, fmt.Errorf("resourcegen: duplicate field %q", field.JSONName)
+		// Duplicate detection covers every JSON identifier the field emits, not
+		// just its grammar token: a belongs_to also claims its <name>_id foreign
+		// key (see reservedJSONKeys).
+		for _, key := range field.reservedJSONKeys() {
+			key = strings.ToLower(key)
+			if _, ok := seen[key]; ok {
+				return nil, fmt.Errorf("resourcegen: duplicate field %q", key)
+			}
+			seen[key] = struct{}{}
 		}
-		seen[key] = struct{}{}
 		fields = append(fields, field)
 	}
 	return fields, nil
 }
 
-func parseField(spec string) (Field, error) {
+func parseField(spec, resourcePkg string) (Field, error) {
 	spec = strings.TrimSpace(spec)
 	if spec == "" {
 		return Field{}, fmt.Errorf("resourcegen: empty field spec")
@@ -235,7 +277,7 @@ func parseField(spec string) (Field, error) {
 		if len(parts) != 3 {
 			return Field{}, fmt.Errorf("resourcegen: relation field %q must be name:%s:Target", spec, strings.ToLower(typeToken))
 		}
-		return parseRelationField(name, jsonName, goName, FieldType(strings.ToLower(typeToken)), parts[2])
+		return parseRelationField(name, jsonName, goName, FieldType(strings.ToLower(typeToken)), parts[2], resourcePkg)
 	}
 
 	field := Field{

--- a/resourcegen/fields.go
+++ b/resourcegen/fields.go
@@ -52,12 +52,13 @@ func parseRelationField(name, jsonName, goName string, kind FieldType, target, r
 	if _, kw := goKeywords[targetPkg]; kw {
 		return Field{}, fmt.Errorf("resourcegen: relation target %q maps to Go keyword %q", target, targetPkg)
 	}
-	// A same-package target is legal only for belongs_to (a self-referential FK,
-	// e.g. a tree parent). has_many / many_to_many onto the same model need
-	// explicit join / foreign keys that this generator does not emit, so refuse
-	// rather than write Go that fails to migrate.
-	if targetPkg == resourcePkg && kind != FieldBelongsTo {
-		return Field{}, fmt.Errorf("resourcegen: %s relation %q cannot target the resource itself (self-referential %s needs explicit join/foreign keys; only belongs_to self-references are supported)", strings.ToLower(string(kind)), name, strings.ToLower(string(kind)))
+	// Self-referential relations are not supported in this milestone. A
+	// belongs_to onto the same model would need a nullable (*uint) foreign key so
+	// a tree root stores NULL rather than 0 (0 references no row and fails the
+	// self-FK); has_many / many_to_many need explicit join / foreign keys. Rather
+	// than emit output that cannot insert a root or migrate, reject it here.
+	if targetPkg == resourcePkg {
+		return Field{}, fmt.Errorf("resourcegen: %s relation %q cannot target the resource itself (self-referential relations are not supported yet; they need a nullable foreign key / explicit join keys)", strings.ToLower(string(kind)), name)
 	}
 	f := Field{
 		Name:      name,
@@ -67,23 +68,12 @@ func parseRelationField(name, jsonName, goName string, kind FieldType, target, r
 		Target:    targetType,
 		TargetPkg: targetPkg,
 	}
-	// A self-referential belongs_to uses the local type name and imports nothing;
-	// a cross-package target is qualified as <pkg>.<Type>.
-	selfRef := targetPkg == resourcePkg
+	// The target is always a distinct feature-package (same-package targets are
+	// rejected above), qualified as <pkg>.<Type>.
 	qualified := targetPkg + "." + targetType
-	if selfRef {
-		qualified = targetType
-	}
 	switch kind {
 	case FieldBelongsTo:
-		// A self-referential association must be a pointer: an embedded value of
-		// the same struct is an invalid recursive type. A cross-package target is
-		// a distinct struct, so it stays a value.
-		if selfRef {
-			f.GoType = "*" + qualified
-		} else {
-			f.GoType = qualified
-		}
+		f.GoType = qualified // the association struct field
 	case FieldHasMany, FieldManyToMany:
 		f.GoType = "[]" + qualified
 	}

--- a/resourcegen/fields.go
+++ b/resourcegen/fields.go
@@ -24,6 +24,129 @@ type Field struct {
 	// Precision/Scale set the decimal(p,s) column for FieldDecimal.
 	Precision int
 	Scale     int
+
+	// Target is the related model type (PascalCase) for a relation field, e.g.
+	// "Engine". TargetPkg is its feature-package name (snake), e.g. "engine".
+	Target    string
+	TargetPkg string
+}
+
+// parseRelationField builds a belongs_to / has_many / many_to_many field from
+// its target model. The target is a PascalCase model living in
+// internal/<target>/ (imported as <target>.<Target>).
+func parseRelationField(name, jsonName, goName string, kind FieldType, target string) (Field, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return Field{}, fmt.Errorf("resourcegen: relation field %q is missing a target model", name)
+	}
+	targetType := toPascal(target)
+	if !isExportedIdent(targetType) {
+		return Field{}, fmt.Errorf("resourcegen: relation target %q is not a valid exported Go type", target)
+	}
+	targetPkg := toSnake(targetType)
+	if _, reserved := reservedPackages[targetPkg]; reserved {
+		return Field{}, fmt.Errorf("resourcegen: relation target %q maps to reserved package %q", target, targetPkg)
+	}
+	if _, kw := goKeywords[targetPkg]; kw {
+		return Field{}, fmt.Errorf("resourcegen: relation target %q maps to Go keyword %q", target, targetPkg)
+	}
+	f := Field{
+		Name:      name,
+		JSONName:  jsonName,
+		GoName:    goName,
+		Type:      kind,
+		Target:    targetType,
+		TargetPkg: targetPkg,
+	}
+	switch kind {
+	case FieldBelongsTo:
+		f.GoType = targetPkg + "." + targetType // the association struct field
+	case FieldHasMany, FieldManyToMany:
+		f.GoType = "[]" + targetPkg + "." + targetType
+	}
+	return f, nil
+}
+
+// fkGoName / fkJSONName are the foreign-key field names for a belongs_to (the
+// association is GoName, the FK is GoName+ID).
+func (f Field) fkGoName() string   { return f.GoName + "ID" }
+func (f Field) fkJSONName() string { return f.JSONName + "_id" }
+
+// dtoGoName / dtoGoType / dtoJSONName name the field as it appears in the
+// generated handler DTO. A belongs_to is exposed as its uint foreign key; other
+// fields keep their own names. (m2m / has_many are excluded from the DTO via
+// inDTO and never reach these.)
+func (f Field) dtoGoName() string {
+	if f.Type == FieldBelongsTo {
+		return f.fkGoName()
+	}
+	return f.GoName
+}
+
+func (f Field) dtoGoType() string {
+	if f.Type == FieldBelongsTo {
+		return "uint"
+	}
+	return f.GoType
+}
+
+func (f Field) dtoJSONName() string {
+	if f.Type == FieldBelongsTo {
+		return f.fkJSONName()
+	}
+	return f.JSONName
+}
+
+// dtoHumaTags is the Huma struct tag for the DTO create-input field.
+func (f Field) dtoHumaTags() string {
+	if f.Type == FieldBelongsTo {
+		return fmt.Sprintf(`json:"%s" minimum:"0" doc:"%s"`, f.fkJSONName(), f.fkGoName())
+	}
+	return f.humaTags()
+}
+
+// joinTable is the many2many join-table name for a relation on resourcePkg.
+func (f Field) joinTable(resourcePkg string) string { return resourcePkg + "_" + f.JSONName }
+
+// dtoFields projects the fields as they appear in the generated handler DTO and
+// frontend: belongs_to becomes its uint foreign key; many_to_many / has_many are
+// dropped (model-only, edited through the admin).
+func dtoFields(fields []Field) []Field {
+	out := make([]Field, 0, len(fields))
+	for _, f := range fields {
+		if !f.inDTO() {
+			continue
+		}
+		if f.Type == FieldBelongsTo {
+			out = append(out, Field{
+				Name:     f.fkJSONName(),
+				JSONName: f.fkJSONName(),
+				GoName:   f.fkGoName(),
+				Type:     FieldUint,
+				GoType:   "uint",
+			})
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// isRelation reports whether the field is a belongs_to / has_many / many_to_many.
+func (f Field) isRelation() bool {
+	switch f.Type {
+	case FieldBelongsTo, FieldHasMany, FieldManyToMany:
+		return true
+	default:
+		return false
+	}
+}
+
+// inDTO reports whether the field appears in the generated handler DTO. The thin
+// generated CRUD exposes belongs_to as its foreign key; many_to_many / has_many
+// are model-only (edited through the admin), not in the REST DTO.
+func (f Field) inDTO() bool {
+	return !f.isRelation() || f.Type == FieldBelongsTo
 }
 
 // FieldType is a supported scalar in the v0.1 subset.
@@ -39,6 +162,10 @@ const (
 	FieldDecimal FieldType = "decimal"
 	FieldTime    FieldType = "time"
 	FieldEnum    FieldType = "enum"
+
+	FieldBelongsTo  FieldType = "belongs_to"
+	FieldHasMany    FieldType = "has_many"
+	FieldManyToMany FieldType = "many_to_many"
 )
 
 // defaultDecimalPrecision / defaultDecimalScale back a bare `decimal` field.
@@ -99,6 +226,16 @@ func parseField(spec string) (Field, error) {
 	}
 	if _, reserved := reservedFields[jsonName]; reserved {
 		return Field{}, fmt.Errorf("resourcegen: field %q conflicts with gorm.Model", jsonName)
+	}
+
+	// Relations (name:kind:Target) use parts[2] as the target model, not
+	// modifiers.
+	switch FieldType(strings.ToLower(typeToken)) {
+	case FieldBelongsTo, FieldHasMany, FieldManyToMany:
+		if len(parts) != 3 {
+			return Field{}, fmt.Errorf("resourcegen: relation field %q must be name:%s:Target", spec, strings.ToLower(typeToken))
+		}
+		return parseRelationField(name, jsonName, goName, FieldType(strings.ToLower(typeToken)), parts[2])
 	}
 
 	field := Field{
@@ -309,10 +446,6 @@ func (f Field) humaTags() string {
 	}
 	parts = append(parts, fmt.Sprintf(`doc:"%s"`, f.GoName))
 	return strings.Join(parts, " ")
-}
-
-func (f Field) jsonTag() string {
-	return fmt.Sprintf(`json:"%s"`, f.JSONName)
 }
 
 // enumColumnSize sizes the varchar column to hold the longest allowed value,

--- a/resourcegen/fields_test.go
+++ b/resourcegen/fields_test.go
@@ -181,32 +181,25 @@ func TestParseRelationErrors(t *testing.T) {
 
 func TestParseRelationSamePackage(t *testing.T) {
 	t.Parallel()
-	// A self-referential belongs_to (tree parent) uses the local type and imports
-	// nothing — it must not emit `category.Category` inside package category.
-	fields, err := parseFields([]string{"parent:belongs_to:Category"}, "category")
-	if err != nil {
-		t.Fatalf("parseFields: %v", err)
+	// Self-referential relations are rejected: a belongs_to onto the same model
+	// would need a nullable FK (a uint root stores 0, which fails the self-FK),
+	// and has_many / many_to_many need explicit join keys. All three are refused.
+	for _, spec := range []string{
+		"parent:belongs_to:Category",
+		"children:has_many:Category",
+		"related:many_to_many:Category",
+	} {
+		if _, err := parseFields([]string{spec}, "category"); err == nil {
+			t.Fatalf("parseFields(%q) in its own package error = nil, want a self-reference rejection", spec)
+		}
 	}
-	if fields[0].GoType != "*Category" {
-		t.Fatalf("self belongs_to GoType = %q, want local *Category (pointer, no self-import)", fields[0].GoType)
-	}
-	if fields[0].TargetPkg != "category" {
-		t.Fatalf("TargetPkg = %q, want category", fields[0].TargetPkg)
-	}
-	// A cross-package belongs_to stays qualified.
+	// The same target from a different package is fine and stays qualified.
 	other, err := parseFields([]string{"parent:belongs_to:Category"}, "product")
 	if err != nil {
 		t.Fatalf("parseFields cross-pkg: %v", err)
 	}
 	if other[0].GoType != "category.Category" {
 		t.Fatalf("cross-pkg belongs_to GoType = %q, want category.Category", other[0].GoType)
-	}
-	// has_many / many_to_many onto the same model are refused (they would need
-	// join/foreign keys this generator does not emit).
-	for _, spec := range []string{"children:has_many:Category", "related:many_to_many:Category"} {
-		if _, err := parseFields([]string{spec}, "category"); err == nil {
-			t.Fatalf("parseFields(%q) in its own package error = nil, want a self-reference rejection", spec)
-		}
 	}
 }
 

--- a/resourcegen/fields_test.go
+++ b/resourcegen/fields_test.go
@@ -138,6 +138,47 @@ func TestParseFieldsDuplicate(t *testing.T) {
 	}
 }
 
+func TestParseRelationFields(t *testing.T) {
+	t.Parallel()
+	fields, err := parseFields([]string{
+		"engine:belongs_to:Engine",
+		"parts:has_many:Part",
+		"warehouses:many_to_many:Warehouse",
+	})
+	if err != nil {
+		t.Fatalf("parseFields: %v", err)
+	}
+	want := []struct {
+		name, kind, target, pkg, goType string
+	}{
+		{"engine", string(FieldBelongsTo), "Engine", "engine", "engine.Engine"},
+		{"parts", string(FieldHasMany), "Part", "part", "[]part.Part"},
+		{"warehouses", string(FieldManyToMany), "Warehouse", "warehouse", "[]warehouse.Warehouse"},
+	}
+	for i, w := range want {
+		f := fields[i]
+		if string(f.Type) != w.kind || f.Target != w.target || f.TargetPkg != w.pkg || f.GoType != w.goType {
+			t.Fatalf("field[%d] = %+v, want kind=%s target=%s pkg=%s goType=%s", i, f, w.kind, w.target, w.pkg, w.goType)
+		}
+	}
+	// belongs_to is in the DTO (as its FK); the collection relations are not.
+	if !fields[0].inDTO() || fields[1].inDTO() || fields[2].inDTO() {
+		t.Fatalf("inDTO = %v/%v/%v, want true/false/false", fields[0].inDTO(), fields[1].inDTO(), fields[2].inDTO())
+	}
+	if fields[0].fkGoName() != "EngineID" || fields[0].fkJSONName() != "engine_id" {
+		t.Fatalf("belongs_to FK names = %s/%s, want EngineID/engine_id", fields[0].fkGoName(), fields[0].fkJSONName())
+	}
+}
+
+func TestParseRelationErrors(t *testing.T) {
+	t.Parallel()
+	for _, spec := range []string{"engine:belongs_to", "warehouses:many_to_many:"} {
+		if _, err := parseFields([]string{spec}); err == nil {
+			t.Fatalf("parseFields(%q) error = nil, want a missing-target error", spec)
+		}
+	}
+}
+
 func TestParseEnumFieldDetails(t *testing.T) {
 	t.Parallel()
 	// Enum values are case-sensitive and preserve declared order.

--- a/resourcegen/fields_test.go
+++ b/resourcegen/fields_test.go
@@ -104,7 +104,7 @@ func TestParseFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			fields, err := parseFields([]string{tt.spec})
+			fields, err := parseFields([]string{tt.spec}, "widget")
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatal("parseFields() error = nil, want error")
@@ -132,7 +132,7 @@ func TestParseFields(t *testing.T) {
 
 func TestParseFieldsDuplicate(t *testing.T) {
 	t.Parallel()
-	_, err := parseFields([]string{"title:string", "title:int"})
+	_, err := parseFields([]string{"title:string", "title:int"}, "widget")
 	if err == nil || !strings.Contains(err.Error(), "duplicate") {
 		t.Fatalf("error = %v, want duplicate", err)
 	}
@@ -144,7 +144,7 @@ func TestParseRelationFields(t *testing.T) {
 		"engine:belongs_to:Engine",
 		"parts:has_many:Part",
 		"warehouses:many_to_many:Warehouse",
-	})
+	}, "rental")
 	if err != nil {
 		t.Fatalf("parseFields: %v", err)
 	}
@@ -173,8 +173,53 @@ func TestParseRelationFields(t *testing.T) {
 func TestParseRelationErrors(t *testing.T) {
 	t.Parallel()
 	for _, spec := range []string{"engine:belongs_to", "warehouses:many_to_many:"} {
-		if _, err := parseFields([]string{spec}); err == nil {
+		if _, err := parseFields([]string{spec}, "rental"); err == nil {
 			t.Fatalf("parseFields(%q) error = nil, want a missing-target error", spec)
+		}
+	}
+}
+
+func TestParseRelationSamePackage(t *testing.T) {
+	t.Parallel()
+	// A self-referential belongs_to (tree parent) uses the local type and imports
+	// nothing — it must not emit `category.Category` inside package category.
+	fields, err := parseFields([]string{"parent:belongs_to:Category"}, "category")
+	if err != nil {
+		t.Fatalf("parseFields: %v", err)
+	}
+	if fields[0].GoType != "*Category" {
+		t.Fatalf("self belongs_to GoType = %q, want local *Category (pointer, no self-import)", fields[0].GoType)
+	}
+	if fields[0].TargetPkg != "category" {
+		t.Fatalf("TargetPkg = %q, want category", fields[0].TargetPkg)
+	}
+	// A cross-package belongs_to stays qualified.
+	other, err := parseFields([]string{"parent:belongs_to:Category"}, "product")
+	if err != nil {
+		t.Fatalf("parseFields cross-pkg: %v", err)
+	}
+	if other[0].GoType != "category.Category" {
+		t.Fatalf("cross-pkg belongs_to GoType = %q, want category.Category", other[0].GoType)
+	}
+	// has_many / many_to_many onto the same model are refused (they would need
+	// join/foreign keys this generator does not emit).
+	for _, spec := range []string{"children:has_many:Category", "related:many_to_many:Category"} {
+		if _, err := parseFields([]string{spec}, "category"); err == nil {
+			t.Fatalf("parseFields(%q) in its own package error = nil, want a self-reference rejection", spec)
+		}
+	}
+}
+
+func TestParseBelongsToFKCollision(t *testing.T) {
+	t.Parallel()
+	// belongs_to:Engine synthesizes EngineID/engine_id; a separate engine_id
+	// column would emit the field twice. Both orderings must be rejected.
+	for _, specs := range [][]string{
+		{"engine:belongs_to:Engine", "engine_id:uint"},
+		{"engine_id:uint", "engine:belongs_to:Engine"},
+	} {
+		if _, err := parseFields(specs, "rental"); err == nil || !strings.Contains(err.Error(), "duplicate") {
+			t.Fatalf("parseFields(%v) error = %v, want duplicate", specs, err)
 		}
 	}
 }
@@ -182,7 +227,7 @@ func TestParseRelationErrors(t *testing.T) {
 func TestParseEnumFieldDetails(t *testing.T) {
 	t.Parallel()
 	// Enum values are case-sensitive and preserve declared order.
-	fields, err := parseFields([]string{"status:enum(Draft,Published,Archived)"})
+	fields, err := parseFields([]string{"status:enum(Draft,Published,Archived)"}, "widget")
 	if err != nil {
 		t.Fatalf("parseFields() error = %v", err)
 	}
@@ -201,7 +246,7 @@ func TestParseEnumFieldDetails(t *testing.T) {
 
 func TestParseDecimalPrecision(t *testing.T) {
 	t.Parallel()
-	fields, err := parseFields([]string{"amount:decimal", "price:decimal(10,2):required"})
+	fields, err := parseFields([]string{"amount:decimal", "price:decimal(10,2):required"}, "widget")
 	if err != nil {
 		t.Fatalf("parseFields() error = %v", err)
 	}
@@ -221,7 +266,7 @@ func TestParseDecimalPrecision(t *testing.T) {
 
 func TestParseDuplicateEnumValueRejected(t *testing.T) {
 	t.Parallel()
-	_, err := parseFields([]string{"status:enum(a,b,a)"})
+	_, err := parseFields([]string{"status:enum(a,b,a)"}, "widget")
 	if err == nil || !strings.Contains(err.Error(), "duplicate enum value") {
 		t.Fatalf("error = %v, want duplicate enum value", err)
 	}

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -3,6 +3,7 @@ package resourcegen
 import (
 	"fmt"
 	"go/format"
+	"sort"
 	"strings"
 )
 
@@ -69,9 +70,13 @@ func renderFeatureFiles(ctx renderContext) ([]fileSpec, error) {
 		})
 	}
 
+	// The generated frontend (thin CRUD) sees only the DTO fields: belongs_to as
+	// its uint FK, m2m / has_many dropped (edited through the admin).
+	tsxCtx := ctx
+	tsxCtx.Fields = dtoFields(ctx.Fields)
 	files = append(files,
-		fileSpec{relPath: fmt.Sprintf("frontend/src/%s/list.tsx", ctx.Resource.Package), content: []byte(renderListTSX(ctx))},
-		fileSpec{relPath: fmt.Sprintf("frontend/src/%s/form.tsx", ctx.Resource.Package), content: []byte(renderFormTSX(ctx))},
+		fileSpec{relPath: fmt.Sprintf("frontend/src/%s/list.tsx", ctx.Resource.Package), content: []byte(renderListTSX(tsxCtx))},
+		fileSpec{relPath: fmt.Sprintf("frontend/src/%s/form.tsx", ctx.Resource.Package), content: []byte(renderFormTSX(tsxCtx))},
 	)
 	return files, nil
 }
@@ -150,6 +155,7 @@ func renderModel(ctx renderContext) string {
 	if fieldsUse(ctx.Fields, FieldDecimal) {
 		third = append(third, gombitTypesImport)
 	}
+	third = append(third, targetImports(ctx)...)
 	b.WriteString(importBlock(std, third))
 	b.WriteString("// ")
 	b.WriteString(ctx.Resource.TypeName)
@@ -158,19 +164,51 @@ func renderModel(ctx renderContext) string {
 	b.WriteString(ctx.Resource.TypeName)
 	b.WriteString(" struct {\n\tgorm.Model\n")
 	for _, field := range ctx.Fields {
-		b.WriteByte('\t')
-		b.WriteString(field.GoName)
-		b.WriteByte(' ')
-		b.WriteString(field.GoType)
-		if tag := field.gormTag(); tag != "" {
-			b.WriteString(" `gorm:\"")
-			b.WriteString(tag)
-			b.WriteString("\"`")
-		}
-		b.WriteByte('\n')
+		b.WriteString(modelFieldLines(field, ctx.Resource.Package))
 	}
 	b.WriteString("}\n")
 	return b.String()
+}
+
+// targetImports returns the distinct feature-package import paths for the
+// relation fields' target models (internal/<target>).
+func targetImports(ctx renderContext) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, f := range ctx.Fields {
+		if !f.isRelation() {
+			continue
+		}
+		imp := ctx.Module + "/internal/" + f.TargetPkg
+		if _, ok := seen[imp]; ok {
+			continue
+		}
+		seen[imp] = struct{}{}
+		out = append(out, imp)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// modelFieldLines renders the struct field line(s) for one model field. A
+// belongs_to emits the foreign key plus the association; has_many / m2m emit the
+// association slice (m2m carries the join-table tag).
+func modelFieldLines(f Field, resourcePkg string) string {
+	switch f.Type {
+	case FieldBelongsTo:
+		return "\t" + f.fkGoName() + " uint `gorm:\"index\"`\n" +
+			"\t" + f.GoName + " " + f.GoType + "\n"
+	case FieldHasMany:
+		return "\t" + f.GoName + " " + f.GoType + "\n"
+	case FieldManyToMany:
+		return "\t" + f.GoName + " " + f.GoType + " `gorm:\"many2many:" + f.joinTable(resourcePkg) + ";\"`\n"
+	default:
+		line := "\t" + f.GoName + " " + f.GoType
+		if tag := f.gormTag(); tag != "" {
+			line += " `gorm:\"" + tag + "\"`"
+		}
+		return line + "\n"
+	}
 }
 
 func renderHandler(ctx renderContext) string {
@@ -202,7 +240,10 @@ func renderHandler(ctx renderContext) string {
 	b.WriteString("type " + data + " struct {\n")
 	b.WriteString("\tID uint `json:\"id\" example:\"1\" doc:\"" + typ + " identifier\"`\n")
 	for _, field := range ctx.Fields {
-		b.WriteString("\t" + field.GoName + " " + field.GoType + " `" + field.jsonTag() + " doc:\"" + field.GoName + "\"`\n")
+		if !field.inDTO() {
+			continue
+		}
+		b.WriteString("\t" + field.dtoGoName() + " " + field.dtoGoType() + " `json:\"" + field.dtoJSONName() + "\" doc:\"" + field.dtoGoName() + "\"`\n")
 	}
 	b.WriteString("}\n\n")
 	listOut := "list" + ctx.Resource.Tag + "Output"
@@ -218,7 +259,10 @@ func renderHandler(ctx renderContext) string {
 	b.WriteString("\tBody contract.Data[" + data + "]\n}\n\n")
 	b.WriteString("type create" + typ + "Input struct {\n\tBody struct {\n")
 	for _, field := range ctx.Fields {
-		b.WriteString("\t\t" + field.GoName + " " + field.GoType + " `" + field.humaTags() + "`\n")
+		if !field.inDTO() {
+			continue
+		}
+		b.WriteString("\t\t" + field.dtoGoName() + " " + field.dtoGoType() + " `" + field.dtoHumaTags() + "`\n")
 	}
 	b.WriteString("\t}\n}\n\n")
 	b.WriteString("type create" + typ + "Output struct {\n")
@@ -260,7 +304,10 @@ func renderHandler(ctx renderContext) string {
 	b.WriteString("func (h *Handler) create(ctx context.Context, input *create" + typ + "Input) (*create" + typ + "Output, error) {\n")
 	b.WriteString("\trow := " + typ + "{\n")
 	for _, field := range ctx.Fields {
-		b.WriteString("\t\t" + field.GoName + ": input.Body." + field.GoName + ",\n")
+		if !field.inDTO() {
+			continue
+		}
+		b.WriteString("\t\t" + field.dtoGoName() + ": input.Body." + field.dtoGoName() + ",\n")
 	}
 	b.WriteString("\t}\n")
 	b.WriteString("\tif err := h.DB.WithContext(ctx).Create(&row).Error; err != nil {\n")
@@ -273,7 +320,10 @@ func renderHandler(ctx renderContext) string {
 	b.WriteString("func to" + typ + "Data(row " + typ + ") " + data + " {\n")
 	b.WriteString("\treturn " + data + "{ID: row.ID")
 	for _, field := range ctx.Fields {
-		b.WriteString(", " + field.GoName + ": row." + field.GoName)
+		if !field.inDTO() {
+			continue
+		}
+		b.WriteString(", " + field.dtoGoName() + ": row." + field.dtoGoName())
 	}
 	b.WriteString("}\n}\n")
 	return b.String()

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -171,13 +171,12 @@ func renderModel(ctx renderContext) string {
 }
 
 // targetImports returns the distinct feature-package import paths for the
-// relation fields' target models (internal/<target>). A self-referential
-// belongs_to targets the resource's own package and imports nothing.
+// relation fields' target models (internal/<target>).
 func targetImports(ctx renderContext) []string {
 	seen := map[string]struct{}{}
 	var out []string
 	for _, f := range ctx.Fields {
-		if !f.isRelation() || f.TargetPkg == ctx.Resource.Package {
+		if !f.isRelation() {
 			continue
 		}
 		imp := ctx.Module + "/internal/" + f.TargetPkg

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -171,12 +171,13 @@ func renderModel(ctx renderContext) string {
 }
 
 // targetImports returns the distinct feature-package import paths for the
-// relation fields' target models (internal/<target>).
+// relation fields' target models (internal/<target>). A self-referential
+// belongs_to targets the resource's own package and imports nothing.
 func targetImports(ctx renderContext) []string {
 	seen := map[string]struct{}{}
 	var out []string
 	for _, f := range ctx.Fields {
-		if !f.isRelation() {
+		if !f.isRelation() || f.TargetPkg == ctx.Resource.Package {
 			continue
 		}
 		imp := ctx.Module + "/internal/" + f.TargetPkg

--- a/resourcegen/files_test.go
+++ b/resourcegen/files_test.go
@@ -116,3 +116,51 @@ func TestRenderMUIFormNewTypes(t *testing.T) {
 		}
 	}
 }
+
+// TestRenderRelations checks the generated model has the FK + associations +
+// target imports, and the thin handler DTO exposes belongs_to as its FK but
+// omits many_to_many / has_many (#222 part b).
+func TestRenderRelations(t *testing.T) {
+	fields, err := parseFields([]string{
+		"engine:belongs_to:Engine",
+		"parts:has_many:Part",
+		"warehouses:many_to_many:Warehouse",
+	})
+	if err != nil {
+		t.Fatalf("parseFields: %v", err)
+	}
+	name, err := parseResourceName("Rental")
+	if err != nil {
+		t.Fatalf("parseResourceName: %v", err)
+	}
+	ctx := newRenderContext("github.com/example/demo", name, fields, "/api/v1", "minimal", false, false)
+	collapse := func(s string) string { return strings.Join(strings.Fields(s), " ") }
+	model := collapse(string(mustFormatGo(renderModel(ctx))))
+	handler := collapse(string(mustFormatGo(renderHandler(ctx))))
+	if strings.Contains(model, "format error") || strings.Contains(handler, "format error") {
+		t.Fatalf("did not gofmt-parse:\nmodel:\n%s\nhandler:\n%s", model, handler)
+	}
+
+	for _, want := range []string{
+		`"github.com/example/demo/internal/engine"`,
+		`"github.com/example/demo/internal/part"`,
+		`"github.com/example/demo/internal/warehouse"`,
+		"EngineID uint",
+		"Engine engine.Engine",
+		"Parts []part.Part",
+		"Warehouses []warehouse.Warehouse",
+		"many2many:rental_warehouses",
+	} {
+		if !strings.Contains(model, want) {
+			t.Fatalf("model missing %q:\n%s", want, model)
+		}
+	}
+
+	// Thin handler DTO: belongs_to FK present, collection relations absent.
+	if !strings.Contains(handler, "EngineID uint") || !strings.Contains(handler, `json:"engine_id"`) {
+		t.Fatalf("handler DTO missing engine_id FK:\n%s", handler)
+	}
+	if strings.Contains(handler, "Warehouses") || strings.Contains(handler, "Parts") {
+		t.Fatalf("handler DTO must not carry m2m/has_many fields:\n%s", handler)
+	}
+}

--- a/resourcegen/files_test.go
+++ b/resourcegen/files_test.go
@@ -14,7 +14,7 @@ func TestRenderNewScalarTypes(t *testing.T) {
 		"price:decimal:required",
 		"starts_at:time:required",
 		"status:enum(requested,confirmed,active)",
-	})
+	}, "rental")
 	if err != nil {
 		t.Fatalf("parseFields: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestRenderMinimalFormNewTypes(t *testing.T) {
 		"price:decimal:required",
 		"starts_at:time",
 		"status:enum(a,b)",
-	})
+	}, "rental")
 	if err != nil {
 		t.Fatalf("parseFields: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestRenderMUIFormNewTypes(t *testing.T) {
 		"price:decimal:required",
 		"starts_at:time",
 		"status:enum(a,b)",
-	})
+	}, "rental")
 	if err != nil {
 		t.Fatalf("parseFields: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestRenderRelations(t *testing.T) {
 		"engine:belongs_to:Engine",
 		"parts:has_many:Part",
 		"warehouses:many_to_many:Warehouse",
-	})
+	}, "rental")
 	if err != nil {
 		t.Fatalf("parseFields: %v", err)
 	}
@@ -162,5 +162,36 @@ func TestRenderRelations(t *testing.T) {
 	}
 	if strings.Contains(handler, "Warehouses") || strings.Contains(handler, "Parts") {
 		t.Fatalf("handler DTO must not carry m2m/has_many fields:\n%s", handler)
+	}
+}
+
+// TestRenderSelfBelongsTo checks a self-referential belongs_to (a tree parent)
+// renders the local type and imports nothing — no `category.Category` and no
+// self-import inside package category, which would not compile (#222 review).
+func TestRenderSelfBelongsTo(t *testing.T) {
+	fields, err := parseFields([]string{"parent:belongs_to:Category"}, "category")
+	if err != nil {
+		t.Fatalf("parseFields: %v", err)
+	}
+	name, err := parseResourceName("Category")
+	if err != nil {
+		t.Fatalf("parseResourceName: %v", err)
+	}
+	ctx := newRenderContext("github.com/example/demo", name, fields, "/api/v1", "minimal", false, false)
+	collapse := func(s string) string { return strings.Join(strings.Fields(s), " ") }
+	model := collapse(string(mustFormatGo(renderModel(ctx))))
+	if strings.Contains(model, "format error") {
+		t.Fatalf("model did not gofmt-parse:\n%s", model)
+	}
+	if strings.Contains(model, "internal/category") {
+		t.Fatalf("self belongs_to must not emit a self-import:\n%s", model)
+	}
+	for _, want := range []string{"ParentID uint", "Parent *Category"} {
+		if !strings.Contains(model, want) {
+			t.Fatalf("model missing %q:\n%s", want, model)
+		}
+	}
+	if strings.Contains(model, "category.Category") {
+		t.Fatalf("self belongs_to must use the local type, not category.Category:\n%s", model)
 	}
 }

--- a/resourcegen/files_test.go
+++ b/resourcegen/files_test.go
@@ -164,34 +164,3 @@ func TestRenderRelations(t *testing.T) {
 		t.Fatalf("handler DTO must not carry m2m/has_many fields:\n%s", handler)
 	}
 }
-
-// TestRenderSelfBelongsTo checks a self-referential belongs_to (a tree parent)
-// renders the local type and imports nothing — no `category.Category` and no
-// self-import inside package category, which would not compile (#222 review).
-func TestRenderSelfBelongsTo(t *testing.T) {
-	fields, err := parseFields([]string{"parent:belongs_to:Category"}, "category")
-	if err != nil {
-		t.Fatalf("parseFields: %v", err)
-	}
-	name, err := parseResourceName("Category")
-	if err != nil {
-		t.Fatalf("parseResourceName: %v", err)
-	}
-	ctx := newRenderContext("github.com/example/demo", name, fields, "/api/v1", "minimal", false, false)
-	collapse := func(s string) string { return strings.Join(strings.Fields(s), " ") }
-	model := collapse(string(mustFormatGo(renderModel(ctx))))
-	if strings.Contains(model, "format error") {
-		t.Fatalf("model did not gofmt-parse:\n%s", model)
-	}
-	if strings.Contains(model, "internal/category") {
-		t.Fatalf("self belongs_to must not emit a self-import:\n%s", model)
-	}
-	for _, want := range []string{"ParentID uint", "Parent *Category"} {
-		if !strings.Contains(model, want) {
-			t.Fatalf("model missing %q:\n%s", want, model)
-		}
-	}
-	if strings.Contains(model, "category.Category") {
-		t.Fatalf("self belongs_to must use the local type, not category.Category:\n%s", model)
-	}
-}

--- a/resourcegen/generate.go
+++ b/resourcegen/generate.go
@@ -37,7 +37,7 @@ func Generate(ctx context.Context, opts Options) error {
 	if err := checkHTTPPathConflict(opts.WorkDir, name); err != nil {
 		return err
 	}
-	fields, err := parseFields(opts.Fields)
+	fields, err := parseFields(opts.Fields, name.Package)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Completes **#222 part (b)** — relationships in the `make resource` field grammar, using `name:kind:Target` where `Target` is a model in `internal/<target>/`.

- **`belongs_to:Engine`** → the model gets `EngineID uint` (indexed FK) **+** `Engine engine.Engine` (association). The thin CRUD handler exposes **`engine_id`** in its DTO; the admin renders a picker.
- **`many_to_many:Warehouse`** → `Warehouses []warehouse.Warehouse` with a `many2many:<resource>_<field>` join-table tag (GORM/Atlas create the join table).
- **`has_many:Part`** → `Parts []part.Part`. The child model must carry the parent FK itself (`RentalID`); the generator does not edit the child — that would be an import cycle.

The generated model imports each target feature-package (`module/internal/<target>`). Per the confirmed design, the generated CRUD stays **thin**: `belongs_to` is exposed as its FK; `many_to_many`/`has_many` are **model-only** (so migrations create the FK/join-table and the admin's relation widgets — belongs_to picker, m2m multi-select, has_many read view — pick them up), never bloating the REST handler. The generated frontend/DTO see only the `belongs_to` FK.

Closes #222.

## Acceptance criteria (from the issue)

- [x] `belongs_to` / `has_many` / `many_to_many` in the field grammar generate the FK/association + admin registration hints
- [x] Generated handler DTO and model stay in sync (belongs_to FK exposed; collection relations model-only) — no #218-style drift
- [x] Scalar types (decimal/time/enum) — landed in #229 (part a)

## Validation

- [x] `go test ./...`
- [x] `goldentest`: `TestMakeResourceRelationsCompiles` generates the target models + a `Rental` with all three relation kinds and **compiles the app** against the local framework; the scalar make-resource golden is unchanged
- [x] `resourcegen`: relation parsing (kinds, target/pkg/GoType, FK names, DTO membership) and model/handler rendering (FK + associations + imports; DTO omits m2m/has_many)
- [x] `golangci-lint run ./resourcegen/... ./cli/...` — 0 issues

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — *generation only; the generated GORM associations use standard tags exercised across the matrix; compile-tested*
- [x] Stable features ship docs and appear in an example app — *`docs/cli.md` + `gombit make resource --help` + CHANGELOG; the compile test's generated app exercises all three kinds*
- [x] Extraction preserves contracts — refactor and move, don't rewrite
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — *relation fields reuse the same additive model/handler generation; Go source edited via go/ast as before*
- [x] API changes regenerate the OpenAPI doc + TS client in this PR — *N/A: relations only appear in generated apps, which regenerate their own client*
- [x] No secrets in generated frontend source; `VITE_*` is treated as public
- [x] Scope stays inside this issue's milestone
- [x] This PR links its issue and states which acceptance criteria it satisfies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
