### PR TITLE
fix: stripHTML preserves text after an unclosed XSS skip tag

### DIFF
--- a/docs/router.md
+++ b/docs/router.md
@@ -91,8 +91,9 @@ Other behavior notes:
   [`framework.WithRawBodyPaths`](auth-cookie.md#exempting-non-browser-endpoints-webhooks):
   they skip sanitization entirely (and the 8MiB cap below), so the body reaches
   the handler byte-for-byte, and they are CSRF-exempt too.
-- Unclosed dangerous elements (for example a truncated `<script>...`) discard
-  the remainder of the string (fail-closed).
+- Unclosed dangerous elements (for example a truncated `<script>...`) strip
+  the tag itself but keep the following text as plain text; only content
+  inside a *properly closed* dangerous element is discarded.
 - Incomplete angle brackets that are not a complete HTML tag (no closing
   `>`, e.g. a product name `a<b`) are left unchanged. The HTML tokenizer
   would otherwise treat `"<"+letter` as a start tag and silently shorten

--- a/docs/router.md
+++ b/docs/router.md
@@ -91,14 +91,21 @@ Other behavior notes:
   [`framework.WithRawBodyPaths`](auth-cookie.md#exempting-non-browser-endpoints-webhooks):
   they skip sanitization entirely (and the 8MiB cap below), so the body reaches
   the handler byte-for-byte, and they are CSRF-exempt too.
-- Unclosed dangerous elements (for example a truncated `<script>...`) strip
-  the tag itself but keep the following text as plain text; only content
-  inside a *properly closed* dangerous element is discarded.
-- Incomplete angle brackets that are not a complete HTML tag (no closing
-  `>`, e.g. a product name `a<b`) are left unchanged. The HTML tokenizer
-  would otherwise treat `"<"+letter` as a start tag and silently shorten
-  the string. Complete tags (`<b>hi</b>`, `<script>…</script>`) are still
-  stripped.
+- Unclosed dangerous elements (for example a truncated `<script>…`) strip the
+  tag itself but keep the text that follows; only the content of a *properly
+  closed* dangerous element is discarded. That recovered text is re-parsed, so
+  tags smuggled inside the unclosed element are stripped too and never reach
+  handlers.
+- Incomplete angle brackets that are not a complete HTML tag (no closing `>`,
+  e.g. a product name `a<b`) are left unchanged — the HTML tokenizer would
+  otherwise treat `"<"+letter` as a start tag and silently shorten the string.
+  This applies to the submitted value itself, not to text recovered from
+  inside an unclosed dangerous element. That text is unparsed markup rather
+  than something the user typed, so it is re-parsed in full: every `"<"` +
+  letter through the next `>` is treated as a tag and removed, which can drop
+  more than a stray bracket — `<script>if (a<b && c>d) return` yields
+  `if (ad) return`. Complete tags (`<b>hi</b>`, `<script>…</script>`) are
+  always stripped.
 - JSON sanitizer buffering is capped at 8MiB. Larger JSON bodies abort with
   HTTP 413 and a D10 error envelope (`payload_too_large`) and never reach
   handlers. `http.Server.ReadTimeout` matches `GOMBIT_HTTP_REQUEST_TIMEOUT`

--- a/framework/xss.go
+++ b/framework/xss.go
@@ -241,65 +241,70 @@ func sanitizeJSONValue(value any, fieldName string) bool {
 	return changed
 }
 
-// stripHTML removes HTML tags and discards content inside dangerous elements.
-// Plain strings without "<" or ">" are returned unchanged. Strings that
-// contain "<" / ">" but no complete tag (no closing ">", e.g. "a<b") are
-// also returned unchanged so comparison text is not truncated.
+// stripHTML removes HTML tags and discards the content of dangerous elements
+// (xssSkipElementContent). Strings holding no "<" or ">" are returned
+// unchanged, and so are strings that hold them without forming a complete tag
+// ("a<b"): golang.org/x/net/html reads `"<" + letter` as a start tag and would
+// silently eat the rest of the string (issue #118).
 //
-// An unclosed skip element (for example `<script src=x>...`) strips the tag
-// itself but keeps the following text (issue #201). Text seen while
-// skipDepth > 0 is buffered into skipBuf rather than dropped. skipStarts is
-// a stack of checkpoints into skipBuf, one per currently-open skip element:
-// pushed with the length of skipBuf at the moment that element opened,
-// popped and truncated back to on its matching close. That discards exactly
-// the content opened-and-closed by that one element, however deep it is
-// nested inside other still-open skip elements — a single shared skipDepth
-// counter is not enough, since script/style/textarea/noscript/iframe are
-// HTML "raw text" elements (see below) and can never really nest, but
-// object/embed are ordinary elements and can: for `<object><object>x
-// </object>y`, the inner </object> must discard "x" on its own, without
-// waiting for (or depending on) the outer <object> ever closing too.
-//
-// Whatever remains in skipBuf when the tokenizer runs out of input
-// (skipDepth still > 0 at ErrorToken, nothing left open ever closed) is
-// flushed to the output — re-tokenized from scratch, see below. Self-closing
-// skip tags do not enter skip mode.
-//
-// Re-tokenizing applies the same skip logic again, so a nested dangerous
-// element that finds its own closing tag inside the buffer is still
-// discarded — only text that is not inside any closed dangerous element,
-// anywhere in the chain of unclosed wrappers, survives to the output.
-//
-// The flush re-tokenizes rather than emitting the buffer verbatim, and it
-// must do so with the real tokenizer, not a regexp: script/style/textarea/
-// noscript/iframe are HTML "raw text" elements, so golang.org/x/net/html
-// scans them for a literal closing tag and, finding none, hands back
-// everything up to EOF as one opaque, never-tokenized TextToken — it can
-// still contain complete, attribute-quoted tags that were never parsed. A
-// naive regexp strip (completeHTMLTag) does not track quoting, so a `>`
-// inside a quoted attribute value (`onerror="if(1>0){...}"`) ends the match
-// early and leaks the rest of the tag as text — a classic tag-stripper
-// bypass. Re-tokenizing lets the real HTML tokenizer parse the attribute
-// correctly instead.
-//
-// maxUnclosedSkipRecursion bounds that re-tokenizing to a fixed number of
-// rounds so a pathological chain of unclosed raw-text tags
-// (`<script><script>...`) cannot force unbounded recursive re-tokenizing of
-// a string shrinking by one tag per round — that would be quadratic in
-// input size. Past the cap, the remaining tail reverts to the pre-#201
-// fail-closed default (discarded) instead of being trusted as plain text;
-// legitimate content practically never nests this deep.
+// An unclosed dangerous element strips the tag but keeps the text that follows
+// (issue #201); stripHTMLUnclosed does that work.
 func stripHTML(s string) string {
+	if !strings.ContainsAny(s, "<>") {
+		return s
+	}
+	// The #118 gate covers the string the user actually submitted, and only
+	// that one — stripHTMLUnclosed explains why recovered skip content must
+	// never be admitted by it.
+	if !completeHTMLTag.MatchString(s) {
+		return s
+	}
 	return stripHTMLUnclosed(s, maxUnclosedSkipRecursion)
 }
 
 const maxUnclosedSkipRecursion = 4
 
+// stripHTMLUnclosed tokenizes s, buffering the text of open skip elements so
+// that one which never closes can flush that text instead of dropping it
+// (issue #201), and re-tokenizes what it flushes, at most budget times.
+//
+// Text seen while skipDepth > 0 goes to skipBuf. skipStarts is a stack of
+// offsets into skipBuf, one per open skip element, each recording skipBuf's
+// length when that element opened; the element's matching close pops the
+// offset and truncates back to it, discarding exactly that element's content
+// however deep it sits inside other still-open skip elements. A single shared
+// depth counter is not enough: script/style/textarea/noscript/iframe are HTML
+// "raw text" elements and can never really nest, but object and embed are
+// ordinary elements and can — in `<object><object>x</object>y`, the inner
+// close must discard "x" whether or not the outer one ever closes.
+//
+// Whatever is still buffered at EOF goes back through this function rather
+// than being written out verbatim. It has to: a raw-text element missing its
+// closing tag makes the tokenizer hand back everything up to EOF as one
+// opaque, never-parsed TextToken, so the buffer can still hold complete tags.
+// Re-tokenizing applies the same skip logic to them, so a dangerous element
+// that does find its close inside the buffer is still discarded.
+//
+// That second pass must use the tokenizer, never completeHTMLTag. The regexp
+// is the #118 gate for user-typed comparison text, not a stripper; as an
+// admission gate it would emit live every tag it fails to recognize, and it
+// misses two classes the tokenizer handles — an attribute not preceded by
+// whitespace (`<script/src=x>`, where HTML5 reconsumes the "/" and reads
+// `<script src=x>`), and a ">" inside a quoted attribute value
+// (`onerror="if(1>0){...}"`), which ends the match early and leaks the rest of
+// the tag as text. Anything still holding "<" or ">" is therefore
+// re-tokenized unconditionally, which costs the #118 protection inside
+// recovered text: every `"<" + letter` through the next ">" goes, so
+// `<script>if (a<b && c>d) return` yields "if (ad) return". That is markup
+// smuggled through a raw-text element, not the comparison text #118 covers.
+//
+// budget bounds the re-tokenizing: each unclosed raw-text tag buys one more
+// round on a string only one tag shorter, so an unbounded chain
+// (`<script><script>...`) would be quadratic in input size. Past the cap the
+// tail reverts to the pre-#201 default and is discarded; legitimate content
+// does not nest this deep.
 func stripHTMLUnclosed(s string, budget int) string {
 	if !strings.ContainsAny(s, "<>") {
-		return s
-	}
-	if !completeHTMLTag.MatchString(s) {
 		return s
 	}
 

--- a/framework/xss.go
+++ b/framework/xss.go
@@ -246,10 +246,56 @@ func sanitizeJSONValue(value any, fieldName string) bool {
 // contain "<" / ">" but no complete tag (no closing ">", e.g. "a<b") are
 // also returned unchanged so comparison text is not truncated.
 //
-// An unclosed skip element (for example `<script src=x>...`) discards the
-// remainder of the string — fail-closed for truncated markup. Self-closing
+// An unclosed skip element (for example `<script src=x>...`) strips the tag
+// itself but keeps the following text (issue #201). Text seen while
+// skipDepth > 0 is buffered into skipBuf rather than dropped. skipStarts is
+// a stack of checkpoints into skipBuf, one per currently-open skip element:
+// pushed with the length of skipBuf at the moment that element opened,
+// popped and truncated back to on its matching close. That discards exactly
+// the content opened-and-closed by that one element, however deep it is
+// nested inside other still-open skip elements — a single shared skipDepth
+// counter is not enough, since script/style/textarea/noscript/iframe are
+// HTML "raw text" elements (see below) and can never really nest, but
+// object/embed are ordinary elements and can: for `<object><object>x
+// </object>y`, the inner </object> must discard "x" on its own, without
+// waiting for (or depending on) the outer <object> ever closing too.
+//
+// Whatever remains in skipBuf when the tokenizer runs out of input
+// (skipDepth still > 0 at ErrorToken, nothing left open ever closed) is
+// flushed to the output — re-tokenized from scratch, see below. Self-closing
 // skip tags do not enter skip mode.
+//
+// Re-tokenizing applies the same skip logic again, so a nested dangerous
+// element that finds its own closing tag inside the buffer is still
+// discarded — only text that is not inside any closed dangerous element,
+// anywhere in the chain of unclosed wrappers, survives to the output.
+//
+// The flush re-tokenizes rather than emitting the buffer verbatim, and it
+// must do so with the real tokenizer, not a regexp: script/style/textarea/
+// noscript/iframe are HTML "raw text" elements, so golang.org/x/net/html
+// scans them for a literal closing tag and, finding none, hands back
+// everything up to EOF as one opaque, never-tokenized TextToken — it can
+// still contain complete, attribute-quoted tags that were never parsed. A
+// naive regexp strip (completeHTMLTag) does not track quoting, so a `>`
+// inside a quoted attribute value (`onerror="if(1>0){...}"`) ends the match
+// early and leaks the rest of the tag as text — a classic tag-stripper
+// bypass. Re-tokenizing lets the real HTML tokenizer parse the attribute
+// correctly instead.
+//
+// maxUnclosedSkipRecursion bounds that re-tokenizing to a fixed number of
+// rounds so a pathological chain of unclosed raw-text tags
+// (`<script><script>...`) cannot force unbounded recursive re-tokenizing of
+// a string shrinking by one tag per round — that would be quadratic in
+// input size. Past the cap, the remaining tail reverts to the pre-#201
+// fail-closed default (discarded) instead of being trusted as plain text;
+// legitimate content practically never nests this deep.
 func stripHTML(s string) string {
+	return stripHTMLUnclosed(s, maxUnclosedSkipRecursion)
+}
+
+const maxUnclosedSkipRecursion = 4
+
+func stripHTMLUnclosed(s string, budget int) string {
 	if !strings.ContainsAny(s, "<>") {
 		return s
 	}
@@ -259,20 +305,28 @@ func stripHTML(s string) string {
 
 	var b strings.Builder
 	b.Grow(len(s))
+	var skipBuf []byte
+	var skipStarts []int
 	tokenizer := html.NewTokenizer(strings.NewReader(s))
 	skipDepth := 0
 	for {
 		switch tokenizer.Next() {
 		case html.ErrorToken:
+			if skipDepth > 0 && budget > 0 {
+				b.WriteString(stripHTMLUnclosed(string(skipBuf), budget-1))
+			}
 			return b.String()
 		case html.TextToken:
 			if skipDepth == 0 {
 				b.Write(tokenizer.Text())
+			} else {
+				skipBuf = append(skipBuf, tokenizer.Text()...)
 			}
 		case html.StartTagToken:
 			name, _ := tokenizer.TagName()
 			if _, skip := xssSkipElementContent[string(name)]; skip {
 				skipDepth++
+				skipStarts = append(skipStarts, len(skipBuf))
 			}
 		case html.SelfClosingTagToken:
 			// Self-closing skip tags have no body; do not raise skipDepth.
@@ -280,6 +334,9 @@ func stripHTML(s string) string {
 			name, _ := tokenizer.TagName()
 			if _, skip := xssSkipElementContent[string(name)]; skip && skipDepth > 0 {
 				skipDepth--
+				start := skipStarts[len(skipStarts)-1]
+				skipStarts = skipStarts[:len(skipStarts)-1]
+				skipBuf = skipBuf[:start]
 			}
 		}
 	}

--- a/framework/xss_test.go
+++ b/framework/xss_test.go
@@ -27,7 +27,60 @@ func TestStripHTML(t *testing.T) {
 		{name: "script discarded", in: `<script>alert(1)</script>hi`, want: "hi"},
 		{name: "bold stripped", in: `<b>hi</b>`, want: "hi"},
 		{name: "img stripped", in: `x<img src=x onerror=alert(0)>y`, want: "xy"},
-		{name: "unclosed script fail-closed", in: `<script src=x>alert(1)`, want: ""},
+		{name: "unclosed script keeps trailing text", in: `<script src=x>alert(1)`, want: "alert(1)"},
+		{name: "unclosed script keeps surrounding text", in: `hi<script>bye`, want: "hibye"},
+		{name: "unclosed textarea after closed script", in: `<script>a</script>b<textarea>c`, want: "bc"},
+		// The inner <textarea> finds its own matching close tag inside the
+		// buffered raw text, so re-tokenizing discards its content exactly
+		// like the top-level pass would — properly closed dangerous content
+		// stays hidden even when it is nested inside a wrapper that never
+		// closes at all.
+		{name: "nested skip: inner closes, its content is still discarded", in: `<script><textarea>x</textarea>y`, want: "y"},
+		{name: "nested skip, outer closes, all content discarded", in: `<script><textarea>x</textarea>y</script>z`, want: "z"},
+		{name: "doubled unclosed skip of same tag", in: `<script><script>x`, want: "x"},
+		{name: "stray end tag closes the real open, extra one is a no-op", in: `<textarea>a</textarea></textarea>b`, want: "b"},
+		{name: "self-closing skip tag does not enter skip mode", in: `<script/>after`, want: "after"},
+		{name: "empty closed skip element", in: `<script></script>`, want: ""},
+		// script/style/textarea/noscript/iframe are HTML "raw text" elements:
+		// golang.org/x/net/html scans them for a literal closing tag and, when
+		// the wrapper never closes, hands back everything up to EOF as one
+		// opaque, never-tokenized TextToken — so a payload smuggled inside an
+		// unclosed wrapper must be stripped again on the way out, not trusted
+		// as already-safe plain text. Here the inner <script> also finds its
+		// own close tag, so (like the case above) its content is discarded —
+		// no live tag AND no leftover script body reach the output.
+		{name: "unclosed wrapper: inner script that does close is still fully discarded", in: `<textarea><script>alert(1)</script>`, want: ""},
+		// Neither wrapper closes this time, so there is no "properly closed
+		// dangerous content" to discard — the plain text at the very center
+		// is legitimately safe and must survive, with no tag syntax at all
+		// (not even a partial "<script>") leaking out around it.
+		{name: "doubly unclosed wrapper still recovers the innermost plain text", in: `<textarea><script>alert(1)`, want: "alert(1)"},
+		{name: "unclosed wrapper cannot smuggle a live img onerror tag", in: `<noscript>x<img src=x onerror=alert(1)>y`, want: "xy"},
+		// A quoted attribute value may itself contain a literal ">". A regexp
+		// strip that isn't quote-aware ends its match at that inner ">" and
+		// leaks the rest of the tag (including the closing ">") as text — the
+		// classic tag-stripper bypass. stripHTML must re-tokenize with the
+		// real (quote-aware) HTML tokenizer, not a regexp, so the whole <img>
+		// start tag is recognized and dropped instead of partially surviving.
+		{name: "unclosed wrapper: quoted attribute containing > does not defeat the strip", in: `<noscript><img src=x onerror="if(1>0){alert(document.cookie)}">`, want: ""},
+		// object/embed are ordinary elements, not HTML "raw text" elements
+		// like script/style/textarea/noscript/iframe, so — unlike those —
+		// they can genuinely nest within a single tokenizer pass. A single
+		// shared skipDepth counter is not enough to get this right: the
+		// inner </object> must discard its own "x" independently of whether
+		// the outer <object> ever closes, so a nested-but-properly-closed
+		// dangerous element cannot smuggle its content out just because an
+		// ancestor happens to stay open.
+		{name: "nested object, inner closes, outer closes: all discarded", in: `<object><object>x</object>y</object>z`, want: "z"},
+		{name: "nested object, inner closes, outer never closes: inner content still discarded", in: `<object><object>x</object>y`, want: "y"},
+		// Each unclosed raw-text wrapper forces one more re-tokenizing round
+		// on a string that is only one tag shorter, so re-tokenizing without
+		// a bound would be quadratic in a chain this deep. Past
+		// maxUnclosedSkipRecursion (4), stripHTML falls back to discarding
+		// the remainder rather than recursing further — verified fast in
+		// isolation; asserted here only for correctness of the fallback.
+		{name: "unclosed chain within the recursion budget still recovers text", in: `<script><script><script><script>x`, want: "x"},
+		{name: "unclosed chain past the recursion budget falls back to discard", in: `<script><script><script><script><script><script>x`, want: ""},
 		{name: "nested markup", in: `<div><b>a</b><i>b</i></div>`, want: "ab"},
 		// Incomplete "<"+letter is not a tag (golang.org/x/net/html would
 		// otherwise eat the rest of the string: "a<b" → "a").

--- a/framework/xss_test.go
+++ b/framework/xss_test.go
@@ -23,72 +23,74 @@ func TestStripHTML(t *testing.T) {
 		in   string
 		want string
 	}{
+		// Baseline: tags stripped, closed dangerous elements discarded.
 		{name: "plain", in: "hello", want: "hello"},
 		{name: "script discarded", in: `<script>alert(1)</script>hi`, want: "hi"},
 		{name: "bold stripped", in: `<b>hi</b>`, want: "hi"},
 		{name: "img stripped", in: `x<img src=x onerror=alert(0)>y`, want: "xy"},
+		{name: "nested markup", in: `<div><b>a</b><i>b</i></div>`, want: "ab"},
+		{name: "empty closed skip element", in: `<script></script>`, want: ""},
+
+		// #201: a dangerous element that never closes strips the tag but
+		// keeps the text that follows, instead of truncating the value.
 		{name: "unclosed script keeps trailing text", in: `<script src=x>alert(1)`, want: "alert(1)"},
 		{name: "unclosed script keeps surrounding text", in: `hi<script>bye`, want: "hibye"},
 		{name: "unclosed textarea after closed script", in: `<script>a</script>b<textarea>c`, want: "bc"},
-		// The inner <textarea> finds its own matching close tag inside the
-		// buffered raw text, so re-tokenizing discards its content exactly
-		// like the top-level pass would — properly closed dangerous content
-		// stays hidden even when it is nested inside a wrapper that never
-		// closes at all.
+		{name: "doubled unclosed skip of same tag", in: `<script><script>x`, want: "x"},
+		{name: "doubly unclosed wrapper still recovers the innermost plain text", in: `<textarea><script>alert(1)`, want: "alert(1)"},
+		{name: "self-closing skip tag does not enter skip mode", in: `<script/>after`, want: "after"},
+		{name: "stray end tag closes the real open, extra one is a no-op", in: `<textarea>a</textarea></textarea>b`, want: "b"},
+
+		// The recovered text is re-parsed, so a dangerous element that does
+		// find its own close inside it still loses its content — an unclosed
+		// ancestor is not a way to smuggle a closed one's body out.
 		{name: "nested skip: inner closes, its content is still discarded", in: `<script><textarea>x</textarea>y`, want: "y"},
 		{name: "nested skip, outer closes, all content discarded", in: `<script><textarea>x</textarea>y</script>z`, want: "z"},
-		{name: "doubled unclosed skip of same tag", in: `<script><script>x`, want: "x"},
-		{name: "stray end tag closes the real open, extra one is a no-op", in: `<textarea>a</textarea></textarea>b`, want: "b"},
-		{name: "self-closing skip tag does not enter skip mode", in: `<script/>after`, want: "after"},
-		{name: "empty closed skip element", in: `<script></script>`, want: ""},
-		// script/style/textarea/noscript/iframe are HTML "raw text" elements:
-		// golang.org/x/net/html scans them for a literal closing tag and, when
-		// the wrapper never closes, hands back everything up to EOF as one
-		// opaque, never-tokenized TextToken — so a payload smuggled inside an
-		// unclosed wrapper must be stripped again on the way out, not trusted
-		// as already-safe plain text. Here the inner <script> also finds its
-		// own close tag, so (like the case above) its content is discarded —
-		// no live tag AND no leftover script body reach the output.
 		{name: "unclosed wrapper: inner script that does close is still fully discarded", in: `<textarea><script>alert(1)</script>`, want: ""},
-		// Neither wrapper closes this time, so there is no "properly closed
-		// dangerous content" to discard — the plain text at the very center
-		// is legitimately safe and must survive, with no tag syntax at all
-		// (not even a partial "<script>") leaking out around it.
-		{name: "doubly unclosed wrapper still recovers the innermost plain text", in: `<textarea><script>alert(1)`, want: "alert(1)"},
+
+		// ...and live markup in that recovered text is stripped, never
+		// emitted. completeHTMLTag must not gate this path: it misses a ">"
+		// inside a quoted attribute value, and an attribute with no leading
+		// whitespace (`<script/src=x>`, which HTML5 reads as `<script src=x>`).
+		// Every case here is markup that regexp rejects or truncates and the
+		// tokenizer parses correctly.
 		{name: "unclosed wrapper cannot smuggle a live img onerror tag", in: `<noscript>x<img src=x onerror=alert(1)>y`, want: "xy"},
-		// A quoted attribute value may itself contain a literal ">". A regexp
-		// strip that isn't quote-aware ends its match at that inner ">" and
-		// leaks the rest of the tag (including the closing ">") as text — the
-		// classic tag-stripper bypass. stripHTML must re-tokenize with the
-		// real (quote-aware) HTML tokenizer, not a regexp, so the whole <img>
-		// start tag is recognized and dropped instead of partially surviving.
 		{name: "unclosed wrapper: quoted attribute containing > does not defeat the strip", in: `<noscript><img src=x onerror="if(1>0){alert(document.cookie)}">`, want: ""},
-		// object/embed are ordinary elements, not HTML "raw text" elements
-		// like script/style/textarea/noscript/iframe, so — unlike those —
-		// they can genuinely nest within a single tokenizer pass. A single
-		// shared skipDepth counter is not enough to get this right: the
-		// inner </object> must discard its own "x" independently of whether
-		// the outer <object> ever closes, so a nested-but-properly-closed
-		// dangerous element cannot smuggle its content out just because an
-		// ancestor happens to stay open.
+		{name: "unclosed wrapper: slash-separated start tag is still stripped", in: `<textarea><script/src=x>body`, want: "body"},
+		{name: "unclosed wrapper: slash-separated non-skip tag is still stripped", in: `<script><img/src=x>y`, want: "y"},
+		{name: "unclosed wrapper: slash-separated tag with an event handler is still stripped", in: `<noscript><img/src=x onerror=alert(1)>y`, want: "y"},
+		{name: "unclosed wrapper: slash-separated tag with a quoted > is still stripped", in: `<textarea><img/src=x onerror="if(1>0){alert(1)}">z`, want: "z"},
+		{name: "unclosed wrapper: closed slash-separated skip element discards its body", in: `<textarea><script/src=x>a</script>b`, want: "b"},
+
+		// object/embed are ordinary elements, not raw text, so they really
+		// can nest: each open skip element needs its own checkpoint into
+		// skipBuf, which one shared depth counter cannot provide.
 		{name: "nested object, inner closes, outer closes: all discarded", in: `<object><object>x</object>y</object>z`, want: "z"},
 		{name: "nested object, inner closes, outer never closes: inner content still discarded", in: `<object><object>x</object>y`, want: "y"},
-		// Each unclosed raw-text wrapper forces one more re-tokenizing round
-		// on a string that is only one tag shorter, so re-tokenizing without
-		// a bound would be quadratic in a chain this deep. Past
-		// maxUnclosedSkipRecursion (4), stripHTML falls back to discarding
-		// the remainder rather than recursing further — verified fast in
-		// isolation; asserted here only for correctness of the fallback.
+
+		// maxUnclosedSkipRecursion (4) bounds the re-tokenizing, which would
+		// otherwise be quadratic in a chain this deep. Past the cap the tail
+		// reverts to the pre-#201 discard.
 		{name: "unclosed chain within the recursion budget still recovers text", in: `<script><script><script><script>x`, want: "x"},
 		{name: "unclosed chain past the recursion budget falls back to discard", in: `<script><script><script><script><script><script>x`, want: ""},
-		{name: "nested markup", in: `<div><b>a</b><i>b</i></div>`, want: "ab"},
-		// Incomplete "<"+letter is not a tag (golang.org/x/net/html would
-		// otherwise eat the rest of the string: "a<b" → "a").
+
+		// #118: `"<" + letter` without a complete tag is left alone, or the
+		// tokenizer would eat the rest of the string ("a<b" → "a").
 		{name: "comparison a<b", in: "a<b", want: "a<b"},
 		{name: "comparison a<b>c without real tag name", in: "a < b", want: "a < b"},
 		{name: "less-than number", in: "score < 10", want: "score < 10"},
 		{name: "greater-than only", in: "a>b", want: "a>b"},
 		{name: "complete tag still stripped", in: "foo <bar> baz", want: "foo  baz"},
+		// That protection covers the submitted string only. Text recovered
+		// from a raw-text element is unparsed markup, not something the user
+		// typed, so it is re-parsed in full: `"<" + letter` through the next
+		// ">" is a tag there, which can swallow more than a stray bracket.
+		{name: "comparison text inside raw text is not protected by the #118 gate", in: `<textarea>a<b`, want: "a"},
+		{name: "code-like text inside raw text loses what parses as a tag", in: `<script>if (a<b && c>d) return`, want: "if (ad) return"},
+		// Only `"<" + letter` opens a tag, so the common comparison shapes
+		// still survive the re-parse intact.
+		{name: "comparison before a number inside raw text survives", in: `<textarea>score <10`, want: "score <10"},
+		{name: "spaced comparison inside raw text survives", in: `<textarea>price < 10`, want: "price < 10"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `stripHTML` (`framework/xss.go`) discarded all text following an unclosed
  `<script>`/`<style>`/`<textarea>`/`<iframe>`/`<object>`/`<embed>`/
  `<noscript>` start tag, causing silent data loss for any legitimate field
  that merely mentioned one of these tag names in prose.
- Text inside a skip element is now buffered via a stack of per-element
  checkpoints instead of dropped immediately; a checkpoint is popped and the
  buffer truncated back to it on that element's own matching close, so only
  content actually contained by a *closed* dangerous element is discarded.
  Whatever remains unresolved at EOF is re-tokenized (bounded to 4 rounds)
  before reaching the output, instead of being trusted or emitted verbatim.
- `completeHTMLTag` guards the `stripHTML` entry point only. It is the #118
  gate for user-submitted comparison text, not a stripper, so it is never
  applied to recovered skip content — anything still holding `<` or `>` on
  the flush path is re-tokenized unconditionally.

Closes #201

## Acceptance criteria

The issue is a bug report without an explicit AC checklist; its "Expected" /
"Suggested fix" sections are the contract this PR satisfies:

- [x] An unclosed skip element strips the tag itself but keeps the
      following text as plain text, instead of discarding the remainder of
      the string.
- [x] Properly closed dangerous elements still have their content discarded
      (fail-closed preserved for the case it actually protects).
- [x] Text recovered from an unclosed skip element carries no executable
      markup, which is the premise the issue's suggested fix rests on.

## Scope notes

Three security-relevant edge cases were found and closed in this PR rather
than filed separately, since all three are direct consequences of the
`stripHTML` change it makes — not new scope:

- a quoted-attribute tag-stripper bypass on the flush path;
- nested `object`/`embed` content leaking past a shared depth counter;
- `completeHTMLTag` used as an admission gate on recovered skip content
  (@leo-aa88's review), which emitted live markup the regexp does not
  recognize.

**Flagged, not fixed here:** the same regexp gate at the `stripHTML` entry
point lets `<script/src=x>body` and `<img/src=x onerror=alert(1)>y` through
unchanged when they arrive at top level rather than nested inside an unclosed
wrapper. Verified on `main`, so it predates this branch, and #118/#137/#232/
#241 (closed) and #201/#271 (open) do not cover it. Fixing it here would
widen the #118 gate on a data-loss bugfix, so it is raised in review for a
decision instead — and it may be moot under #271.

The recovered-text path deliberately does not inherit the #118 protection:
`<script>if (a<b && c>d) return` yields `if (ad) return`. Documented in
`docs/router.md` and covered by tests.

## Validation

- [x] `go build ./...`
- [x] `go test ./...` — full suite, no failures
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — 0 issues
- [x] `go test ./framework/... -run TestStripHTML` — 36 cases covering the
      unclosed/nested/quote-breakout/slash-separated-tag/recursion-budget
      boundaries. The regression cases for the gate bug were written first and
      confirmed failing against the previous commit before the fix landed.
- [x] Behavior compared against `main` for every case this PR changes, to
      separate regressions introduced here from pre-existing holes.
- [x] Re-tokenizing measured on 1 MiB inputs (plain / incomplete tags / live
      tags / deep unclosed chain): 6.8–26.6 ms, linear, budget-bounded.
- [x] Project `code-review` skill run against this diff — verdict COMMENT; the
      one finding (the docs illustrated the recovered-text tradeoff with its
      mildest example) is fixed in this push.

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — N/A, no database touched; tests added for the new stripHTML behavior
- [ ] Stable features ship docs and appear in an example app — N/A, this is a bug fix to existing documented behavior (`docs/router.md` updated to match), not a new feature
- [ ] Extraction preserves contracts — N/A, no template extraction in this change
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — N/A, no generator touched
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no public API change
- [x] No secrets in generated frontend source; `VITE_*` is treated as public — N/A, no frontend touched, checked anyway
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep
- [x] This PR links its issue and states which acceptance criteria it satisfies
