### PR TITLE
fix: eliminate two data races in dev package process-supervision tests

### DIFF
--- a/dev/options.go
+++ b/dev/options.go
@@ -60,6 +60,9 @@ type Options struct {
 	// AdminURL is printed in the service table when non-empty (cookie-mode
 	// apps that mount the framework admin SPA). JWT apps leave this empty.
 	AdminURL string
+	// onCmdReady is an in-package test seam; see runProcesses. Always nil
+	// outside dev's own tests.
+	onCmdReady func(*exec.Cmd)
 }
 
 func (opts *Options) normalize() error {

--- a/dev/run.go
+++ b/dev/run.go
@@ -114,7 +114,7 @@ func Run(ctx context.Context, opts Options) error {
 		_ = watchOpenAPI(runCtx, opts, services.Backend+"/openapi.json")
 	}()
 
-	err = runProcesses(runCtx, procs, opts.Stdout, opts.Stderr, opts.Command, opts.ShutdownWait)
+	err = runProcesses(runCtx, procs, opts.Stdout, opts.Stderr, opts.Command, opts.ShutdownWait, opts.onCmdReady)
 	cancel()
 	<-watchDone
 	if err != nil {

--- a/dev/run_test.go
+++ b/dev/run_test.go
@@ -54,8 +54,8 @@ func TestRunPrintsServiceTableAndShutsDown(t *testing.T) {
 	}
 
 	workDir := writeDevApp(t)
-	stdout := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
+	stdout := &syncBuffer{}
+	stderr := &syncBuffer{}
 	var started atomic.Int32
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -150,7 +150,7 @@ func TestRunProcessesShutdownOnCancel(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- runProcesses(ctx, specs, ioDiscard{}, ioDiscard{}, command, 2*time.Second)
+		errCh <- runProcesses(ctx, specs, ioDiscard{}, ioDiscard{}, command, 2*time.Second, nil)
 	}()
 
 	waitStarts(t, startedCh, 2)
@@ -172,6 +172,29 @@ type ioDiscard struct{}
 
 func (ioDiscard) Write(p []byte) (int, error) {
 	return len(p), nil
+}
+
+// syncBuffer is a bytes.Buffer safe for concurrent Write/String. Real
+// `gombit dev` always shares its Stdout/Stderr *os.File across child
+// processes (os/exec wires those directly, no in-process copy goroutine),
+// but a mocked test process makes os/exec spin up a copy goroutine per
+// child, so an in-memory sink shared across children (and read from the
+// test goroutine while they run) needs its own locking.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }
 
 func writeDevApp(t *testing.T) string {
@@ -210,37 +233,23 @@ func waitStarts(t *testing.T, startedCh <-chan struct{}, n int) {
 	}
 }
 
-// waitChildEnvAssigned waits until n captured cmds have a non-empty Env.
-// opts.Command signals startedCh before runOne/runProcesses assigns cmd.Env,
-// so reading Env immediately after waitStarts can observe a nil overlay.
-func waitChildEnvAssigned(t *testing.T, mu *sync.Mutex, cmds *[]*exec.Cmd, n int) []*exec.Cmd {
+// waitCmdsReady receives n cmds sent by runProcesses's onCmdReady hook, which
+// fires after cmd.Env is assigned — so each receive has a real happens-before
+// edge to that write (Go memory model: a send happens before the
+// corresponding receive completes), unlike polling cmd.Env directly.
+func waitCmdsReady(t *testing.T, readyCh <-chan *exec.Cmd, n int) []*exec.Cmd {
 	t.Helper()
 	deadline := time.After(3 * time.Second)
-	ticker := time.NewTicker(5 * time.Millisecond)
-	defer ticker.Stop()
-	var captured []*exec.Cmd
-	for {
-		mu.Lock()
-		captured = append([]*exec.Cmd(nil), *cmds...)
-		ready := len(captured) >= n
-		if ready {
-			for _, cmd := range captured {
-				if len(cmd.Env) == 0 {
-					ready = false
-					break
-				}
-			}
-		}
-		mu.Unlock()
-		if ready {
-			return captured
-		}
+	captured := make([]*exec.Cmd, 0, n)
+	for i := 0; i < n; i++ {
 		select {
+		case cmd := <-readyCh:
+			captured = append(captured, cmd)
 		case <-deadline:
-			t.Fatalf("timed out waiting for child Env overlay (got %d cmds)", len(captured))
-		case <-ticker.C:
+			t.Fatalf("timed out waiting for %d child cmds to be ready (got %d)", n, i)
 		}
 	}
+	return captured
 }
 
 func TestPlanBackendPrefersAir(t *testing.T) {
@@ -494,10 +503,12 @@ func TestRunChildEnvReplacesParentHTTPAddr(t *testing.T) {
 	t.Setenv("VITE_API_URL", "http://localhost:8080/api/v1")
 
 	workDir := writeDevApp(t)
-	stdout := new(bytes.Buffer)
-	var mu sync.Mutex
-	var cmds []*exec.Cmd
-	startedCh := make(chan struct{}, 2)
+	// readyCh (not startedCh+polling) is the synchronization point: onCmdReady
+	// fires after runProcesses assigns cmd.Env, so the channel receive below
+	// has a real happens-before edge to that write. Reading cmd.Env off a
+	// racily-polled slice (the previous approach) trips -race even though the
+	// values eventually observed are correct.
+	readyCh := make(chan *exec.Cmd, 2)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -507,7 +518,7 @@ func TestRunChildEnvReplacesParentHTTPAddr(t *testing.T) {
 		FrontendPort: 15174,
 		PollInterval: 50 * time.Millisecond,
 		ShutdownWait: 2 * time.Second,
-		Stdout:       stdout,
+		Stdout:       ioDiscard{},
 		Stderr:       ioDiscard{},
 		LookPath: func(file string) (string, error) {
 			switch file {
@@ -518,16 +529,12 @@ func TestRunChildEnvReplacesParentHTTPAddr(t *testing.T) {
 			}
 		},
 		Command: func(name string, args ...string) *exec.Cmd {
-			cmd := exec.Command("sh", "-c", "echo ready; trap 'exit 0' TERM; sleep 60")
-			mu.Lock()
-			cmds = append(cmds, cmd)
-			mu.Unlock()
-			startedCh <- struct{}{}
-			return cmd
+			return exec.Command("sh", "-c", "echo ready; trap 'exit 0' TERM; sleep 60")
 		},
 		HTTPGet: func(ctx context.Context, rawURL string) ([]byte, error) {
 			return nil, errors.New("backend not ready")
 		},
+		onCmdReady: func(cmd *exec.Cmd) { readyCh <- cmd },
 	}
 
 	errCh := make(chan error, 1)
@@ -535,8 +542,7 @@ func TestRunChildEnvReplacesParentHTTPAddr(t *testing.T) {
 		errCh <- Run(ctx, opts)
 	}()
 
-	waitStarts(t, startedCh, 2)
-	captured := waitChildEnvAssigned(t, &mu, &cmds, 2)
+	captured := waitCmdsReady(t, readyCh, 2)
 	for _, cmd := range captured {
 		if values := envKeyValues(cmd.Env, "GOMBIT_HTTP_ADDR"); len(values) != 1 || values[0] != ":9090" {
 			t.Fatalf("child Env GOMBIT_HTTP_ADDR = %v, want single :9090", values)

--- a/dev/supervisor.go
+++ b/dev/supervisor.go
@@ -19,7 +19,12 @@ type ProcSpec struct {
 	Args []string
 }
 
-func runProcesses(ctx context.Context, specs []ProcSpec, stdout, stderr io.Writer, command CommandFunc, wait time.Duration) error {
+// onCmdReady, when non-nil, is called synchronously right after a spec's
+// Env/Dir/Stdout/Stderr are assigned to its *exec.Cmd, before Start. It is
+// nil on every real `gombit dev` invocation; tests use it to observe a
+// child's final Env without racing runProcesses's unsynchronized field
+// writes (see dev/run_test.go TestRunChildEnvReplacesParentHTTPAddr).
+func runProcesses(ctx context.Context, specs []ProcSpec, stdout, stderr io.Writer, command CommandFunc, wait time.Duration, onCmdReady func(*exec.Cmd)) error {
 	if command == nil {
 		command = exec.Command
 	}
@@ -50,6 +55,9 @@ func runProcesses(ctx context.Context, specs []ProcSpec, stdout, stderr io.Write
 		}
 		if cmd.Stderr == nil {
 			cmd.Stderr = stderr
+		}
+		if onCmdReady != nil {
+			onCmdReady(cmd)
 		}
 		prepareProcessGroup(cmd)
 		if err := cmd.Start(); err != nil {


### PR DESCRIPTION
## Summary

`go test ./dev/... -race` failed on `TestRunChildEnvReplacesParentHTTPAddr`
(reliably, every run) because the test shared one `*bytes.Buffer` as
`Options.Stdout` across two concurrently-started mocked child processes.
`runProcesses` (`dev/supervisor.go`) fans a single writer out to every
`ProcSpec` whose own `cmd.Stdout` is nil; when that writer isn't an
`*os.File`, `os/exec` spins up a copy goroutine per child, and two such
goroutines writing to the same unsynchronized buffer is exactly what `-race`
flagged. The real `gombit dev` binary is unaffected: `cmd/gombit/main.go`
always passes `os.Stdout`/`os.Stderr` (real files) all the way down, and
`os/exec` wires those directly via dup2 with no copy goroutine.

`TestRunPrintsServiceTableAndShutsDown` had the identical construction, plus
a second hazard: it read `stdout.String()`/`stderr.String()` while those
copy goroutines could still be writing.

Fixing the buffer race exposed a **second, previously-masked race** in
`TestRunChildEnvReplacesParentHTTPAddr`: `runProcesses` assigns `cmd.Env` on
its own goroutine with no synchronization, and the existing
`waitChildEnvAssigned` test helper polled `cmd.Env` from the test goroutine
with no memory barrier connecting the two — a genuine unsynchronized access
regardless of whether the polled value was ever actually wrong. This
reproduces on unmodified `main` too (hit in 1 of 15 `-race` runs), just
normally masked by the louder, near-always-reproducible buffer race
finishing first.

## Fix

- `TestRunChildEnvReplacesParentHTTPAddr`: the shared buffer was never read
  (only ever assigned, never inspected) — dropped it for `ioDiscard{}`.
- `TestRunPrintsServiceTableAndShutsDown`: content *is* asserted, so its
  shared writers became a small mutex-guarded `syncBuffer` instead.
- The Env race: added an unexported `onCmdReady func(*exec.Cmd)` test seam to
  `runProcesses`/`Options`, invoked right after `cmd.Env` is assigned and
  before `Start`. The test now blocks on a channel receive instead of
  polling the field, which gives a real happens-before edge under the Go
  memory model. `onCmdReady` is `nil` (a no-op) on every real `gombit dev`
  invocation — `dev/run.go` is the only caller of `runProcesses` outside
  tests, and `Options` is built in a different package (`cli`) that can't
  set an unexported field.

No behavior change to the shipped `gombit dev` command.

Closes #255

## Acceptance criteria

The linked issue is a bug report without a formal AC checklist; treating its
"Suggested fix" / reproduction steps as the bar:

- [x] `go test ./dev/... -race -run TestRunChildEnvReplacesParentHTTPAddr -count=3` passes (was reliably failing before)
- [x] `go test ./dev/... -race -count=30` (targeted at all three touched tests) passes with zero races
- [x] Confirmed via code trace that `cmd/gombit/main.go` → `cli.NewRoot` → `newDevCommand` → `dev.Options` always passes a real `*os.File`, so this was never reachable through the shipped binary
- [x] The second (Env-field) race, not identified in the original issue, is fixed with real synchronization rather than left as residual flakiness

## Scope notes

Test-infrastructure fix plus one small internal (unexported) seam in
`dev/supervisor.go`/`dev/options.go`. No public API, HTTP contract,
generator, database, or auth surface touched.

## Validation

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test ./dev/... -race -count=30` (targeted stress run on the three previously-racy tests)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` (0 issues)
- [x] Project `code-review` skill run against this diff — APPROVE, two non-blocking MINOR notes (doc-comment placement on `runProcesses`; a pre-existing hardcoded channel-capacity convention in the test file, unchanged by this PR)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A, no DB touched; the "new behavior" here is the race-free test synchronization itself, exercised by a 30x `-race` stress run
- [ ] Stable features ship docs and appear in an example app — N/A, internal test-infra fix, not a user-facing feature
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests — assertions in both touched tests are unchanged; only the synchronization mechanism was replaced
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — N/A, no generator touched
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no API change
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public — N/A, no frontend touched
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep — confirmed, test-infra only
- [x] This PR links its issue and states which acceptance criteria it satisfies
