### PR TITLE
[feature] admin relations: Postgres/MySQL matrix + example app (#223)

### DIFF
--- a/admin/fields.go
+++ b/admin/fields.go
@@ -88,8 +88,9 @@ func FieldsFrom(model any) ([]Field, error) {
 			Name: relationFieldName(rel.Field),
 			Type: TypeRelation,
 			Related: &Relation{
-				Kind: RelManyToMany,
-				Slug: rel.FieldSchema.Table,
+				Kind:       RelManyToMany,
+				Slug:       rel.FieldSchema.Table,
+				LabelField: labelFieldFor(rel.FieldSchema),
 			},
 		})
 	}

--- a/admin/integration_test.go
+++ b/admin/integration_test.go
@@ -118,9 +118,9 @@ func runRelationsDriver(t *testing.T, driver config.DatabaseDriver, dsn string) 
 	// registered after openAdminDriver's cleanup, so it runs first (LIFO).
 	t.Cleanup(func() {
 		_ = db.Migrator().DropTable("engine_warehouses")
-		_ = db.Migrator().DropTable(&hmPart{}, &relEngine{}, &belongsEngine{}, &hmMachine{}, &relWarehouse{})
+		_ = db.Migrator().DropTable(&hmPart{}, &relEngine{}, &optBelongsEngine{}, &hmMachine{}, &relWarehouse{})
 	})
-	if err := db.AutoMigrate(&relWarehouse{}, &relEngine{}, &belongsEngine{}, &hmMachine{}, &hmPart{}); err != nil {
+	if err := db.AutoMigrate(&relWarehouse{}, &relEngine{}, &optBelongsEngine{}, &hmMachine{}, &hmPart{}); err != nil {
 		t.Fatalf("AutoMigrate relations: %v", err)
 	}
 	app := newCookieAppWithDB(t, db)
@@ -137,7 +137,7 @@ func runRelationsDriver(t *testing.T, driver config.DatabaseDriver, dsn string) 
 			Kind: admin.RelManyToMany, Slug: "warehouses", LabelField: "name",
 		}},
 	}})
-	mustRegister(belongsEngine{}, admin.Options{Slug: "belongs-engines"})
+	mustRegister(optBelongsEngine{}, admin.Options{Slug: "belongs-engines"})
 	mustRegister(hmMachine{}, admin.Options{Slug: "machines"})
 	jar := loginSuperuser(t, app)
 
@@ -204,9 +204,25 @@ func assertManyToManyRoundTrip(t *testing.T, app *framework.App, jar *cookieJar)
 }
 
 // assertBelongsToRoundTrip writes a belongs_to FK through the derived relation
-// field and reads it back.
+// field and reads it back, and checks that an omitted (nullable) FK is accepted
+// and stored as null — the case where DB foreign-key enforcement differs and a
+// non-nullable uint FK would reject "no parent".
 func assertBelongsToRoundTrip(t *testing.T, app *framework.App, jar *cookieJar) {
 	t.Helper()
+
+	// Optional belongs_to: omitting the FK must succeed and read back null.
+	none := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/belongs-engines", `{"name":"Loose"}`)
+	if none.Code != http.StatusOK {
+		t.Fatalf("create without FK status = %d; body: %s (optional belongs_to must accept none under FK enforcement)", none.Code, none.Body.String())
+	}
+	var noneEnv rowEnvelope
+	if err := json.Unmarshal(none.Body.Bytes(), &noneEnv); err != nil {
+		t.Fatalf("decode create-without-fk: %v", err)
+	}
+	if v, ok := noneEnv.Data["warehouse_id"]; !ok || v != nil {
+		t.Fatalf("warehouse_id = %#v, want null when omitted", noneEnv.Data["warehouse_id"])
+	}
+
 	w := createWarehouse(t, app, jar, "Depot")
 	create := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/belongs-engines",
 		fmt.Sprintf(`{"name":"I4","warehouse_id":%d}`, w))

--- a/admin/integration_test.go
+++ b/admin/integration_test.go
@@ -7,11 +7,15 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"reflect"
+	"sort"
 	"testing"
 
+	"github.com/gombit-dev/gombit/admin"
 	"github.com/gombit-dev/gombit/auth"
 	"github.com/gombit-dev/gombit/config"
 	"github.com/gombit-dev/gombit/database"
+	"github.com/gombit-dev/gombit/framework"
 	"github.com/gin-gonic/gin"
 )
 
@@ -85,4 +89,172 @@ func openAdminDriver(t *testing.T, driver config.DatabaseDriver, dsn string) *da
 		_ = db.Close()
 	})
 	return db
+}
+
+// TestRelationsPostgres / TestRelationsMySQL run the belongs_to / has_many /
+// many_to_many admin round-trips (join-table sync, FK write, has_many preload)
+// against a real Postgres / MySQL, complementing the SQLite coverage in
+// relations_test.go. These paths emit engine-specific SQL, so the matrix is the
+// point (working agreement §5.1).
+func TestRelationsPostgres(t *testing.T) {
+	if *postgresDSN == "" {
+		t.Skip("set -admin.postgres-dsn to run Postgres admin integration tests")
+	}
+	runRelationsDriver(t, config.DatabaseDriverPostgres, *postgresDSN)
+}
+
+func TestRelationsMySQL(t *testing.T) {
+	if *mysqlDSN == "" {
+		t.Skip("set -admin.mysql-dsn to run MySQL admin integration tests")
+	}
+	runRelationsDriver(t, config.DatabaseDriverMySQL, *mysqlDSN)
+}
+
+func runRelationsDriver(t *testing.T, driver config.DatabaseDriver, dsn string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db := openAdminDriver(t, driver, dsn)
+	// Drop the relation tables (join and children before parents) after the run;
+	// registered after openAdminDriver's cleanup, so it runs first (LIFO).
+	t.Cleanup(func() {
+		_ = db.Migrator().DropTable("engine_warehouses")
+		_ = db.Migrator().DropTable(&hmPart{}, &relEngine{}, &belongsEngine{}, &hmMachine{}, &relWarehouse{})
+	})
+	if err := db.AutoMigrate(&relWarehouse{}, &relEngine{}, &belongsEngine{}, &hmMachine{}, &hmPart{}); err != nil {
+		t.Fatalf("AutoMigrate relations: %v", err)
+	}
+	app := newCookieAppWithDB(t, db)
+	mustRegister := func(model any, opts admin.Options) {
+		if err := admin.Register(app, model, opts); err != nil {
+			t.Fatalf("Register %s: %v", opts.Slug, err)
+		}
+	}
+	mustRegister(relWarehouse{}, admin.Options{Slug: "warehouses"})
+	mustRegister(relEngine{}, admin.Options{Slug: "engines", Fields: []admin.Field{
+		{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+		{Name: "name", Type: admin.TypeString, Required: true},
+		{Name: "warehouses", Type: admin.TypeRelation, Related: &admin.Relation{
+			Kind: admin.RelManyToMany, Slug: "warehouses", LabelField: "name",
+		}},
+	}})
+	mustRegister(belongsEngine{}, admin.Options{Slug: "belongs-engines"})
+	mustRegister(hmMachine{}, admin.Options{Slug: "machines"})
+	jar := loginSuperuser(t, app)
+
+	assertManyToManyRoundTrip(t, app, jar)
+	assertBelongsToRoundTrip(t, app, jar)
+	assertHasManyRead(t, app, jar)
+}
+
+// assertManyToManyRoundTrip drives create-with-ids, read-back, shrink, the
+// bad-id 422 that must roll back the whole write (persist + join sync share one
+// transaction), and clear-to-empty — the DB-touching join-table path.
+func assertManyToManyRoundTrip(t *testing.T, app *framework.App, jar *cookieJar) {
+	t.Helper()
+	w1 := createWarehouse(t, app, jar, "North")
+	w2 := createWarehouse(t, app, jar, "South")
+
+	create := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/engines",
+		fmt.Sprintf(`{"name":"V8","warehouses":[%d,%d]}`, w1, w2))
+	if create.Code != http.StatusOK {
+		t.Fatalf("m2m create status = %d; body: %s", create.Code, create.Body.String())
+	}
+	var created rowEnvelope
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode m2m create: %v", err)
+	}
+	engineID := asInt(created.Data["id"])
+	path := fmt.Sprintf("/api/v1/admin/resources/engines/%d", engineID)
+	if ids := idsOf(t, created.Data["warehouses"]); len(ids) != 2 {
+		t.Fatalf("created warehouses = %v, want 2", ids)
+	}
+
+	get := doRequest(app, jar, http.MethodGet, path, "")
+	var got rowEnvelope
+	if err := json.Unmarshal(get.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode m2m get: %v", err)
+	}
+	if ids := idsOf(t, got.Data["warehouses"]); len(ids) != 2 {
+		t.Fatalf("get warehouses = %v, want 2 (join round-trip)", ids)
+	}
+
+	patch := doRequest(app, jar, http.MethodPatch, path, fmt.Sprintf(`{"warehouses":[%d]}`, w1))
+	var patched rowEnvelope
+	_ = json.Unmarshal(patch.Body.Bytes(), &patched)
+	if ids := idsOf(t, patched.Data["warehouses"]); len(ids) != 1 || ids[0] != w1 {
+		t.Fatalf("patched warehouses = %v, want [%d]", ids, w1)
+	}
+
+	bad := doRequest(app, jar, http.MethodPatch, path, `{"name":"should-not-stick","warehouses":[999999]}`)
+	assertError(t, bad, http.StatusUnprocessableEntity, "validation_error")
+	var afterBad relEngine
+	if err := app.DB().First(&afterBad, engineID).Error; err != nil {
+		t.Fatalf("reload after bad patch: %v", err)
+	}
+	if afterBad.Name != "V8" {
+		t.Fatalf("name = %q after failed patch, want unchanged V8 (scalar must roll back with the join sync)", afterBad.Name)
+	}
+
+	clear := doRequest(app, jar, http.MethodPatch, path, `{"warehouses":[]}`)
+	var cleared rowEnvelope
+	_ = json.Unmarshal(clear.Body.Bytes(), &cleared)
+	if ids := idsOf(t, cleared.Data["warehouses"]); len(ids) != 0 {
+		t.Fatalf("cleared warehouses = %v, want empty", ids)
+	}
+}
+
+// assertBelongsToRoundTrip writes a belongs_to FK through the derived relation
+// field and reads it back.
+func assertBelongsToRoundTrip(t *testing.T, app *framework.App, jar *cookieJar) {
+	t.Helper()
+	w := createWarehouse(t, app, jar, "Depot")
+	create := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/belongs-engines",
+		fmt.Sprintf(`{"name":"I4","warehouse_id":%d}`, w))
+	if create.Code != http.StatusOK {
+		t.Fatalf("belongs_to create status = %d; body: %s", create.Code, create.Body.String())
+	}
+	var created rowEnvelope
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode belongs_to create: %v", err)
+	}
+	if got := asInt(created.Data["warehouse_id"]); got != w {
+		t.Fatalf("created warehouse_id = %d, want %d", got, w)
+	}
+	id := asInt(created.Data["id"])
+	get := doRequest(app, jar, http.MethodGet, fmt.Sprintf("/api/v1/admin/resources/belongs-engines/%d", id), "")
+	var got rowEnvelope
+	if err := json.Unmarshal(get.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode belongs_to get: %v", err)
+	}
+	if id := asInt(got.Data["warehouse_id"]); id != w {
+		t.Fatalf("get warehouse_id = %d, want %d (FK must round-trip)", id, w)
+	}
+}
+
+// assertHasManyRead seeds a parent with children and checks the read-only
+// has_many preload returns the child ids, and that a write to it is rejected.
+func assertHasManyRead(t *testing.T, app *framework.App, jar *cookieJar) {
+	t.Helper()
+	machine := hmMachine{Name: "Lathe"}
+	if err := app.DB().Create(&machine).Error; err != nil {
+		t.Fatalf("create machine: %v", err)
+	}
+	children := []hmPart{{Name: "Chuck", MachineID: machine.ID}, {Name: "Bed", MachineID: machine.ID}}
+	if err := app.DB().Create(&children).Error; err != nil {
+		t.Fatalf("create parts: %v", err)
+	}
+	want := []int64{asInt(children[0].ID), asInt(children[1].ID)}
+	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+
+	path := fmt.Sprintf("/api/v1/admin/resources/machines/%d", machine.ID)
+	get := doRequest(app, jar, http.MethodGet, path, "")
+	var got rowEnvelope
+	if err := json.Unmarshal(get.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode machine get: %v", err)
+	}
+	if ids := idsOf(t, got.Data["parts"]); !reflect.DeepEqual(ids, want) {
+		t.Fatalf("detail parts = %v, want preloaded child PKs %v", ids, want)
+	}
+	patch := doRequest(app, jar, http.MethodPatch, path, fmt.Sprintf(`{"parts":[%d]}`, want[0]))
+	assertError(t, patch, http.StatusUnprocessableEntity, "validation_error")
 }

--- a/admin/relations_test.go
+++ b/admin/relations_test.go
@@ -661,4 +661,9 @@ func TestManyToManyAutoDerivation(t *testing.T) {
 	if found.Related.Slug != "warehouses" {
 		t.Fatalf("warehouses slug = %q, want warehouses (related table)", found.Related.Slug)
 	}
+	// The multi-select needs a human label, like belongs_to and has_many — not a
+	// blank that renders raw ids.
+	if found.Related.LabelField != "name" {
+		t.Fatalf("warehouses label_field = %q, want name (auto-derived, consistent with belongs_to/has_many)", found.Related.LabelField)
+	}
 }

--- a/admin/relations_test.go
+++ b/admin/relations_test.go
@@ -582,6 +582,83 @@ func TestBelongsToLabelIsFieldName(t *testing.T) {
 	t.Fatalf("derived fields %v missing warehouse_id", fields)
 }
 
+type optBelongsEngine struct {
+	ID          uint         `gorm:"primaryKey" json:"id"`
+	Name        string       `json:"name"`
+	WarehouseID *uint        `gorm:"index" json:"warehouse_id"`
+	Warehouse   relWarehouse `json:"-"`
+}
+
+func (optBelongsEngine) TableName() string { return "opt_belongs_engines" }
+
+// TestBelongsToOptionalNullable verifies that a belongs_to backed by a nullable
+// (*uint) foreign key is genuinely optional: FieldsFrom marks it not-required,
+// a create omitting it succeeds and reads back null (not rejected by the FK),
+// and a create naming a real target sets it. This is the contract the admin
+// advertises (belongs_to required=false); a non-nullable uint FK would reject
+// "no parent" under foreign key enforcement. See #223 / the #238 review.
+func TestBelongsToOptionalNullable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&relWarehouse{}, &optBelongsEngine{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	if err := admin.Register(app, relWarehouse{}, admin.Options{Slug: "warehouses"}); err != nil {
+		t.Fatalf("Register warehouse: %v", err)
+	}
+	if err := admin.Register(app, optBelongsEngine{}, admin.Options{Slug: "engines"}); err != nil {
+		t.Fatalf("Register engine: %v", err)
+	}
+
+	// Derivation marks the nullable FK optional.
+	fields, err := admin.FieldsFrom(optBelongsEngine{})
+	if err != nil {
+		t.Fatalf("FieldsFrom: %v", err)
+	}
+	var fk *admin.Field
+	for i := range fields {
+		if fields[i].Name == "warehouse_id" {
+			fk = &fields[i]
+		}
+	}
+	if fk == nil || fk.Related == nil || fk.Related.Kind != admin.RelBelongsTo {
+		t.Fatalf("warehouse_id = %+v, want belongs_to relation", fk)
+	}
+	if fk.Required {
+		t.Fatalf("nullable belongs_to FK must not be Required")
+	}
+
+	jar := loginSuperuser(t, app)
+
+	// Create with no warehouse: must succeed and read back null.
+	create := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/engines", `{"name":"Loose"}`)
+	if create.Code != http.StatusOK {
+		t.Fatalf("create without FK status = %d; body: %s (optional belongs_to must accept none)", create.Code, create.Body.String())
+	}
+	var created rowEnvelope
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if v, ok := created.Data["warehouse_id"]; !ok || v != nil {
+		t.Fatalf("warehouse_id = %#v, want null on a create that omits it", created.Data["warehouse_id"])
+	}
+
+	// Create naming a real warehouse: FK round-trips.
+	w := createWarehouse(t, app, jar, "North")
+	set := doRequest(app, jar, http.MethodPost, "/api/v1/admin/resources/engines",
+		fmt.Sprintf(`{"name":"Bolt","warehouse_id":%d}`, w))
+	if set.Code != http.StatusOK {
+		t.Fatalf("create with FK status = %d; body: %s", set.Code, set.Body.String())
+	}
+	var withFK rowEnvelope
+	if err := json.Unmarshal(set.Body.Bytes(), &withFK); err != nil {
+		t.Fatalf("decode create-with-fk: %v", err)
+	}
+	if got := asInt(withFK.Data["warehouse_id"]); got != w {
+		t.Fatalf("warehouse_id = %d, want %d", got, w)
+	}
+}
+
 // TestBelongsToAutoDerivationRoundTrip exercises the full picker contract: both
 // models are registered with auto-derived fields (empty Fields), the belongs_to
 // FK is written through the derived relation field, and it reads back — plus the

--- a/examples/admin/README.md
+++ b/examples/admin/README.md
@@ -1,12 +1,33 @@
-# Admin example (ADMIN-1 through ADMIN-3)
+# Admin example (ADMIN-1 through ADMIN-3, relationships #223)
 
 Minimal `framework.App` with `Config.Auth.Mode = config.AuthModeCookie`,
-SQLite, and an explicit `admin.Register` of a small `widget.Widget` model.
-`framework.New` mounts empty admin Huma routes and the framework-owned
-SPA under `/admin/` in cookie mode; this example registers one model from
-the feature package. JWT-only apps do not get these routes.
+SQLite, and `admin.Register` of a `widget.Widget` model plus its relation
+targets (`warehouse.Warehouse`, `part.Part`). `framework.New` mounts empty
+admin Huma routes and the framework-owned SPA under `/admin/` in cookie mode;
+this example registers three models from their feature packages. JWT-only apps
+do not get these routes.
 
-See [`docs/admin.md`](../../docs/admin.md) and
+## Relationships (#223)
+
+`Widget` carries all three relation kinds, and its `RegisterAdmin` leaves
+`Fields` empty so `admin.FieldsFrom` derives them from the GORM model — no
+per-field wiring:
+
+- **belongs_to** — `WarehouseID` + `Warehouse` derive to a `warehouse_id`
+  picker backed by the `warehouses` list, labelled by `name`.
+- **many_to_many** — `Warehouses []warehouse.Warehouse`
+  (`many2many:widget_warehouses`) derives to a multi-select; a write syncs the
+  join table in the same transaction as the row.
+- **has_many** — `Parts []part.Part` derives to a **read-only** view of the
+  children's ids (`Part` carries the `widget_id` back-reference). A write to it
+  is rejected.
+
+`Part.widget_id` is a plain integer, not a picker: `Part` cannot hold a
+`Widget` association without an import cycle, which is the same constraint
+`gombit make resource ... has_many:Part` documents.
+
+See [`docs/admin.md`](../../docs/admin.md),
+[`docs/cli.md`](../../docs/cli.md) (relation grammar), and
 [ADR-013](../../docs/adr/013-runtime-generic-admin.md).
 
 ## Run

--- a/examples/admin/README.md
+++ b/examples/admin/README.md
@@ -13,8 +13,11 @@ do not get these routes.
 `Fields` empty so `admin.FieldsFrom` derives them from the GORM model — no
 per-field wiring:
 
-- **belongs_to** — `WarehouseID` + `Warehouse` derive to a `warehouse_id`
-  picker backed by the `warehouses` list, labelled by `name`.
+- **belongs_to** — `WarehouseID` (a `*uint`, so genuinely optional) +
+  `Warehouse` derive to a `warehouse_id` picker backed by the `warehouses` list,
+  labelled by `name`. Leaving it unset stores `NULL`; the create still
+  succeeds (a non-nullable `uint` FK would reject "no warehouse" under foreign
+  key enforcement).
 - **many_to_many** — `Warehouses []warehouse.Warehouse`
   (`many2many:widget_warehouses`) derives to a multi-select; a write syncs the
   join table in the same transaction as the row.

--- a/examples/admin/internal/part/admin.go
+++ b/examples/admin/internal/part/admin.go
@@ -1,0 +1,28 @@
+package part
+
+import (
+	"github.com/gombit-dev/gombit/admin"
+	"github.com/gombit-dev/gombit/framework"
+)
+
+// RegisterAdmin registers Part on the runtime admin. Widget reads Parts as a
+// read-only has_many; here the back-reference (widget_id) is a plain integer,
+// because Part cannot hold a Widget association without an import cycle.
+func RegisterAdmin(app *framework.App) error {
+	return admin.Register(app, Part{}, admin.Options{
+		Slug:     "parts",
+		Singular: "Part",
+		Plural:   "Parts",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "name", Type: admin.TypeString, Required: true},
+			{Name: "widget_id", Type: admin.TypeInteger},
+		},
+		List:     []string{"name", "widget_id"},
+		Search:   []string{"name"},
+		Ordering: []string{"name", "created_at"},
+		Actions: admin.Actions{
+			List: true, Detail: true, Create: true, Update: true, Delete: true,
+		},
+	})
+}

--- a/examples/admin/internal/part/part.go
+++ b/examples/admin/internal/part/part.go
@@ -1,0 +1,14 @@
+package part
+
+import "time"
+
+// Part is a child of Widget: it carries the parent foreign key (WidgetID) as a
+// plain column, which is what a has_many relation reads from. The parent
+// (Widget) is not imported here — that would be an import cycle.
+type Part struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	Name      string    `json:"name"`
+	WidgetID  uint      `gorm:"index" json:"widget_id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/examples/admin/internal/warehouse/admin.go
+++ b/examples/admin/internal/warehouse/admin.go
@@ -1,0 +1,27 @@
+package warehouse
+
+import (
+	"github.com/gombit-dev/gombit/admin"
+	"github.com/gombit-dev/gombit/framework"
+)
+
+// RegisterAdmin registers Warehouse on the runtime admin. It is the target of
+// Widget's belongs_to and many_to_many relations, so its slug ("warehouses")
+// must match the relation metadata the pickers resolve against.
+func RegisterAdmin(app *framework.App) error {
+	return admin.Register(app, Warehouse{}, admin.Options{
+		Slug:     "warehouses",
+		Singular: "Warehouse",
+		Plural:   "Warehouses",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "name", Type: admin.TypeString, Required: true},
+		},
+		List:     []string{"name"},
+		Search:   []string{"name"},
+		Ordering: []string{"name", "created_at"},
+		Actions: admin.Actions{
+			List: true, Detail: true, Create: true, Update: true, Delete: true,
+		},
+	})
+}

--- a/examples/admin/internal/warehouse/warehouse.go
+++ b/examples/admin/internal/warehouse/warehouse.go
@@ -1,0 +1,12 @@
+package warehouse
+
+import "time"
+
+// Warehouse is a small model used as the target of Widget's belongs_to
+// (primary warehouse) and many_to_many (stocked-at warehouses) relations.
+type Warehouse struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/examples/admin/internal/widget/admin.go
+++ b/examples/admin/internal/widget/admin.go
@@ -7,17 +7,17 @@ import (
 
 // RegisterAdmin registers Widget on the runtime admin. Feature packages own
 // this call — the framework never discovers GORM models by itself (ADR-013).
+//
+// Fields is left empty so admin.FieldsFrom derives the schema from the GORM
+// model, including the three relations (#223): warehouse_id auto-derives to a
+// belongs_to picker, warehouses to a many_to_many multi-select, and parts to a
+// read-only has_many view — no per-field wiring, no per-model React file.
 func RegisterAdmin(app *framework.App) error {
 	return admin.Register(app, Widget{}, admin.Options{
 		Slug:     "widgets",
 		Singular: "Widget",
 		Plural:   "Widgets",
-		Fields: []admin.Field{
-			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
-			{Name: "name", Type: admin.TypeString, Required: true},
-			{Name: "sku", Type: admin.TypeString},
-		},
-		List:     []string{"name", "sku"},
+		List:     []string{"name", "sku", "warehouse_id"},
 		Search:   []string{"name", "sku"},
 		Ordering: []string{"name", "created_at"},
 		Actions: admin.Actions{

--- a/examples/admin/internal/widget/widget.go
+++ b/examples/admin/internal/widget/widget.go
@@ -16,8 +16,12 @@ type Widget struct {
 	Name string `json:"name"`
 	SKU  string `json:"sku"`
 
-	// belongs_to: the widget's primary warehouse (FK + association).
-	WarehouseID uint                `gorm:"index" json:"warehouse_id"`
+	// belongs_to: the widget's primary warehouse (FK + association). The FK is a
+	// *uint so it is genuinely optional: a widget with no warehouse stores NULL
+	// rather than 0, which a non-nullable uint could not represent under foreign
+	// key enforcement (the admin advertises belongs_to as optional, so the create
+	// must actually accept "none").
+	WarehouseID *uint               `gorm:"index" json:"warehouse_id"`
 	Warehouse   warehouse.Warehouse `json:"-"`
 
 	// many_to_many: every warehouse this widget is stocked at (join table). The

--- a/examples/admin/internal/widget/widget.go
+++ b/examples/admin/internal/widget/widget.go
@@ -1,12 +1,32 @@
 package widget
 
-import "time"
+import (
+	"time"
 
-// Widget is the small model registered with the admin in this example.
+	"github.com/gombit-dev/gombit/examples/admin/internal/part"
+	"github.com/gombit-dev/gombit/examples/admin/internal/warehouse"
+)
+
+// Widget is the model registered with the admin in this example. It carries all
+// three relation kinds so the admin renders their widgets from the registry
+// alone (ADR-013 / #223): a belongs_to picker, a many_to_many multi-select, and
+// a read-only has_many view.
 type Widget struct {
-	ID        uint      `gorm:"primaryKey" json:"id"`
-	Name      string    `json:"name"`
-	SKU       string    `json:"sku"`
+	ID   uint   `gorm:"primaryKey" json:"id"`
+	Name string `json:"name"`
+	SKU  string `json:"sku"`
+
+	// belongs_to: the widget's primary warehouse (FK + association).
+	WarehouseID uint                `gorm:"index" json:"warehouse_id"`
+	Warehouse   warehouse.Warehouse `json:"-"`
+
+	// many_to_many: every warehouse this widget is stocked at (join table). The
+	// JSON name is the admin field name the multi-select binds to.
+	Warehouses []warehouse.Warehouse `gorm:"many2many:widget_warehouses;" json:"warehouses"`
+
+	// has_many: the widget's parts (read-only in the admin; Part carries the FK).
+	Parts []part.Part `json:"parts"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/examples/admin/main.go
+++ b/examples/admin/main.go
@@ -36,8 +36,9 @@ func main() {
 		_ = db.Close()
 		log.Fatal(err)
 	}
-	// Register relation targets before Widget so its belongs_to / many_to_many
-	// pickers resolve against registered slugs.
+	// Register every model. Order is not significant: the belongs_to /
+	// many_to_many pickers resolve against the target slug at request time (the
+	// SPA calls the target's list endpoint), not at Register time.
 	for _, register := range []func(*framework.App) error{
 		warehouse.RegisterAdmin,
 		part.RegisterAdmin,

--- a/examples/admin/main.go
+++ b/examples/admin/main.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gombit-dev/gombit/auth"
 	"github.com/gombit-dev/gombit/config"
 	"github.com/gombit-dev/gombit/database"
+	"github.com/gombit-dev/gombit/examples/admin/internal/part"
+	"github.com/gombit-dev/gombit/examples/admin/internal/warehouse"
 	"github.com/gombit-dev/gombit/examples/admin/internal/widget"
 	"github.com/gombit-dev/gombit/framework"
 )
@@ -34,16 +36,24 @@ func main() {
 		_ = db.Close()
 		log.Fatal(err)
 	}
-	if err := widget.RegisterAdmin(app); err != nil {
-		_ = db.Close()
-		log.Fatal(err)
+	// Register relation targets before Widget so its belongs_to / many_to_many
+	// pickers resolve against registered slugs.
+	for _, register := range []func(*framework.App) error{
+		warehouse.RegisterAdmin,
+		part.RegisterAdmin,
+		widget.RegisterAdmin,
+	} {
+		if err := register(app); err != nil {
+			_ = db.Close()
+			log.Fatal(err)
+		}
 	}
 
 	app.OnStart(func(ctx context.Context) error {
 		if err := auth.Migrate(db.DB); err != nil {
 			return err
 		}
-		if err := db.AutoMigrate(&widget.Widget{}); err != nil {
+		if err := db.AutoMigrate(&warehouse.Warehouse{}, &part.Part{}, &widget.Widget{}); err != nil {
 			return err
 		}
 		svc, err := auth.NewService(db.DB, cfg)


### PR DESCRIPTION
## Summary

Closes out the two remaining **#223** leftovers I flagged after the admin relationship widgets shipped (#231/#233/#235/#236):

1. **Postgres/MySQL integration matrix for relations.** `admin/integration_test.go` adds `TestRelationsPostgres` / `TestRelationsMySQL`, running the belongs_to / has_many / many_to_many admin round-trips against real Postgres and MySQL — the DB-touching paths (join-table sync, transactional rollback on a bad related id, belongs_to FK write, has_many preload) that emit engine-specific SQL and can't be covered by SQLite alone. They run under the **existing** `go test -tags integration ./admin -admin.{postgres,mysql}-dsn` CI jobs — no workflow change.

2. **Example app.** `examples/admin` gains `warehouse.Warehouse` (belongs_to + m2m target) and `part.Part` (has_many child). `Widget` now carries all three relation kinds and registers with **empty `Fields`**, so `admin.FieldsFrom` derives them — the headline #223 behavior — documented in the README.

3. **Auto-derivation fix (found by building the example).** `many_to_many` omitted `LabelField` while belongs_to/has_many set it, so the multi-select rendered raw ids. `FieldsFrom` now defaults the m2m label the same way.

Closes #223.

## Acceptance criteria (issue #223)

- [x] belongs_to/has_many render as pickers backed by the related list, labelled not raw ids — **now consistent across all three kinds** (m2m label fixed here; belongs_to/has_many from #233/#236)
- [x] many_to_many end to end: registry metadata, data-plane read of ids/labels, write that syncs the join table — **now matrix-tested on PG + MySQL**
- [x] Auto-derivation emits `TypeRelation` with the target slug for association fields — exercised by the example's empty-`Fields` registration

## Validation

- [x] `go test ./...` (SQLite) + `golangci-lint run ./admin/... ./examples/...` — 0 issues
- [x] **Real DB matrix**, verified locally against `postgres:16-alpine` and `mysql:8.4`:
  ```
  TestResourcePostgres PASS   TestResourceMySQL PASS
  TestRelationsPostgres PASS  TestRelationsMySQL PASS
  ```
  (also with CI's exact MySQL DSN, no `multiStatements`)
- [x] Example runs: logged in, created warehouses, created a widget with `warehouse_id` (belongs_to) + `warehouses:[1,2]` (m2m) — both round-trip; meta advertises `belongs_to` / `many_to_many` / read-only `has_many`, m2m `label_field` now `name`.

## Working agreement

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — **this PR is that matrix coverage**
- [x] Stable feature appears in an example app (examples/admin) with docs (README + links to docs/admin.md, docs/cli.md)
- [x] Extraction preserves contracts — reuses existing helpers; no rewrite of passing tests
- [x] No API contract change → no OpenAPI/TS regen needed (admin data plane is generic; N/A)
- [x] No secrets in frontend source
- [x] Scope stays in M6 admin (#223); no new batteries
- [x] Links its issue and states which acceptance criteria it satisfies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
