### PR TITLE
perf: generate correlation IDs without crypto/rand (#240)

### DIFF
--- a/framework/correlation_id_test.go
+++ b/framework/correlation_id_test.go
@@ -1,0 +1,58 @@
+package framework
+
+import (
+	"regexp"
+	"testing"
+)
+
+// uuidV4Pattern matches the canonical UUIDv4 textual form: version nibble 4 and
+// variant nibble in [89ab]. newRequestID must keep emitting this shape after
+// switching its randomness source from crypto/rand to math/rand/v2 (issue #240).
+var uuidV4Pattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+// traceIDPattern is a 32-char lowercase hex string, the W3C trace-id form.
+var traceIDPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
+
+func TestNewRequestIDFormatAndUniqueness(t *testing.T) {
+	const n = 10000
+	seen := make(map[string]struct{}, n)
+	for range n {
+		id := newRequestID()
+		if !uuidV4Pattern.MatchString(id) {
+			t.Fatalf("newRequestID() = %q, want UUIDv4 form", id)
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("newRequestID() produced a duplicate %q within %d draws", id, n)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+func TestNewTraceIDFormatAndUniqueness(t *testing.T) {
+	const n = 10000
+	seen := make(map[string]struct{}, n)
+	for range n {
+		id := newTraceID()
+		if !traceIDPattern.MatchString(id) {
+			t.Fatalf("newTraceID() = %q, want 32-char lowercase hex", id)
+		}
+		if id == "00000000000000000000000000000000" {
+			t.Fatalf("newTraceID() returned the all-zero trace ID, which is invalid")
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("newTraceID() produced a duplicate %q within %d draws", id, n)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// TestGeneratedTraceIDSurvivesTraceparentRoundTrip pins that a generated trace
+// ID is accepted by the inbound traceparent parser — i.e. the two ends of the
+// trace-context path agree on the 32-hex-lowercase shape.
+func TestGeneratedTraceIDSurvivesTraceparentRoundTrip(t *testing.T) {
+	id := newTraceID()
+	got := traceIDFromTraceparent("00-" + id + "-00f067aa0ba902b7-01")
+	if got != id {
+		t.Fatalf("traceIDFromTraceparent round-trip = %q, want %q", got, id)
+	}
+}

--- a/framework/http_middleware.go
+++ b/framework/http_middleware.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -264,10 +263,7 @@ func traceIDFromTraceparent(value string) string {
 }
 
 func newTraceID() string {
-	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return ""
-	}
+	b := randomBytes16()
 	if b == [16]byte{} {
 		b[15] = 1
 	}

--- a/framework/request_id.go
+++ b/framework/request_id.go
@@ -100,8 +100,12 @@ func GetRequestIDFromContext(ctx context.Context) string {
 // have an error path to handle.
 func randomBytes16() [16]byte {
 	var b [16]byte
-	binary.LittleEndian.PutUint64(b[0:8], rand.Uint64())
-	binary.LittleEndian.PutUint64(b[8:16], rand.Uint64())
+	for i := 0; i < len(b); i += 8 {
+		// G404 is intentional here: see this function's doc comment. Correlation
+		// IDs are not secrets, and a CSPRNG's syscall + global lock is exactly
+		// the cost issue #240 removes.
+		binary.LittleEndian.PutUint64(b[i:i+8], rand.Uint64()) //nolint:gosec // G404: non-secret correlation IDs (issue #240)
+	}
 	return b
 }
 

--- a/framework/request_id.go
+++ b/framework/request_id.go
@@ -2,8 +2,9 @@ package framework
 
 import (
 	"context"
-	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
+	"math/rand/v2"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -89,11 +90,23 @@ func GetRequestIDFromContext(ctx context.Context) string {
 	return meta.requestID
 }
 
-func newRequestID() string {
+// randomBytes16 fills a 16-byte array with non-cryptographic randomness from
+// math/rand/v2, whose top-level generator is per-P and lock-free — unlike
+// crypto/rand's globally locked reader, which also incurs a getrandom syscall.
+// Request and trace IDs are opaque correlation tokens, not secrets, so they do
+// not need a CSPRNG; paying crypto/rand's syscall + global lock on every
+// request was a measurable hot-path CPU and cross-core contention cost
+// (issue #240). Unlike crypto/rand.Read this cannot fail, so callers no longer
+// have an error path to handle.
+func randomBytes16() [16]byte {
 	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return ""
-	}
+	binary.LittleEndian.PutUint64(b[0:8], rand.Uint64())
+	binary.LittleEndian.PutUint64(b[8:16], rand.Uint64())
+	return b
+}
+
+func newRequestID() string {
+	b := randomBytes16()
 
 	b[6] = (b[6] & 0x0f) | 0x40
 	b[8] = (b[8] & 0x3f) | 0x80


### PR DESCRIPTION
## Summary

`newRequestID` and `newTraceID` each called `crypto/rand.Read` on every request — a `getrandom` syscall behind a globally locked reader. That cost ~14% of single-threaded plaintext CPU and was the top remaining cross-core contention point after the metrics mutex was removed (#239).

Request and trace IDs are opaque correlation tokens, not secrets, so they don't need a CSPRNG. This fills the 16 ID bytes from `math/rand/v2`, whose top-level generator is per-P and lock-free. Output formats are unchanged (UUIDv4-shaped request ID; 32-hex trace ID), and because `math/rand/v2` cannot fail, the dead error paths are removed.

**Measured**: after the change `crypto/rand` no longer appears in the plaintext CPU profile.

Closes #240

## Acceptance criteria

- [x] Neither request-ID nor trace-ID generation calls `crypto/rand` on the request path.
- [x] Output formats/lengths unchanged; existing request_id/trace tests pass. Added dedicated UUIDv4 + 32-hex format and uniqueness tests (10k draws each) and a traceparent round-trip test.
- [x] Benchmark shows the `getrandom` frames gone from the plaintext CPU profile.

## Scope notes

Runtime-only, post-v0.1 optimization; no contract change. IDs remain non-guessable-enough for correlation but are explicitly **not** security tokens — documented in the `randomBytes16` helper. If any consumer ever needs unpredictable IDs, that would be a separate, opt-in change.

## Validation

- [x] `go test ./...` — passes
- [x] `go test ./framework/ -race` — passes (incl. new format/uniqueness tests)
- [ ] `golangci-lint` — not run locally (CI will run it)
- [ ] Project `code-review` skill — not run

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A, no DB change
- [ ] Stable features ship docs and appear in an example app — N/A, internal runtime optimization, no user-facing surface change
- [x] Extraction preserves contracts — ID formats preserved; existing trace/request-id tests unchanged
- [ ] Generators are idempotent/additive, AST-safe — N/A, no generator change
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no API change
- [x] No secrets in generated frontend source — N/A, no frontend change
- [x] Scope stays inside this issue's milestone — no battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies
