### PR TITLE
fix: embedded frontend serves HEAD like GET on SPA routes and index.html

### DIFF
--- a/framework/embed.go
+++ b/framework/embed.go
@@ -69,10 +69,9 @@ func embeddedFrontendHandler(fsys fs.FS, apiPrefix string) gin.HandlerFunc {
 			}
 		}
 
-		if c.Request.Method != http.MethodGet {
-			c.AbortWithStatus(http.StatusNotFound)
-			return
-		}
+		// SPA fallback: only GET and HEAD reach this handler at all (the
+		// guard above), and serveIndexHTML writes via writeBytes, which
+		// already skips the body for HEAD — so no method check belongs here.
 		serveIndexHTML(c, fsys, apiPrefix)
 	}
 }
@@ -139,7 +138,7 @@ func serveEmbeddedFile(c *gin.Context, fsys fs.FS, name string) bool {
 	if err != nil {
 		return false
 	}
-	c.Data(http.StatusOK, contentTypeFor(name), data)
+	writeBytes(c, contentTypeFor(name), data)
 	return true
 }
 
@@ -151,7 +150,7 @@ func serveIndexHTML(c *gin.Context, fsys fs.FS, apiPrefix string) {
 	}
 	data = injectAPIPrefixHTML(data, apiPrefix)
 	applySPAContentSecurityPolicy(c)
-	c.Data(http.StatusOK, "text/html; charset=utf-8", data)
+	writeBytes(c, "text/html; charset=utf-8", data)
 }
 
 func contentTypeFor(name string) string {

--- a/framework/embed_test.go
+++ b/framework/embed_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -42,6 +43,61 @@ func TestEmbeddedFrontendServesIndexAndAssets(t *testing.T) {
 	}
 	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "javascript") && !strings.Contains(ct, "ecmascript") {
 		t.Fatalf("GET /assets/app.js Content-Type = %q, want javascript", ct)
+	}
+}
+
+// TestEmbeddedFrontendHeadMatchesGet is the regression test for #251: HEAD
+// on the SPA fallback (root and any unmatched client-side route) must
+// behave like GET minus the body, not 404. It also covers /index.html
+// directly: that path returned 200 for HEAD even before this fix (the
+// bug report's own repro only checked status via curl -I), but serveIndexHTML
+// still wrote the full body on a HEAD request — a body-suppression gap
+// curl -I can't see (libcurl silently discards a HEAD response body), only
+// caught here because serveEmbed drives the handler directly against a
+// ResponseRecorder, which — unlike a real net/http.Server — never
+// suppresses a HEAD body on its own.
+func TestEmbeddedFrontendHeadMatchesGet(t *testing.T) {
+	app := newTestApp(t, WithEmbeddedFrontend(spaFixtureFS()))
+
+	for _, path := range []string{"/", "/index.html", "/login", "/products/new"} {
+		get := serveEmbed(t, app, http.MethodGet, path, nil)
+		if get.Code != http.StatusOK {
+			t.Fatalf("GET %s status = %d, want %d; body=%s", path, get.Code, http.StatusOK, get.Body.String())
+		}
+		wantLength := strconv.Itoa(get.Body.Len())
+
+		rec := serveEmbed(t, app, http.MethodHead, path, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("HEAD %s status = %d, want %d; body=%s", path, rec.Code, http.StatusOK, rec.Body.String())
+		}
+		if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+			t.Fatalf("HEAD %s Content-Type = %q, want text/html", path, ct)
+		}
+		if got := rec.Body.String(); got != "" {
+			t.Fatalf("HEAD %s body = %q, want empty", path, got)
+		}
+		// RFC 9110: a HEAD response must carry the Content-Length the
+		// equivalent GET would send, even though the body itself is omitted.
+		if got := rec.Header().Get("Content-Length"); got != wantLength {
+			t.Fatalf("HEAD %s Content-Length = %q, want %q (GET body length)", path, got, wantLength)
+		}
+	}
+
+	get := serveEmbed(t, app, http.MethodGet, "/assets/app.js", nil)
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET /assets/app.js status = %d, want %d; body=%s", get.Code, http.StatusOK, get.Body.String())
+	}
+	wantLength := strconv.Itoa(get.Body.Len())
+
+	rec := serveEmbed(t, app, http.MethodHead, "/assets/app.js", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HEAD /assets/app.js status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != "" {
+		t.Fatalf("HEAD /assets/app.js body = %q, want empty", got)
+	}
+	if got := rec.Header().Get("Content-Length"); got != wantLength {
+		t.Fatalf("HEAD /assets/app.js Content-Length = %q, want %q (GET body length)", got, wantLength)
 	}
 }
 


### PR DESCRIPTION
## Summary

`embeddedFrontendHandler` blocked HEAD with a redundant guard that ran
after the file-serving attempts, 404ing `HEAD /` and any unmatched
client-side route while `GET` served the SPA fine. The guard was dead
weight: given the handler's own entry guard, only GET or HEAD can ever
reach that point.

Removing it exposed a second, deeper problem the issue itself didn't
catch: `serveIndexHTML` and `serveEmbeddedFile`'s non-seekable fallback
wrote the response body via `c.Data` even for HEAD, so `/index.html`
"working" (200 status) still leaked a body that `curl -I` can't reveal
(libcurl discards a HEAD body silently). Both now route through the
`writeBytes` helper `adminui.go` already uses for the same purpose,
which explicitly skips the body (and sets `Content-Length` correctly)
on HEAD.

Closes #251

## Acceptance criteria

- [x] `HEAD /` (and any unmatched SPA route) returns the same status
      and headers as `GET`, with no body — verified against `/`,
      `/login`, `/products/new`.
- [x] `HEAD /index.html` returns the same, closing a body-suppression
      gap the issue's own `curl -I` repro couldn't detect.
- [x] `HEAD` on a real embedded asset (`/assets/app.js`) keeps working
      as before.
- [x] `Content-Length` on a HEAD response matches what the equivalent
      GET would send (RFC 9110), asserted against the live GET response
      rather than a hardcoded value.

## Scope notes

None — this is a self-contained runtime fix, no generator/contract/DB
surface touched.

## Validation

- [x] `go build ./...`
- [x] `go test ./framework/... -race -v`
- [x] `go test ./...` (full repo, matches CI baseline)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`
- [x] Project `code-review` skill run against this diff: one finding
      (the regression test didn't assert `Content-Length` on HEAD,
      the most specific RFC 9110 guarantee the issue names) — addressed
      by comparing HEAD's `Content-Length` against the equivalent GET
      response's actual body length

Note: `go test ./... -race` surfaces a pre-existing, unrelated data race
in `dev/supervisor.go` (`TestRunChildEnvReplacesParentHTTPAddr`,
concurrent stdout/stderr pipe copying between two spawned child
processes). Confirmed present on `main` before this branch — out of
scope here, flagging separately.

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A, no database touched
- [ ] Stable features ship docs and appear in an example app — N/A, bugfix restoring documented HEAD/GET parity, not a new feature
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests — N/A, no extraction involved
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — N/A, no generator touched
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no request/response shape change; these routes stay out of OpenAPI (raw Gin escape hatch, unchanged)
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public — N/A, no frontend touched
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep (jobs, events, scheduler, mail, storage, gRPC, multi-tenancy, i18n)
- [x] This PR links its issue and states which acceptance criteria it satisfies