### PR TITLE
fix: reject non-ASCII resource names before make resource writes anything

### DIFF
--- a/resourcegen/fields_test.go
+++ b/resourcegen/fields_test.go
@@ -349,3 +349,64 @@ func TestParseResourceName(t *testing.T) {
 		t.Fatalf("product error = %v, want reserved package product", err)
 	}
 }
+
+// TestParseResourceNameRejectsNonASCII covers issue #217: a resource name
+// becomes both a Go package name and an import path segment
+// (internal/<pkg>). Go package names may be Unicode, but Go import paths may
+// not, so a name like "Café" used to pass parseResourceName, get every file
+// written and main.go/database.go edited, and only fail deep inside
+// makemigrations — after which the tree no longer compiled and every later
+// `make resource` was wedged on the same invalid model. The fix rejects any
+// non-ASCII rune here, before anything is written, the same way Go keywords
+// and reserved packages already are.
+func TestParseResourceNameRejectsNonASCII(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		wantErr string
+	}{
+		// Exact message on this one case pins the actionable guidance
+		// ("only ASCII letters, digits...") so a future edit can't quietly
+		// regress it back to a bare "invalid character" with no next step.
+		{name: "accented letter", in: "Café", wantErr: `resource name "Café" contains invalid character "é" (only ASCII letters, digits, "_", and "-" are allowed)`},
+		{name: "non-Latin script", in: "Pokémon", wantErr: "invalid character"},
+		{name: "entirely non-Latin", in: "日本語", wantErr: "invalid character"},
+		// Unicode digits satisfy unicode.IsDigit but are not valid in a Go
+		// import path any more than accented letters are.
+		{name: "full-width digit", in: "Order１", wantErr: "invalid character"},
+		{name: "arabic-indic digit", in: "Order١", wantErr: "invalid character"},
+		// A combining mark rides on the preceding ASCII letter and is
+		// invisible in a casual read of the name ("café" via NFD instead of
+		// NFC), but it is still a distinct, non-ASCII rune the loop must
+		// catch on its own, not something toPascal/toSnake silently drops.
+		{name: "combining diacritic (NFD)", in: "Café", wantErr: "invalid character"},
+		// Non-letter, non-digit non-ASCII (emoji) was already rejected
+		// before #217 (not unicode.IsLetter/IsDigit) — kept as a regression
+		// guard now that the character check was rewritten.
+		{name: "emoji", in: "Widget🎉", wantErr: "invalid character"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseResourceName(tt.in)
+			if err == nil {
+				t.Fatalf("parseResourceName(%q) succeeded, want error containing %q", tt.in, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("parseResourceName(%q) error = %q, want it to contain %q", tt.in, err, tt.wantErr)
+			}
+		})
+	}
+
+	// Regression guard: legitimate ASCII names (including ones that happen
+	// to be common real-world nouns like "Order") must keep working — #217
+	// found no evidence that these break generation (Atlas quotes every
+	// identifier it emits), so this fix must not reject them.
+	for _, ok := range []string{"Widget", "part-2", "part_2", "Order", "Status"} {
+		if _, err := parseResourceName(ok); err != nil {
+			t.Fatalf("parseResourceName(%q) = %v, want success", ok, err)
+		}
+	}
+}

--- a/resourcegen/names.go
+++ b/resourcegen/names.go
@@ -51,8 +51,8 @@ func parseResourceName(raw string) (ResourceName, error) {
 		if unicode.IsSpace(r) {
 			return ResourceName{}, fmt.Errorf("resourcegen: resource name %q must not contain whitespace", raw)
 		}
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '-' {
-			return ResourceName{}, fmt.Errorf("resourcegen: resource name %q contains invalid character %q", raw, string(r))
+		if !isASCIILetterOrDigit(r) && r != '_' && r != '-' {
+			return ResourceName{}, fmt.Errorf("resourcegen: resource name %q contains invalid character %q (only ASCII letters, digits, \"_\", and \"-\" are allowed)", raw, string(r))
 		}
 	}
 	first, _ := utf8.DecodeRuneInString(strings.TrimLeft(raw, "_-"))
@@ -156,6 +156,19 @@ func pluralizeSnake(snake string) string {
 		return "s"
 	}
 	return inflection.Plural(snake)
+}
+
+// isASCIILetterOrDigit reports whether r is an ASCII letter or digit.
+// Unlike unicode.IsLetter/IsDigit, this rejects non-ASCII letters and digits
+// ("é", full-width "１"): a resource name becomes both a Go package name and
+// an import path segment (internal/<pkg>), and while Go package names may be
+// Unicode, Go import paths may not. Accepting a rune here that later fails
+// import-path validation lets `make resource` write the whole feature tree,
+// edit main.go and database.go, and only fail deep inside makemigrations —
+// after which the tree no longer compiles and every later `make resource`
+// is wedged on the same invalid model (issue #217).
+func isASCIILetterOrDigit(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
 }
 
 func isGoIdent(name string) bool {


### PR DESCRIPTION
## Summary

- `parseResourceName` accepted any Unicode letter/digit in a resource name
  (`unicode.IsLetter`/`IsDigit`). A resource name becomes both a Go package
  name (Unicode-safe) and a Go import path segment (`internal/<pkg>`, not
  Unicode-safe), so a name like `Café` passed validation, and `make resource`
  wrote the whole feature tree and edited `cmd/server/main.go` and
  `internal/platform/database.go` before failing deep inside
  `makemigrations`. Because `database.go` was already edited, every later
  `make resource` failed too, wedged on the same invalid model in
  AutoMigrate — no rollback of the partial write.
- The per-rune check is now restricted to ASCII letters/digits (plus the
  already-allowed `_`/`-`), rejected in `parseResourceName` itself — the same
  place Go keywords and reserved packages already are, before anything is
  written. This closes the wedge structurally: nothing is written until the
  name is known-good.

Closes #217

## Acceptance criteria

The issue is a bug report without an explicit AC checklist; its "Expected"
section is the contract this PR satisfies:

- [x] Names that cannot produce a valid Go import path are rejected before
      anything is written, the same way Go keywords already are.
- [x] A failed generation leaves the tree unchanged — verified end to end
      against a real scaffolded app: `make resource Café` now fails
      immediately with an empty `git status`, and a subsequent
      `make resource Widget` in the same tree generates, migrates, and
      builds cleanly (previously wedged).
- [ ] SQL reserved words (`Order`, `Group`, `Table`, `Data`, `Status`) as
      resource names — deliberately **not** implemented; see Scope notes.

## Scope notes

The issue's SQL-reserved-word note is not implemented. I tested
`make resource Order` end to end (generate → `db makemigrations` →
`db migrate` → `go build`) against real SQLite, Postgres 16, and MySQL 8.4:
it works cleanly on all three. Atlas quotes every identifier it emits
per-dialect (backtick / double-quote), and the actual table name is the
pluralized form (`orders`) regardless of what the user types. A blocklist
would reject legitimate, common resource nouns (an e-commerce "Order", a
workflow "Status") for a collision that does not reproduce. Left as a
comment on #217 for the maintainer rather than added as unverified scope.

## Validation

- [x] `go build ./...`
- [x] `go test ./...` — full suite, no failures
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — 0 issues
- [x] `go test ./goldentest/...` (no `-update`) — confirms no generator output changed, only input validation
- [x] `go test ./resourcegen/... -run TestParseResourceName -v` — including the new
      `TestParseResourceNameRejectsNonASCII` table (accented letters, non-Latin
      scripts, Unicode digits, an NFD combining-mark form, emoji, plus a
      regression guard that `Order`/`Status` still succeed)
- [x] End-to-end repro against a real scaffolded app, before and after the fix
      (see Summary), and against real Postgres/MySQL containers for the
      reserved-word investigation above
- [x] Project `code-review` skill run against this diff — APPROVE

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — no DB schema change in this PR; the reserved-word investigation (not a code change) was verified against all three
- [ ] Stable features ship docs and appear in an example app — N/A, this is a bug fix to existing validated input, not a new feature
- [ ] Extraction preserves contracts — N/A, no template extraction in this change
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — unchanged; this PR only tightens input validation ahead of the existing AST-safe write path, confirmed via `go test ./goldentest/...` with no golden diff
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no public API change
- [x] No secrets in generated frontend source; `VITE_*` is treated as public — N/A, no frontend touched, checked anyway
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep
- [x] This PR links its issue and states which acceptance criteria it satisfies