### PR TITLE
fix: admin search is case-insensitive across SQLite/Postgres/MySQL

### DIFF
--- a/admin/integration_test.go
+++ b/admin/integration_test.go
@@ -60,6 +60,23 @@ func runResourceDriver(t *testing.T, driver config.DatabaseDriver, dsn string) {
 	if list.Code != http.StatusOK {
 		t.Fatalf("list status = %d; body: %s", list.Code, list.Body.String())
 	}
+
+	// Search must be ASCII case-insensitive on every driver, matching
+	// SQLite's default behavior — Postgres's plain LIKE is case-sensitive,
+	// which was issue #200. (ASCII only: SQLite's LOWER() doesn't fold
+	// non-ASCII case, so this doesn't prove Unicode parity with Postgres/
+	// MySQL's locale-aware LOWER().)
+	caseInsensitive := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets?search=bolt", "")
+	if caseInsensitive.Code != http.StatusOK {
+		t.Fatalf("case-insensitive search status = %d; body: %s", caseInsensitive.Code, caseInsensitive.Body.String())
+	}
+	var foundLower listEnvelope
+	if err := json.Unmarshal(caseInsensitive.Body.Bytes(), &foundLower); err != nil {
+		t.Fatalf("decode case-insensitive search: %v", err)
+	}
+	if foundLower.Meta == nil || foundLower.Meta.Total != 1 || len(foundLower.Data) != 1 || foundLower.Data[0]["name"] != "Bolt" {
+		t.Fatalf("case-insensitive search = %+v", foundLower)
+	}
 	del := doRequest(app, jar, http.MethodDelete, "/api/v1/admin/resources/widgets/"+id, "")
 	if del.Code != http.StatusOK {
 		t.Fatalf("delete status = %d; body: %s", del.Code, del.Body.String())

--- a/admin/resources.go
+++ b/admin/resources.go
@@ -485,7 +485,7 @@ func applySearch(q *gorm.DB, m *registered, term string) (*gorm.DB, error) {
 			continue
 		}
 		ors = append(ors, clause.Expr{
-			SQL:  quoteIdent(q, col) + " LIKE ? ESCAPE ?",
+			SQL:  "LOWER(" + quoteIdent(q, col) + ") LIKE LOWER(?) ESCAPE ?",
 			Vars: []any{pattern, `\`},
 		})
 	}

--- a/admin/resources_test.go
+++ b/admin/resources_test.go
@@ -515,6 +515,19 @@ func TestResourceListPaginationSearchOrderFilter(t *testing.T) {
 		t.Fatalf("search = %+v", found)
 	}
 
+	// Search is ASCII case-insensitive regardless of driver collation — see
+	// issue #200. (Not a full Django icontains equivalent: SQLite's LOWER()
+	// only folds ASCII, so Unicode case-folding parity across drivers isn't
+	// guaranteed for accented/non-Latin terms.)
+	caseInsensitive := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets?search=beta", "")
+	var foundLower listEnvelope
+	if err := json.Unmarshal(caseInsensitive.Body.Bytes(), &foundLower); err != nil {
+		t.Fatalf("decode case-insensitive search: %v", err)
+	}
+	if foundLower.Meta == nil || foundLower.Meta.Total != 1 || len(foundLower.Data) != 1 || foundLower.Data[0]["name"] != "Beta" {
+		t.Fatalf("case-insensitive search = %+v", foundLower)
+	}
+
 	ordered := doRequest(app, jar, http.MethodGet, "/api/v1/admin/resources/widgets?ordering=-price", "")
 	var ranked listEnvelope
 	if err := json.Unmarshal(ordered.Body.Bytes(), &ranked); err != nil {

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -250,7 +250,10 @@ List query parameters:
 
 - `page`, `per_page` (default page 1, per_page 20, max 100; same
   `contract.ClampPage` as generated list handlers)
-- `search` (OR `LIKE` across `Options.Search`)
+- `search` (OR `LIKE` across `Options.Search`, ASCII case-insensitive on
+  every supported driver — SQLite's built-in `LOWER()` folds ASCII only, so
+  full Unicode case-folding parity with Django's `icontains` is not
+  guaranteed for accented/non-Latin search terms)
 - `ordering` (a field from `Options.Ordering`; prefix `-` for DESC)
 - one query key per `Options.Filter` field
 


### PR DESCRIPTION
## Summary

`applySearch` built its predicate with a plain SQL `LIKE`, whose case
sensitivity is driver-dependent: case-sensitive on PostgreSQL, case-
insensitive on SQLite/MySQL by default collation. The same `?search=`
query silently returned fewer/zero results on Postgres than on
SQLite/MySQL for the same data. Fixed by wrapping both sides of the
comparison in SQL `LOWER()` uniformly (no per-driver branching),
matching the cross-driver convention already used in
`database/errors.go`.

Closes #200

## Acceptance criteria

- [x] The generic admin list search (`Options.Search`) returns the same
      result set for the same query and data on SQLite, PostgreSQL, and
      MySQL — verified by running the fix against live Postgres 16 and
      MySQL 8.4 containers, not just the SQLite default test path.
- [x] No driver-specific branching introduced (`ILIKE`, `Dialector.Name()`,
      etc.) — the fix is a single uniform SQL predicate.

## Scope notes

Case-insensitivity here is ASCII-only, matching what SQLite's built-in
`LOWER()` can do without the ICU extension (not loaded by this
codebase). Postgres/MySQL fold full Unicode via their locale/charset
`LOWER()`, so accented/non-Latin search terms are not guaranteed
identical results across all three drivers — that gap is documented in
`docs/admin.md` and in the two regression-test comments rather than
silently implied. Closing it fully would mean either a per-driver
collation/extension story or reaching into Unicode-aware text handling,
which borders the M6 i18n battery and is out of scope for this issue
(the reported symptom, and the issue's own suggested fix, are ASCII
case only).

## Validation

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test -tags integration ./admin -admin.postgres-dsn '...'` (Postgres 16 container)
- [x] `go test -tags integration ./admin -admin.mysql-dsn '...'` (MySQL 8.4 container)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [x] Project `code-review` skill run against this diff (one MAJOR finding — overclaiming "case-insensitive on every driver" without the ASCII qualifier — addressed by tightening the docs/comments wording; no code change needed)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix
- [ ] Stable features ship docs and appear in an example app — N/A, this is a bugfix to existing documented behavior, not a new stable feature; `docs/admin.md`'s search description is updated in place instead
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests — N/A, no extraction involved
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — N/A, no generator touched
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no request/response shape change, internal query-building only
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public — N/A, no frontend touched
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n) — explicitly declined to chase full Unicode parity for this reason, see Scope notes
- [x] This PR links its issue and states which acceptance criteria it satisfies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TdyJhLKLe6k26JEi9i6VZ