### PR TITLE
fix: gombit db rollback runs down files statement-by-statement

### DIFF
--- a/migrations/apply_test.go
+++ b/migrations/apply_test.go
@@ -250,6 +250,59 @@ func TestMigrateRecordsOnlyVersionsPresentInAtlas(t *testing.T) {
 	}
 }
 
+// Note: a happy-path multi-statement SQLite test is intentionally not here.
+// mattn/go-sqlite3 already executes a multi-statement string sequentially in
+// one Exec, and Rollback runs inside a transaction on SQLite, so such a test
+// would pass identically before and after the statement-splitting fix for
+// #249 and prove nothing. The real regression coverage for that fix is
+// TestMigrateRollbackStatusMySQL (migrations/integration_test.go, requires a
+// live MySQL DSN) and the statement-numbering check below.
+
+func TestRollbackMidStatementFailureNamesStatementNumber(t *testing.T) {
+	workDir := t.TempDir()
+	migrationDir := filepath.Join(workDir, "database", "migrations")
+	if err := os.MkdirAll(migrationDir, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(migrationDir, "20260101000000_create_widgets.sql"),
+		"CREATE TABLE widgets (id INTEGER PRIMARY KEY);")
+	writeFile(t, filepath.Join(migrationDir, "downs", "20260101000000_create_widgets.down.sql"),
+		"DROP TABLE widgets;\nTHIS IS NOT VALID SQL;")
+
+	dsn := "file:" + filepath.Join(workDir, "app.db") + "?cache=shared&_fk=1"
+	cfg := config.DatabaseConfig{Driver: config.DatabaseDriverSQLite, DSN: dsn}
+	opts := ApplyOptions{
+		WorkDir:      workDir,
+		MigrationDir: migrationDir,
+		Database:     cfg,
+		Stdout:       io.Discard,
+		runner:       &applyFakeAtlas{t: t},
+	}
+	if err := Migrate(context.Background(), opts); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	err := Rollback(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Rollback() error = nil, want second-statement failure")
+	}
+	if !strings.Contains(err.Error(), "execute statement 2 of") {
+		t.Fatalf("Rollback() error = %q, want it to name the failing statement", err)
+	}
+	if !strings.Contains(err.Error(), "framework_migrations unchanged") {
+		t.Fatalf("Rollback() error = %q, want unchanged revisions guidance", err)
+	}
+
+	db, err := database.Open(cfg)
+	if err != nil {
+		t.Fatalf("database.Open() error = %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !db.Migrator().HasTable("widgets") {
+		t.Fatal("expected widgets table to remain: rollback runs in a transaction on SQLite, so the successful first statement must be rolled back too")
+	}
+}
+
 func TestRollbackMidBatchFailureAbortsTransaction(t *testing.T) {
 	workDir := t.TempDir()
 	migrationDir := filepath.Join(workDir, "database", "migrations")

--- a/migrations/integration_test.go
+++ b/migrations/integration_test.go
@@ -34,7 +34,8 @@ func TestMigrateRollbackStatusPostgres(t *testing.T) {
 CREATE TABLE IF NOT EXISTS widgets (
   id BIGSERIAL PRIMARY KEY,
   name TEXT NOT NULL
-);`, `DROP TABLE IF EXISTS widgets;`)
+);`,
+		"ALTER TABLE widgets DROP COLUMN name;\nDROP TABLE IF EXISTS widgets;")
 }
 
 func TestMigrateRollbackStatusMySQL(t *testing.T) {
@@ -48,7 +49,8 @@ func TestMigrateRollbackStatusMySQL(t *testing.T) {
 CREATE TABLE IF NOT EXISTS widgets (
   id BIGINT AUTO_INCREMENT PRIMARY KEY,
   name VARCHAR(255) NOT NULL
-);`, `DROP TABLE IF EXISTS widgets;`)
+);`,
+		"ALTER TABLE widgets DROP COLUMN name;\nDROP TABLE IF EXISTS widgets;")
 }
 
 func TestSeedResetPostgres(t *testing.T) {

--- a/migrations/rollback.go
+++ b/migrations/rollback.go
@@ -13,13 +13,17 @@ import (
 )
 
 // Rollback rolls back the latest framework_migrations batch using companion down SQL.
+// Each down file is split into individual statements (like Seed) and executed
+// one Exec per statement, so a down file is no longer required to be a single
+// SQL statement on MySQL.
 //
 // On SQLite and PostgreSQL, down SQL and revision deletes run in one transaction
 // so a mid-batch failure leaves neither schema nor revision ledgers partially
 // updated. MySQL DDL often auto-commits, so a mid-batch failure can leave the
-// schema partially rolled back while revision rows remain; the error message
-// lists completed downs and revision rows are not deleted until every down
-// succeeds.
+// schema partially rolled back while revision rows remain — including inside a
+// single down file, if an earlier statement in it already committed before a
+// later one failed; the error message names the failing statement and file,
+// and revision rows are not deleted until every down succeeds.
 func Rollback(ctx context.Context, opts ApplyOptions) error {
 	if ctx == nil {
 		return errors.New("migrations: nil context")
@@ -100,8 +104,17 @@ func Rollback(ctx context.Context, opts ApplyOptions) error {
 		if sqlText == "" {
 			return rollbackFail(tx, useTx, versions, file.DownPath, errors.New("empty down migration"), "execute")
 		}
-		if err := execDB.Exec(sqlText).Error; err != nil {
-			return rollbackFail(tx, useTx, versions, file.DownPath, err, "execute")
+		// Split like Seed does: go-sql-driver/mysql rejects a multi-statement
+		// string in one Exec unless the DSN opts in with multiStatements=true,
+		// which no gombit-generated or documented MySQL DSN does.
+		stmts := splitSQLStatements(sqlText)
+		if len(stmts) == 0 {
+			return rollbackFail(tx, useTx, versions, file.DownPath, errors.New("down migration has no executable statements"), "execute")
+		}
+		for i, stmt := range stmts {
+			if err := execDB.Exec(stmt).Error; err != nil {
+				return rollbackFail(tx, useTx, versions, file.DownPath, err, fmt.Sprintf("execute statement %d of", i+1))
+			}
 		}
 		versions = append(versions, file.Version)
 	}


### PR DESCRIPTION
## Summary

- `migrations.Rollback` ran each companion down file as a single `Exec(wholeFile)` call. On MySQL, `go-sql-driver/mysql` rejects a multi-statement string in one `Exec` unless the DSN opts in with `multiStatements=true` — which no gombit-generated or documented MySQL DSN does — so any down file with more than one statement failed with a 1064 syntax error. SQLite and PostgreSQL masked this because their drivers tolerate a multi-statement `Exec`.
- Split each down file with the same `splitSQLStatements` helper `Seed` already uses, and execute one statement per `Exec`, in order (inside the existing transaction on SQLite/Postgres, sequentially on MySQL). The failure message now names the failing statement index and file, as suggested in the issue.

Closes #249

## Acceptance criteria

The issue is a bug report without an explicit AC checklist; its "Expected" / "Suggested fix" sections are the contract this PR satisfies:

- [x] Rollback executes down files statement-by-statement the same way `Seed` does (`splitSQLStatements`), so a documented multi-statement down file works on all three supported drivers.
- [x] The MySQL partial-failure error message names the exact statement that failed rather than the whole file.

## Scope notes

None — this is scoped to `migrations.Rollback`'s down-file execution, matching the issue exactly. No M6 battery, no API surface change.

## Validation

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — 0 issues
- [x] `go test -tags integration ./migrations -migrations.postgres-dsn ... -migrations.mysql-dsn ...` against real Postgres 16 and MySQL 8.4 containers — confirmed the MySQL test reproduces the original 1064 error against the pre-fix code and passes after the fix
- [x] Project `code-review` skill run against this diff (two rounds: first round found a non-discriminating SQLite unit test and an under-specified doc comment, both fixed and re-verified in the second round — APPROVE)

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix
- [ ] Stable features ship docs and appear in an example app — N/A, this is a bug fix to existing documented behavior, not a new feature
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests — reuses `seed.go`'s existing `splitSQLStatements`, no new parsing logic
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (if this PR touches generators) — N/A, no generator touched
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no public API change
- [x] No secrets in generated frontend source; `VITE_*` is treated as public — N/A, no frontend touched, checked anyway
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep
- [x] This PR links its issue and states which acceptance criteria it satisfies