### PR TITLE
perf: skip XSS JSON decode/re-encode when body has no markup (#241)

### DIFF
--- a/framework/xss.go
+++ b/framework/xss.go
@@ -149,9 +149,10 @@ func sanitizeJSONBody(c *gin.Context) {
 	// carry a tag in any string value or key, so sanitization is a guaranteed
 	// no-op. Skip the decode + re-encode round trip entirely and hand the
 	// original bytes to the handler unchanged. This is the common case for API
-	// traffic. The escaped-bypass reasoning is locked by
+	// traffic. ContainsAny scans the (up to 8 MiB) body once; the escaped-bypass
+	// reasoning — why '\' must be in the set — is locked by
 	// TestSanitizeJSONBodyFastPathDoesNotBypassEscapedTags.
-	if bytes.IndexByte(raw, '<') < 0 && bytes.IndexByte(raw, '>') < 0 && bytes.IndexByte(raw, '\\') < 0 {
+	if !bytes.ContainsAny(raw, "<>\\") {
 		c.Request.Body = io.NopCloser(bytes.NewReader(raw))
 		return
 	}

--- a/framework/xss.go
+++ b/framework/xss.go
@@ -143,6 +143,19 @@ func sanitizeJSONBody(c *gin.Context) {
 		return
 	}
 
+	// Fast path (issue #241): an HTML tag can only reach a decoded JSON string
+	// as a literal '<'/'>' or as a "\uXXXX" escape, and every JSON escape needs
+	// a backslash. A body containing none of '<', '>', or '\' therefore cannot
+	// carry a tag in any string value or key, so sanitization is a guaranteed
+	// no-op. Skip the decode + re-encode round trip entirely and hand the
+	// original bytes to the handler unchanged. This is the common case for API
+	// traffic. The escaped-bypass reasoning is locked by
+	// TestSanitizeJSONBodyFastPathDoesNotBypassEscapedTags.
+	if bytes.IndexByte(raw, '<') < 0 && bytes.IndexByte(raw, '>') < 0 && bytes.IndexByte(raw, '\\') < 0 {
+		c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+		return
+	}
+
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.UseNumber()
 	var payload any
@@ -152,7 +165,15 @@ func sanitizeJSONBody(c *gin.Context) {
 		return
 	}
 
-	sanitizeJSONValue(payload, "")
+	// Only re-encode when a value actually changed. When sanitization stripped
+	// nothing (the body reached here only because of a backslash or an
+	// angle-bracket that turned out not to form a complete tag), the original
+	// bytes go through untouched — no json.Marshal, and no JSON normalization
+	// of a body we did not modify.
+	if !sanitizeJSONValue(payload, "") {
+		c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+		return
+	}
 	cleaned, err := json.Marshal(payload)
 	if err != nil {
 		c.Request.Body = io.NopCloser(bytes.NewReader(raw))
@@ -174,7 +195,12 @@ func isJSONContentType(contentType string) bool {
 	return strings.EqualFold(mediaType, "application/json")
 }
 
-func sanitizeJSONValue(value any, fieldName string) {
+// sanitizeJSONValue strips HTML from every string in value in place and reports
+// whether it changed anything. The changed flag lets the caller skip a
+// json.Marshal re-encode when the body carried no strippable markup (issue
+// #241).
+func sanitizeJSONValue(value any, fieldName string) bool {
+	changed := false
 	switch typed := value.(type) {
 	case map[string]any:
 		for key, child := range typed {
@@ -183,9 +209,14 @@ func sanitizeJSONValue(value any, fieldName string) {
 			}
 			switch childValue := child.(type) {
 			case string:
-				typed[key] = stripHTML(childValue)
+				if cleaned := stripHTML(childValue); cleaned != childValue {
+					typed[key] = cleaned
+					changed = true
+				}
 			default:
-				sanitizeJSONValue(child, key)
+				if sanitizeJSONValue(child, key) {
+					changed = true
+				}
 			}
 		}
 	case []any:
@@ -195,12 +226,18 @@ func sanitizeJSONValue(value any, fieldName string) {
 				if fieldName == xssPasswordField {
 					continue
 				}
-				typed[i] = stripHTML(childValue)
+				if cleaned := stripHTML(childValue); cleaned != childValue {
+					typed[i] = cleaned
+					changed = true
+				}
 			default:
-				sanitizeJSONValue(child, fieldName)
+				if sanitizeJSONValue(child, fieldName) {
+					changed = true
+				}
 			}
 		}
 	}
+	return changed
 }
 
 // stripHTML removes HTML tags and discards content inside dangerous elements.

--- a/framework/xss_test.go
+++ b/framework/xss_test.go
@@ -270,6 +270,67 @@ func TestSanitizeJSONBodyPreservesComparisonText(t *testing.T) {
 	}
 }
 
+// TestSanitizeJSONBodyFastPathDoesNotBypassEscapedTags is the safety lock for
+// the issue #241 fast path. A tag delivered through "\uXXXX" escapes contains a
+// backslash in the raw bytes, so it must NOT take the no-'<'/'>'/'\\' fast path
+// — it must be decoded and stripped like a literal tag. If the fast-path guard
+// ever drops its backslash check, this test fails instead of silently opening
+// an XSS bypass.
+func TestSanitizeJSONBodyFastPathDoesNotBypassEscapedTags(t *testing.T) {
+	t.Parallel()
+
+	// No literal '<' or '>' anywhere; the tag is entirely \uXXXX-escaped.
+	raw := []byte(`{"comment":"<script>alert(1)</script>"}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	sanitizeJSONBody(c)
+
+	got, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(got, &payload); err != nil {
+		t.Fatalf("unmarshal sanitized body: %v (%s)", err, got)
+	}
+	if strings.ContainsAny(payload["comment"], "<>") {
+		t.Fatalf("comment = %q still contains tag markup — escaped-tag XSS bypass", payload["comment"])
+	}
+	// script element body is discarded by stripHTML (strict mode).
+	if payload["comment"] != "" {
+		t.Fatalf("comment = %q, want empty (script body discarded)", payload["comment"])
+	}
+}
+
+// TestSanitizeJSONBodyCleanBodyPassesThroughVerbatim locks the fast path's
+// other half: a body with no markup reaches the handler byte-for-byte, with no
+// JSON re-encoding (issue #241). The Content-Length header the client sent is
+// left untouched because the bytes are unchanged.
+func TestSanitizeJSONBodyCleanBodyPassesThroughVerbatim(t *testing.T) {
+	t.Parallel()
+
+	// Deliberately non-normalized: spaces after colons, '&' in a value. If the
+	// body were decoded and re-marshaled, these bytes would change.
+	raw := []byte(`{"name": "Ada Lovelace", "note": "tea & cake"}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(raw))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	sanitizeJSONBody(c)
+
+	got, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Fatalf("body = %q, want verbatim %q (clean body must not be re-encoded)", got, raw)
+	}
+}
+
 func TestXSSMiddlewareRawBodyPathSkipsSanitization(t *testing.T) {
 	// A body that json re-encoding would change (< / & escaped, <b> stripped).
 	const raw = `{"tag":"v1","body":"<b>notes</b> a < b & c"}`


### PR DESCRIPTION
## Summary

The XSS input sanitizer decoded every JSON request body into `map[string]any` and re-marshaled it, redundantly with Huma's own typed decode that runs immediately after. On the valid-POST microbench that round trip was **~15% of CPU** and **~28% of allocations**.

Two changes:
- **Fast path** — an HTML tag can only reach a decoded string as a literal `<`/`>` or a `\uXXXX` escape, and every JSON escape carries a backslash. A body with none of `<`, `>`, or `\` cannot contain a tag in any string value or key, so sanitization is a guaranteed no-op: skip the decode + re-encode entirely and pass the original bytes through. This is the common case for API traffic.
- **Changed-flag** — when a body *is* decoded, only `json.Marshal` it if `sanitizeJSONValue` actually changed a value; otherwise the original bytes pass through untouched.

Bodies that contain markup are sanitized exactly as before.

**Measured** (valid-POST microbench): `83 → 60 allocs/op` (~28% fewer), `~8340 → ~6937 ns/op` (~17% faster); invalid-POST `93 → 73 allocs/op`.

Closes #241

## Security note

The backslash guard in the fast path is load-bearing: an escaped tag like `{"c":"<script>…"}` has no literal `<`/`>` but MUST still be sanitized. It carries a backslash, so it correctly bypasses the fast path and is decoded + stripped. `TestSanitizeJSONBodyFastPathDoesNotBypassEscapedTags` fails loudly if that guard is ever dropped.

## Acceptance criteria

- [x] Bodies with no sanitizable content incur no `json.Marshal` re-encode (and, via the fast path, no decode either).
- [x] Existing XSS tests still pass (incl. #118 `a<b`, #201 truncation, raw-body exemption); sanitized bytes are unchanged for inputs that contain HTML.
- [x] Benchmark shows reduced POST ns/op and allocs; `sanitizeJSONBody`'s decode/marshal is skipped for clean bodies.

## Scope notes

Runtime-only, post-v0.1 optimization; sanitization behavior is unchanged for any body that contains markup. A side effect (improvement): clean bodies now reach the handler byte-for-byte instead of being JSON-normalized/`<`-escaped by the re-marshal — locked by `TestSanitizeJSONBodyCleanBodyPassesThroughVerbatim`. Moving sanitization to the typed layer (parse once) remains a possible larger follow-up but is out of scope here.

## Validation

- [x] `go test ./...` — passes
- [x] `go test ./framework/ -race` — passes (incl. new bypass-safety + verbatim tests)
- [ ] `golangci-lint` — not run locally (CI will run it)
- [ ] Project `code-review` skill — not run

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A, no DB change
- [ ] Stable features ship docs and appear in an example app — N/A, internal runtime optimization; behavior unchanged
- [x] Extraction preserves contracts — sanitization semantics preserved for markup-bearing bodies; existing XSS tests unchanged
- [ ] Generators are idempotent/additive, AST-safe — N/A, no generator change
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no API change
- [x] No secrets in generated frontend source — N/A, no frontend change
- [x] Scope stays inside this issue's milestone — no battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies
