### PR TITLE
test(bench): add cross-core scaling row to the micro harness (#243)

### DIFF
--- a/benchmarks/docs/methodology.md
+++ b/benchmarks/docs/methodology.md
@@ -52,6 +52,28 @@ Two families of measurement:
    (≥20 restarts, median/p95), idle memory, memory + CPU under the same load,
    and image size. `make benchmark-footprint`.
 
+### Cross-core scaling (parallel microbench)
+
+`BenchmarkFrameworkTaxParallel` (issue #243) drives the plaintext and
+valid-POST scenarios through the same four in-process handlers as the
+abstraction-cost microbench, but concurrently via `b.RunParallel`. Its purpose
+is orthogonal to the single-goroutine `BenchmarkFrameworkTax`: it exposes
+**per-request serialization** — a shared lock on the hot path — that a
+single-goroutine benchmark cannot see. Run one row across core counts and read
+whether its per-op time falls with more cores:
+
+```
+go test ./benchmarks/micro/... -bench=BenchmarkFrameworkTaxParallel -benchmem -cpu=1,2,4,8,16
+```
+
+A row whose ns/op drops roughly in proportion to `-cpu` scales; a row whose
+ns/op flattens as cores are added is contention-bound (every request is
+funnelling through a shared lock). This is the measurement that surfaced the
+metrics-middleware mutex in #239 — invisible to the single-goroutine numbers,
+obvious here. It is a **diagnostic**, not part of the published README snapshot:
+the numbers are host- and scheduler-sensitive, so read them as a scaling *shape*
+on your own machine, not as an absolute to compare across hosts.
+
 ### Canonical protocol vs. a particular snapshot
 
 The sweep above is the **canonical protocol**: the parameters a run must use to

--- a/benchmarks/micro/gin/gin_test.go
+++ b/benchmarks/micro/gin/gin_test.go
@@ -24,3 +24,12 @@ func TestScenarios(t *testing.T) {
 func BenchmarkFrameworkTax(b *testing.B) {
 	scenario.RunBenchmark(b, stack())
 }
+
+// BenchmarkFrameworkTaxParallel reports this row's cross-core scaling (issue
+// #243). Compare its per-op time across -cpu values to see whether the stack
+// serializes requests; run alongside the other rows with:
+//
+//	go test ./benchmarks/micro/... -bench=BenchmarkFrameworkTaxParallel -benchmem -cpu=1,2,4,8,16
+func BenchmarkFrameworkTaxParallel(b *testing.B) {
+	scenario.RunParallelBenchmark(b, stack())
+}

--- a/benchmarks/micro/gombit/gombit_test.go
+++ b/benchmarks/micro/gombit/gombit_test.go
@@ -24,3 +24,12 @@ func TestScenarios(t *testing.T) {
 func BenchmarkFrameworkTax(b *testing.B) {
 	scenario.RunBenchmark(b, stack())
 }
+
+// BenchmarkFrameworkTaxParallel reports this row's cross-core scaling (issue
+// #243). Compare its per-op time across -cpu values to see whether the stack
+// serializes requests; run alongside the other rows with:
+//
+//	go test ./benchmarks/micro/... -bench=BenchmarkFrameworkTaxParallel -benchmem -cpu=1,2,4,8,16
+func BenchmarkFrameworkTaxParallel(b *testing.B) {
+	scenario.RunParallelBenchmark(b, stack())
+}

--- a/benchmarks/micro/huma/huma_test.go
+++ b/benchmarks/micro/huma/huma_test.go
@@ -24,3 +24,12 @@ func TestScenarios(t *testing.T) {
 func BenchmarkFrameworkTax(b *testing.B) {
 	scenario.RunBenchmark(b, stack())
 }
+
+// BenchmarkFrameworkTaxParallel reports this row's cross-core scaling (issue
+// #243). Compare its per-op time across -cpu values to see whether the stack
+// serializes requests; run alongside the other rows with:
+//
+//	go test ./benchmarks/micro/... -bench=BenchmarkFrameworkTaxParallel -benchmem -cpu=1,2,4,8,16
+func BenchmarkFrameworkTaxParallel(b *testing.B) {
+	scenario.RunParallelBenchmark(b, stack())
+}

--- a/benchmarks/micro/nethttp/nethttp_test.go
+++ b/benchmarks/micro/nethttp/nethttp_test.go
@@ -24,3 +24,12 @@ func TestScenarios(t *testing.T) {
 func BenchmarkFrameworkTax(b *testing.B) {
 	scenario.RunBenchmark(b, stack())
 }
+
+// BenchmarkFrameworkTaxParallel reports this row's cross-core scaling (issue
+// #243). Compare its per-op time across -cpu values to see whether the stack
+// serializes requests; run alongside the other rows with:
+//
+//	go test ./benchmarks/micro/... -bench=BenchmarkFrameworkTaxParallel -benchmem -cpu=1,2,4,8,16
+func BenchmarkFrameworkTaxParallel(b *testing.B) {
+	scenario.RunParallelBenchmark(b, stack())
+}

--- a/benchmarks/micro/scenario/parallel.go
+++ b/benchmarks/micro/scenario/parallel.go
@@ -1,0 +1,63 @@
+package scenario
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// RunParallelBenchmark reports how a stack scales across CPU cores by driving
+// the plaintext and valid-POST scenarios concurrently with b.RunParallel, as
+// b.Run sub-benchmarks. It is the contention counterpart to RunBenchmark, whose
+// single-goroutine numbers hide any per-request serialization: a stack that
+// funnels every request through a shared lock barely improves here as
+// GOMAXPROCS rises, while a lock-free stack approaches linear scaling. That gap
+// is exactly what a single-goroutine microbench cannot surface (issue #243,
+// motivated by the metrics-mutex finding in #239).
+//
+// Read a row by comparing its per-op time across -cpu values, e.g.:
+//
+//	go test ./benchmarks/micro/... -bench=BenchmarkFrameworkTaxParallel -benchmem -cpu=1,2,4,8,16
+//
+// A row whose ns/op falls roughly in proportion to the core count scales;
+// a row whose ns/op flattens is contention-bound. The shared plaintext GET
+// request is safe to reuse across goroutines: none of the four stacks mutate
+// the inbound *http.Request in place (context changes go through
+// Request.WithContext, which returns a copy). POST cannot share a request — a
+// drained body can't be re-read — so each iteration builds its own.
+func RunParallelBenchmark(b *testing.B, stack Stack) {
+	b.Helper()
+
+	b.Run("plaintext", func(b *testing.B) {
+		request := httptest.NewRequest(http.MethodGet, "/plaintext", nil)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				response := httptest.NewRecorder()
+				stack.Handler.ServeHTTP(response, request)
+				if response.Code != http.StatusOK {
+					b.Fatalf("plaintext status = %d, want %d; body: %s", response.Code, http.StatusOK, response.Body.String())
+				}
+			}
+		})
+	})
+
+	b.Run("valid-post", func(b *testing.B) {
+		payload := []byte(ValidCreateUserBody)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				request := httptest.NewRequest(http.MethodPost, "/users", bytes.NewReader(payload))
+				request.Header.Set("Content-Type", "application/json")
+				response := httptest.NewRecorder()
+				stack.Handler.ServeHTTP(response, request)
+				if !statusOKOrCreated(response.Code) {
+					b.Fatalf("valid-post status = %d; body: %s", response.Code, response.Body.String())
+				}
+			}
+		})
+	})
+}

--- a/benchmarks/micro/scenario/parallel.go
+++ b/benchmarks/micro/scenario/parallel.go
@@ -38,7 +38,12 @@ func RunParallelBenchmark(b *testing.B, stack Stack) {
 				response := httptest.NewRecorder()
 				stack.Handler.ServeHTTP(response, request)
 				if response.Code != http.StatusOK {
-					b.Fatalf("plaintext status = %d, want %d; body: %s", response.Code, http.StatusOK, response.Body.String())
+					// Errorf, not Fatalf: this runs in a RunParallel worker
+					// goroutine, and testing.Fatal/FailNow are only safe from the
+					// benchmark's own goroutine. Errorf marks the failure
+					// concurrency-safely; return stops this worker.
+					b.Errorf("plaintext status = %d, want %d; body: %s", response.Code, http.StatusOK, response.Body.String())
+					return
 				}
 			}
 		})
@@ -55,7 +60,10 @@ func RunParallelBenchmark(b *testing.B, stack Stack) {
 				response := httptest.NewRecorder()
 				stack.Handler.ServeHTTP(response, request)
 				if !statusOKOrCreated(response.Code) {
-					b.Fatalf("valid-post status = %d; body: %s", response.Code, response.Body.String())
+					// Errorf, not Fatalf: called from a RunParallel worker
+					// goroutine (see the plaintext site above).
+					b.Errorf("valid-post status = %d; body: %s", response.Code, response.Body.String())
+					return
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

The BENCH-1 micro suite ran every scenario single-goroutine, so it could not surface per-request serialization. The metrics-mutex scaling problem (#239) was invisible to `BenchmarkFrameworkTax` and only appeared under a parallel driver.

This adds `scenario.RunParallelBenchmark` (plaintext + valid-POST via `b.RunParallel`) and a `BenchmarkFrameworkTaxParallel` in all four rows (nethttp/gin/huma/gombit). Reading a row's per-op time across `-cpu` values shows whether it scales (ns/op falls with cores) or is contention-bound (ns/op flattens):

```
go test ./benchmarks/micro/... -bench=BenchmarkFrameworkTaxParallel -benchmem -cpu=1,2,4,8,16
```

Demonstration on this branch (Gombit still mutex-bound here, i.e. #239 not yet merged), plaintext ns/op:

| stack | -cpu=1 | -cpu=4 | -cpu=8 |
| --- | --- | --- | --- |
| gombit | 4401 | 2470 | 2825 (plateaus/regresses — contention-bound) |
| net-http (control) | 637 | — | 419 (keeps improving — no shared lock) |

Closes #243

## Acceptance criteria

- [x] Parallel benchmark exists in the shared harness and runs for all four rows.
- [x] Methodology doc (`benchmarks/docs/methodology.md`) explains what the parallel row measures and how to read it.
- [ ] Results/schema updated to carry the parallel numbers — **deliberately deferred** (see scope): the canonical snapshot must be regenerated on the dedicated benchmark host named in `metadata.json`, not a dev machine, or it would poison the README table with host-noisy numbers.

## Scope notes

Benchmark-infra only (labels align with #141: infra/tests/ci); no runtime change. The parallel row is a **diagnostic**, host- and scheduler-sensitive, intentionally kept out of the published README snapshot. Wiring the numbers into the generated results pipeline (`run-suite.sh`, `schema.md`) and a CI scaling-floor gate is a follow-up that belongs on the canonical host. This harness is what verifies #239/#240's scaling claims.

## Validation

- [x] `go test ./benchmarks/micro/... -run TestScenarios` — passes (all rows still correct)
- [x] `go vet ./benchmarks/micro/...` — clean
- [x] `BenchmarkFrameworkTaxParallel` runs for all four rows
- [ ] `golangci-lint` — not run locally (CI will run it)
- [ ] Project `code-review` skill — not run

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A, no DB change (benchmark harness)
- [x] Stable features ship docs and appear in an example app — methodology doc updated; the "example" for a benchmark is the harness itself
- [x] Extraction preserves contracts — existing `BenchmarkFrameworkTax` and `TestScenarios` untouched
- [ ] Generators are idempotent/additive, AST-safe — N/A, no generator change
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no API change
- [x] No secrets in generated frontend source — N/A
- [x] Scope stays inside this issue's milestone — no battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies
