### PR TITLE
perf: skip request-timeout re-wrap when a tighter deadline exists (#242)

### DIFF
--- a/framework/http_middleware.go
+++ b/framework/http_middleware.go
@@ -34,7 +34,21 @@ func requestTimeoutMiddleware(timeout time.Duration) gin.HandlerFunc {
 	}
 
 	return func(c *gin.Context) {
-		ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
+		ctx := c.Request.Context()
+		// If the request already carries a deadline at or before the one we
+		// would impose, wrapping it again only allocates a second timer and a
+		// shallow Request copy that can never take effect first — context
+		// always honors the earliest deadline, which is the existing one. Skip
+		// the wrap in that case (issue #242). When no deadline (or a later one)
+		// is present — the common case — the context.WithTimeout timer is
+		// intrinsic to propagating cancellation to handlers and DB calls, so it
+		// stays.
+		if deadline, ok := ctx.Deadline(); ok && !deadline.After(time.Now().Add(timeout)) {
+			c.Next()
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()

--- a/framework/request_timeout_test.go
+++ b/framework/request_timeout_test.go
@@ -1,0 +1,105 @@
+package framework
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestRequestTimeoutMiddlewareSkipsWrapWhenTighterDeadlineExists locks the
+// issue #242 guard: when the incoming request already carries a deadline at or
+// before the middleware's timeout, the middleware must not allocate a second
+// timeout context — the handler must observe the exact same context instance it
+// came in with. Context identity is the discriminator: a re-wrap would hand the
+// handler a different (child) context even though the effective deadline is
+// unchanged.
+func TestRequestTimeoutMiddlewareSkipsWrapWhenTighterDeadlineExists(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	parent, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	eng := gin.New()
+	eng.Use(requestTimeoutMiddleware(time.Hour))
+	var sameContext bool
+	eng.GET("/", func(c *gin.Context) {
+		sameContext = c.Request.Context() == parent
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(parent)
+	eng.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !sameContext {
+		t.Fatal("middleware re-wrapped a request that already had a tighter deadline; guard did not fire")
+	}
+}
+
+// TestRequestTimeoutMiddlewareImposesDeadlineWhenNonePresent is the other half:
+// a request with no deadline (the common case) must still leave the handler
+// with a bounded context, and it must be a fresh context, not the original.
+func TestRequestTimeoutMiddlewareImposesDeadlineWhenNonePresent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	eng := gin.New()
+	eng.Use(requestTimeoutMiddleware(time.Hour))
+	var hasDeadline, replaced bool
+	eng.GET("/", func(c *gin.Context) {
+		_, hasDeadline = c.Request.Context().Deadline()
+		replaced = c.Request.Context() != context.Background()
+		c.Status(http.StatusOK)
+	})
+
+	// httptest.NewRequest attaches context.Background() by default (no deadline).
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	eng.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !hasDeadline {
+		t.Fatal("middleware did not impose a deadline on a request that had none")
+	}
+	if !replaced {
+		t.Fatal("middleware left the original context in place")
+	}
+}
+
+// TestRequestTimeoutMiddlewareDisabledIsNoop confirms a non-positive timeout
+// leaves the request context untouched.
+func TestRequestTimeoutMiddlewareDisabledIsNoop(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	eng := gin.New()
+	eng.Use(requestTimeoutMiddleware(0))
+	var hasDeadline bool
+	eng.GET("/", func(c *gin.Context) {
+		_, hasDeadline = c.Request.Context().Deadline()
+		c.Status(http.StatusOK)
+	})
+
+	eng.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if hasDeadline {
+		t.Fatal("disabled timeout middleware imposed a deadline")
+	}
+}
+
+// BenchmarkRequestTimeoutMiddleware quantifies the per-request cost the guard
+// avoids and guards against a regression in the enabled path. The recorder
+// allocation is constant across runs; the interesting delta is the
+// context.WithTimeout timer + Request copy.
+func BenchmarkRequestTimeoutMiddleware(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	eng := gin.New()
+	eng.Use(requestTimeoutMiddleware(30 * time.Second))
+	eng.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		eng.ServeHTTP(httptest.NewRecorder(), req)
+	}
+}


### PR DESCRIPTION
## Summary

`requestTimeoutMiddleware` calls `context.WithTimeout` on every request, allocating a `time.Timer` plus a shallow `Request` copy — ~15% of plaintext-path allocations.

**Honest framing (this is the P2 issue):** the timer is *intrinsic* to context-based cancellation. It is what propagates the deadline to handlers and DB calls when the request carries no deadline of its own — the common case — so it cannot be removed there without weakening cancellation semantics. What this PR removes is the genuinely redundant case: a request that **already** has a deadline at or before our timeout. Re-wrapping it only allocates a second timer that can never fire first (context always honors the earliest deadline), so the guard skips the wrap and hands the handler the original context unchanged.

Closes #242

## Acceptance criteria

The issue allows either a measured reduction on the plaintext path **or** a written conclusion that the timer is unavoidable there. This PR does the latter, plus a real (narrow) reduction:

- [x] Written conclusion: on the plaintext/no-inbound-deadline path the `context.WithTimeout` timer is unavoidable given the cancellation contract — documented inline in the middleware.
- [x] Real reduction where it *is* avoidable: requests that arrive with a tighter-or-equal deadline no longer allocate a redundant second timeout context.
- [x] Timeout behavior unchanged: requests with no deadline still get one (`TestRequestTimeoutMiddlewareImposesDeadlineWhenNonePresent`, existing `TestDefaultRouterRequestTimeoutSetsDeadline`); a disabled timeout stays a no-op.

## Scope notes

Runtime-only, post-v0.1, lowest-priority of the PERF batch. No plaintext alloc change (the timer is intrinsic there). A `BenchmarkRequestTimeoutMiddleware` is added to guard the enabled path against regressions. Deeper avoidance (a pooled custom deadline context) was considered and rejected as not worth the cancel/reset-race complexity for a P2.

## Validation

- [x] `go test ./...` — passes
- [x] `go test ./framework/ -race` — passes (incl. new guard/identity tests)
- [ ] `golangci-lint` — not run locally (CI will run it)
- [ ] Project `code-review` skill — not run

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A, no DB change
- [ ] Stable features ship docs and appear in an example app — N/A, internal runtime optimization; behavior unchanged
- [x] Extraction preserves contracts — timeout/cancellation semantics preserved; existing timeout test unchanged
- [ ] Generators are idempotent/additive, AST-safe — N/A, no generator change
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no API change
- [x] No secrets in generated frontend source — N/A, no frontend change
- [x] Scope stays inside this issue's milestone — no battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies
