### PR TITLE
feat: declared server-side list filtering/sort/search (#260)

### DIFF
--- a/admin/convert.go
+++ b/admin/convert.go
@@ -273,10 +273,3 @@ func validUUID(s string) bool {
 func isHex(c byte) bool {
 	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
 }
-
-func escapeLike(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `%`, `\%`)
-	s = strings.ReplaceAll(s, `_`, `\_`)
-	return s
-}

--- a/admin/resources.go
+++ b/admin/resources.go
@@ -470,29 +470,16 @@ func applyWrite(ctx context.Context, m *registered, inst any, body map[string]an
 }
 
 func applySearch(q *gorm.DB, m *registered, term string) (*gorm.DB, error) {
-	term = strings.TrimSpace(term)
-	if term == "" {
-		return q, nil
-	}
-	if len(m.meta.Search) == 0 {
-		return q, nil
-	}
-	pattern := "%" + escapeLike(term) + "%"
-	ors := make([]clause.Expression, 0, len(m.meta.Search))
+	// Resolve the registered search field names to columns, then delegate the
+	// LIKE building to the shared database.Search so the admin and the generated
+	// list handler cannot drift on search behavior.
+	cols := make([]string, 0, len(m.meta.Search))
 	for _, name := range m.meta.Search {
-		col, ok := m.columnFor(name)
-		if !ok {
-			continue
+		if col, ok := m.columnFor(name); ok {
+			cols = append(cols, col)
 		}
-		ors = append(ors, clause.Expr{
-			SQL:  "LOWER(" + quoteIdent(q, col) + ") LIKE LOWER(?) ESCAPE ?",
-			Vars: []any{pattern, `\`},
-		})
 	}
-	if len(ors) == 0 {
-		return q, nil
-	}
-	return q.Where(clause.Or(ors...)), nil
+	return database.Search(q, cols, term), nil
 }
 
 func applyFilters(ctx context.Context, q *gorm.DB, m *registered, values interface{ Get(string) string }) (*gorm.DB, error) {
@@ -520,15 +507,13 @@ func applyFilters(ctx context.Context, q *gorm.DB, m *registered, values interfa
 }
 
 func applyOrdering(q *gorm.DB, m *registered, ordering string) (*gorm.DB, error) {
-	ordering = strings.TrimSpace(ordering)
-	if ordering == "" {
+	// Share the `?ordering=<field>` / `-<field>` spelling with the generated list
+	// handler via database.ParseOrdering; the admin keeps its own field-name
+	// allowlist + column resolution (registry-driven, so names differ from
+	// columns).
+	name, desc := database.ParseOrdering(ordering)
+	if name == "" {
 		return q, nil
-	}
-	desc := false
-	name := ordering
-	if strings.HasPrefix(name, "-") {
-		desc = true
-		name = strings.TrimPrefix(name, "-")
 	}
 	allowed := false
 	for _, n := range m.meta.Ordering {
@@ -545,10 +530,4 @@ func applyOrdering(q *gorm.DB, m *registered, ordering string) (*gorm.DB, error)
 		return nil, errors.New("ordering is not allowed for this field")
 	}
 	return q.Order(clause.OrderByColumn{Column: clause.Column{Name: col}, Desc: desc}), nil
-}
-
-func quoteIdent(db *gorm.DB, name string) string {
-	var b strings.Builder
-	db.QuoteTo(&b, name)
-	return b.String()
 }

--- a/cli/make.go
+++ b/cli/make.go
@@ -46,7 +46,7 @@ regex), next to product.Register(app). AutoMigrate is updated the same way.
 
 Field grammar (design §27 subset):
 
-  name:type[:required][,unique][,index]
+  name:type[:required][,unique][,index][,filterable][,sortable][,searchable]
 
 Supported types: string, text, int, int64, bool, uint, decimal, time, enum,
 belongs_to, has_many, many_to_many.
@@ -55,6 +55,18 @@ belongs_to, has_many, many_to_many.
   decimal(p,s)       pin precision/scale, e.g. decimal(10,2).
   time               time.Time (RFC3339 in JSON).
   enum(a,b,c)        string column validated against the listed values.
+
+List-query modifiers opt a field into the generated list handler's declared
+query surface (safe, indexable subset):
+
+  filterable         exact-match ?<field>=<value> query param.
+                     Types: string, int, int64, uint, bool, enum. A belongs_to
+                     foreign key is filterable by default (GET /children?
+                     <parent>_id=<id>) with no modifier needed.
+  sortable           ?sort=<field>&order=asc|desc (replaces the fixed id order;
+                     id stays the default when ?sort= is absent).
+  searchable         case-insensitive ?q=<term> LIKE across searchable text
+                     fields. Types: string, text, enum.
 
 Relations use name:kind:Target, where Target is a model in internal/<target>/:
 
@@ -74,6 +86,8 @@ foreign key / explicit join keys. Point relations at a different package.
 Examples:
 
   gombit make resource Widget name:string:required price:int
+  gombit make resource Article title:string:required,searchable,sortable \
+    status:enum(draft,published):filterable author:belongs_to:Author
   gombit make resource Rental price:decimal:required starts_at:time \
     status:enum(requested,confirmed,active,returned,cancelled) \
     engine:belongs_to:Engine warehouses:many_to_many:Warehouse

--- a/cli/make.go
+++ b/cli/make.go
@@ -57,16 +57,18 @@ belongs_to, has_many, many_to_many.
   enum(a,b,c)        string column validated against the listed values.
 
 List-query modifiers opt a field into the generated list handler's declared
-query surface (safe, indexable subset):
+query surface (safe, indexable subset). The query spelling matches Gombit's
+admin data plane so the two contracts stay in sync:
 
   filterable         exact-match ?<field>=<value> query param.
                      Types: string, int, int64, uint, bool, enum. A belongs_to
                      foreign key is filterable by default (GET /children?
                      <parent>_id=<id>) with no modifier needed.
-  sortable           ?sort=<field>&order=asc|desc (replaces the fixed id order;
-                     id stays the default when ?sort= is absent).
-  searchable         case-insensitive ?q=<term> LIKE across searchable text
-                     fields. Types: string, text, enum.
+  sortable           ?ordering=<field> (prefix with - for DESC, e.g.
+                     ?ordering=-created_at). Replaces the fixed id order; id
+                     stays the default when ?ordering= is absent.
+  searchable         case-insensitive ?search=<term> LIKE across searchable
+                     text fields. Types: string, text, enum.
 
 Relations use name:kind:Target, where Target is a model in internal/<target>/:
 

--- a/cli/make.go
+++ b/cli/make.go
@@ -65,7 +65,7 @@ admin data plane so the two contracts stay in sync:
                      foreign key is filterable by default (GET /children?
                      <parent>_id=<id>) with no modifier needed.
   sortable           ?ordering=<field> (prefix with - for DESC, e.g.
-                     ?ordering=-created_at). Replaces the fixed id order; id
+                     ?ordering=-title). Replaces the fixed id order; id
                      stays the default when ?ordering= is absent.
   searchable         case-insensitive ?search=<term> LIKE across searchable
                      text fields. Types: string, text, enum.

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -61,6 +61,26 @@ func TestMapPersistErrorMySQLConstraintViolations(t *testing.T) {
 	testForeignKeyAndNotNullViolations(t, db)
 }
 
+func TestListQueryHelpersPostgres(t *testing.T) {
+	if *postgresDSN == "" {
+		t.Skip("set -database.postgres-dsn to run Postgres integration tests")
+	}
+	assertListQueryHelpers(t, openIntegrationDB(t, config.DatabaseConfig{
+		Driver: config.DatabaseDriverPostgres,
+		DSN:    *postgresDSN,
+	}))
+}
+
+func TestListQueryHelpersMySQL(t *testing.T) {
+	if *mysqlDSN == "" {
+		t.Skip("set -database.mysql-dsn to run MySQL integration tests")
+	}
+	assertListQueryHelpers(t, openIntegrationDB(t, config.DatabaseConfig{
+		Driver: config.DatabaseDriverMySQL,
+		DSN:    *mysqlDSN,
+	}))
+}
+
 type integrationFKCategory struct {
 	ID uint `gorm:"primaryKey"`
 }

--- a/database/listquery.go
+++ b/database/listquery.go
@@ -1,0 +1,155 @@
+package database
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/gombit-dev/gombit/contract"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// FilterKind is the column type an exact-match filter coerces its raw query
+// string to before comparing. Filters arrive as strings (Huma does not support
+// optional/pointer query params, so an empty string is the "absent" signal —
+// the same convention the admin data plane uses), and the kind decides how the
+// string is parsed and bound.
+type FilterKind int
+
+const (
+	FilterString FilterKind = iota
+	FilterInt
+	FilterInt64
+	FilterUint
+	FilterBool
+)
+
+// This file holds the reusable list-query primitives (exact-match filter,
+// text search, validated sort) that the generated resource list handler calls.
+// The generator only emits calls for fields a resource declares filterable /
+// searchable / sortable, so the query surface stays a safe, declared subset —
+// the same contract the admin data plane applies (admin/resources.go), extracted
+// here so both the framework-owned admin and generated apps share one behavior.
+
+// FilterEq adds an exact-match `column = <raw coerced to kind>` predicate. An
+// empty (or whitespace-only) raw value is a no-op — the filter was not supplied
+// — so callers can chain one FilterEq per declared filterable field. A raw value
+// that does not parse as kind returns a D10 validation error (422) keyed on
+// column. The column name is generator-controlled (a declared field's DB
+// column); only raw is user input.
+func FilterEq(ctx context.Context, q *gorm.DB, column string, kind FilterKind, raw string) (*gorm.DB, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return q, nil
+	}
+	var (
+		value any
+		err   error
+	)
+	switch kind {
+	case FilterInt:
+		value, err = strconv.Atoi(raw)
+	case FilterInt64:
+		value, err = strconv.ParseInt(raw, 10, 64)
+	case FilterUint:
+		var u uint64
+		u, err = strconv.ParseUint(raw, 10, 64)
+		value = uint(u)
+	case FilterBool:
+		value, err = strconv.ParseBool(raw)
+	default: // FilterString
+		value = raw
+	}
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.Validation(
+			"The request contains invalid fields.",
+			map[string][]string{column: {"invalid filter value"}},
+		))
+	}
+	return q.Where(clause.Eq{Column: clause.Column{Name: column}, Value: value}), nil
+}
+
+// Search adds a case-insensitive OR of `LOWER(col) LIKE LOWER(%term%)` across
+// the given columns. An empty (or whitespace-only) term, or an empty column
+// list, is a no-op. The term is treated as a literal: LIKE wildcards in it are
+// escaped, so a user searching for "50%" matches the literal text, not a
+// prefix. Columns are generator-controlled; only the term is user input.
+func Search(q *gorm.DB, columns []string, term string) *gorm.DB {
+	term = strings.TrimSpace(term)
+	if term == "" || len(columns) == 0 {
+		return q
+	}
+	pattern := "%" + escapeLike(term) + "%"
+	ors := make([]clause.Expression, 0, len(columns))
+	for _, col := range columns {
+		ors = append(ors, clause.Expr{
+			SQL:  "LOWER(" + quoteIdent(q, col) + ") LIKE LOWER(?) ESCAPE ?",
+			Vars: []any{pattern, `\`},
+		})
+	}
+	return q.Where(clause.Or(ors...))
+}
+
+// SortBy applies `ORDER BY sort [ASC|DESC]`, validated against the allowed set.
+//
+//   - sort empty: order by fallback (the stable default, e.g. "id") when
+//     fallback is non-empty; otherwise no ORDER BY is added.
+//   - sort present but not in allowed: a 422 validation error on "sort".
+//   - order is "" or "asc" (ascending) or "desc"; anything else is a 422 on
+//     "order".
+//
+// allowed and fallback are generator-controlled (a resource's declared sortable
+// columns); sort and order are user input, matched by exact string equality so
+// only a declared column can reach the query.
+func SortBy(ctx context.Context, q *gorm.DB, sort, order string, allowed []string, fallback string) (*gorm.DB, error) {
+	sort = strings.TrimSpace(sort)
+	if sort == "" {
+		if fallback != "" {
+			q = q.Order(clause.OrderByColumn{Column: clause.Column{Name: fallback}})
+		}
+		return q, nil
+	}
+	permitted := false
+	for _, a := range allowed {
+		if a == sort {
+			permitted = true
+			break
+		}
+	}
+	if !permitted {
+		return nil, contract.WithContext(ctx, contract.Validation(
+			"The request contains invalid fields.",
+			map[string][]string{"sort": {"sorting is not allowed for this field"}},
+		))
+	}
+	var desc bool
+	switch strings.ToLower(strings.TrimSpace(order)) {
+	case "", "asc":
+		desc = false
+	case "desc":
+		desc = true
+	default:
+		return nil, contract.WithContext(ctx, contract.Validation(
+			"The request contains invalid fields.",
+			map[string][]string{"order": {"must be asc or desc"}},
+		))
+	}
+	return q.Order(clause.OrderByColumn{Column: clause.Column{Name: sort}, Desc: desc}), nil
+}
+
+// escapeLike escapes the LIKE metacharacters so a search term matches literally
+// under the `ESCAPE '\'` clause Search emits.
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
+// quoteIdent quotes a column identifier using the active dialect's quoting rules.
+func quoteIdent(db *gorm.DB, name string) string {
+	var b strings.Builder
+	db.QuoteTo(&b, name)
+	return b.String()
+}

--- a/database/listquery.go
+++ b/database/listquery.go
@@ -91,20 +91,31 @@ func Search(q *gorm.DB, columns []string, term string) *gorm.DB {
 	return q.Where(clause.Or(ors...))
 }
 
-// SortBy applies `ORDER BY sort [ASC|DESC]`, validated against the allowed set.
+// ParseOrdering splits a Django-style `?ordering=` token into its field name and
+// direction: a leading '-' means descending, e.g. "-created_at" → ("created_at",
+// true). The admin data plane and generated list handlers share this spelling so
+// the two contracts cannot drift.
+func ParseOrdering(ordering string) (field string, desc bool) {
+	field = strings.TrimSpace(ordering)
+	if strings.HasPrefix(field, "-") {
+		return strings.TrimSpace(strings.TrimPrefix(field, "-")), true
+	}
+	return field, false
+}
+
+// Ordering applies `ORDER BY` for a Django-style `?ordering=` value (optional
+// leading '-' for DESC), validated against the allowed columns:
 //
-//   - sort empty: order by fallback (the stable default, e.g. "id") when
+//   - empty ordering: order by fallback (the stable default, e.g. "id") when
 //     fallback is non-empty; otherwise no ORDER BY is added.
-//   - sort present but not in allowed: a 422 validation error on "sort".
-//   - order is "" or "asc" (ascending) or "desc"; anything else is a 422 on
-//     "order".
+//   - ordering field not in allowed: a 422 validation error on "ordering".
 //
 // allowed and fallback are generator-controlled (a resource's declared sortable
-// columns); sort and order are user input, matched by exact string equality so
-// only a declared column can reach the query.
-func SortBy(ctx context.Context, q *gorm.DB, sort, order string, allowed []string, fallback string) (*gorm.DB, error) {
-	sort = strings.TrimSpace(sort)
-	if sort == "" {
+// columns); ordering is user input, matched by exact string equality so only a
+// declared column can reach the query.
+func Ordering(ctx context.Context, q *gorm.DB, ordering string, allowed []string, fallback string) (*gorm.DB, error) {
+	field, desc := ParseOrdering(ordering)
+	if field == "" {
 		if fallback != "" {
 			q = q.Order(clause.OrderByColumn{Column: clause.Column{Name: fallback}})
 		}
@@ -112,7 +123,7 @@ func SortBy(ctx context.Context, q *gorm.DB, sort, order string, allowed []strin
 	}
 	permitted := false
 	for _, a := range allowed {
-		if a == sort {
+		if a == field {
 			permitted = true
 			break
 		}
@@ -120,22 +131,10 @@ func SortBy(ctx context.Context, q *gorm.DB, sort, order string, allowed []strin
 	if !permitted {
 		return nil, contract.WithContext(ctx, contract.Validation(
 			"The request contains invalid fields.",
-			map[string][]string{"sort": {"sorting is not allowed for this field"}},
+			map[string][]string{"ordering": {"ordering is not allowed for this field"}},
 		))
 	}
-	var desc bool
-	switch strings.ToLower(strings.TrimSpace(order)) {
-	case "", "asc":
-		desc = false
-	case "desc":
-		desc = true
-	default:
-		return nil, contract.WithContext(ctx, contract.Validation(
-			"The request contains invalid fields.",
-			map[string][]string{"order": {"must be asc or desc"}},
-		))
-	}
-	return q.Order(clause.OrderByColumn{Column: clause.Column{Name: sort}, Desc: desc}), nil
+	return q.Order(clause.OrderByColumn{Column: clause.Column{Name: field}, Desc: desc}), nil
 }
 
 // escapeLike escapes the LIKE metacharacters so a search term matches literally

--- a/database/listquery_test.go
+++ b/database/listquery_test.go
@@ -1,0 +1,302 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/gombit-dev/gombit/contract"
+	"gorm.io/gorm"
+)
+
+type lqItem struct {
+	ID       uint `gorm:"primaryKey"`
+	Title    string
+	AuthorID uint
+	Views    int
+}
+
+// TestListQueryHelpersSQLite exercises FilterEq / Search / SortBy on SQLite.
+// The same assertions run against Postgres and MySQL from the integration suite
+// (see TestListQueryHelpers{Postgres,MySQL}) so the SQLite+PG+MySQL matrix the
+// working agreement requires is covered.
+func TestListQueryHelpersSQLite(t *testing.T) {
+	assertListQueryHelpers(t, openSQLite(t))
+}
+
+func assertListQueryHelpers(t *testing.T, db *DB) {
+	t.Helper()
+	seedListQuery(t, db)
+
+	t.Run("FilterEq", func(t *testing.T) {
+		ctx := context.Background()
+		// Empty raw value is a no-op.
+		q, err := FilterEq(ctx, db.Model(&lqItem{}), "author_id", FilterUint, "  ")
+		if err != nil {
+			t.Fatalf("empty filter: %v", err)
+		}
+		var all []lqItem
+		if err := q.Find(&all).Error; err != nil {
+			t.Fatalf("empty filter find: %v", err)
+		}
+		if len(all) != 3 {
+			t.Fatalf("empty filter returned %d rows, want 3 (no-op)", len(all))
+		}
+		// Coerced uint match.
+		q, err = FilterEq(ctx, db.Model(&lqItem{}), "author_id", FilterUint, "1")
+		if err != nil {
+			t.Fatalf("author filter: %v", err)
+		}
+		var byAuthor []lqItem
+		if err := q.Find(&byAuthor).Error; err != nil {
+			t.Fatalf("author filter find: %v", err)
+		}
+		if len(byAuthor) != 2 {
+			t.Fatalf("author_id=1 returned %d rows, want 2", len(byAuthor))
+		}
+		// A value that does not parse as the kind is a 422 on the column.
+		_, err = FilterEq(ctx, db.Model(&lqItem{}), "author_id", FilterUint, "not-a-number")
+		assertValidationField(t, err, "author_id")
+	})
+
+	t.Run("SearchEscapesWildcards", func(t *testing.T) {
+		var matches []lqItem
+		if err := Search(db.Model(&lqItem{}), []string{"title"}, "report").Find(&matches).Error; err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(matches) != 1 || matches[0].Title != "Alpha report" {
+			t.Fatalf("search 'report' = %+v, want the Alpha row", matches)
+		}
+		// A literal "%" must not act as a wildcard.
+		var literal []lqItem
+		if err := Search(db.Model(&lqItem{}), []string{"title"}, "50%").Find(&literal).Error; err != nil {
+			t.Fatalf("search literal percent: %v", err)
+		}
+		if len(literal) != 1 || literal[0].Title != "Beta 50% off" {
+			t.Fatalf("search '50%%' = %+v, want only the Beta row (wildcard escaped)", literal)
+		}
+		// Empty term is a no-op.
+		var none []lqItem
+		if err := Search(db.Model(&lqItem{}), []string{"title"}, "  ").Find(&none).Error; err != nil {
+			t.Fatalf("empty search: %v", err)
+		}
+		if len(none) != 3 {
+			t.Fatalf("empty search returned %d rows, want 3 (no-op)", len(none))
+		}
+	})
+
+	t.Run("SortBy", func(t *testing.T) {
+		ctx := context.Background()
+		allowed := []string{"views"}
+		firstView := func(order string) int {
+			t.Helper()
+			q, err := SortBy(ctx, db.Model(&lqItem{}), "views", order, allowed, "id")
+			if err != nil {
+				t.Fatalf("SortBy(order=%q) error = %v", order, err)
+			}
+			var rows []lqItem
+			if err := q.Find(&rows).Error; err != nil {
+				t.Fatalf("find: %v", err)
+			}
+			return rows[0].Views
+		}
+		if got := firstView("asc"); got != 10 {
+			t.Fatalf("asc first Views = %d, want 10", got)
+		}
+		if got := firstView("desc"); got != 30 {
+			t.Fatalf("desc first Views = %d, want 30", got)
+		}
+		if got := firstView(""); got != 10 {
+			t.Fatalf("default first Views = %d, want 10 (asc)", got)
+		}
+		// Fallback ordering when sort is empty.
+		q, err := SortBy(ctx, db.Model(&lqItem{}), "", "", allowed, "id")
+		if err != nil {
+			t.Fatalf("fallback SortBy error = %v", err)
+		}
+		var rows []lqItem
+		if err := q.Find(&rows).Error; err != nil {
+			t.Fatalf("fallback find: %v", err)
+		}
+		if rows[0].ID != 1 {
+			t.Fatalf("fallback first row ID = %d, want 1 (order by id)", rows[0].ID)
+		}
+	})
+
+	t.Run("SortByRejectsUndeclared", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := SortBy(ctx, db.Model(&lqItem{}), "author_id", "asc", []string{"views"}, "id")
+		assertValidationField(t, err, "sort")
+		_, err = SortBy(ctx, db.Model(&lqItem{}), "views", "sideways", []string{"views"}, "id")
+		assertValidationField(t, err, "order")
+	})
+}
+
+func seedListQuery(t *testing.T, db *DB) {
+	t.Helper()
+	if err := db.AutoMigrate(&lqItem{}); err != nil {
+		t.Fatalf("AutoMigrate() error = %v", err)
+	}
+	if err := db.Where("1 = 1").Delete(&lqItem{}).Error; err != nil {
+		t.Fatalf("reset table: %v", err)
+	}
+	rows := []lqItem{
+		{Title: "Alpha report", AuthorID: 1, Views: 30},
+		{Title: "Beta 50% off", AuthorID: 1, Views: 10},
+		{Title: "Gamma memo", AuthorID: 2, Views: 20},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func assertValidationField(t *testing.T, err error, field string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want validation error on %q", field)
+	}
+	env, ok := err.(*contract.ErrorEnvelope)
+	if !ok {
+		t.Fatalf("error type = %T, want *contract.ErrorEnvelope", err)
+	}
+	if env.Body.Code != contract.CodeValidationError {
+		t.Fatalf("error code = %q, want %q", env.Body.Code, contract.CodeValidationError)
+	}
+	if _, ok := env.Body.Fields[field]; !ok {
+		t.Fatalf("validation fields = %v, want a %q entry", env.Body.Fields, field)
+	}
+}
+
+// --- Runtime contract test -------------------------------------------------
+// TestGeneratedListContractRuntime mirrors the exact input struct and handler
+// the resource generator emits for a resource declaring searchable / sortable /
+// filterable fields (plus a belongs_to, filterable by default), and drives it
+// through Huma end to end. It proves the generated shape registers with Huma
+// (string query params, no unsupported pointers) and that filter+search+sort+
+// pagination behave over a real SQLite database.
+
+type ctItem struct {
+	ID       uint `gorm:"primaryKey"`
+	Title    string
+	AuthorID uint
+	Done     bool
+}
+
+type ctListInput struct {
+	Page     int    `query:"page" doc:"1-based page"`
+	PerPage  int    `query:"per_page" doc:"Page size"`
+	Q        string `query:"q" doc:"Search"`
+	Sort     string `query:"sort" enum:"title" doc:"Sort field"`
+	Order    string `query:"order" enum:"asc,desc" doc:"Sort direction"`
+	Done     string `query:"done" enum:"true,false" doc:"Filter by Done"`
+	AuthorID string `query:"author_id" doc:"Filter by AuthorID"`
+}
+
+type ctListOutput struct {
+	Body contract.DataMeta[[]ctItem, contract.PageMeta]
+}
+
+func TestGeneratedListContractRuntime(t *testing.T) {
+	db := openSQLite(t)
+	if err := db.AutoMigrate(&ctItem{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := db.Where("1 = 1").Delete(&ctItem{}).Error; err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	rows := []ctItem{
+		{Title: "Zulu", AuthorID: 1, Done: true},
+		{Title: "Alpha", AuthorID: 1, Done: false},
+		{Title: "Mike", AuthorID: 2, Done: true},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	list := func(ctx context.Context, in *ctListInput) (*ctListOutput, error) {
+		page, perPage := contract.ClampPage(in.Page, in.PerPage)
+		q := db.WithContext(ctx).Model(&ctItem{})
+		q, err := FilterEq(ctx, q, "done", FilterBool, in.Done)
+		if err != nil {
+			return nil, err
+		}
+		q, err = FilterEq(ctx, q, "author_id", FilterUint, in.AuthorID)
+		if err != nil {
+			return nil, err
+		}
+		q = Search(q, []string{"title"}, in.Q)
+		var total int64
+		if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+			return nil, contract.WithContext(ctx, contract.Internal("count"))
+		}
+		q, err = SortBy(ctx, q, in.Sort, in.Order, []string{"title"}, "id")
+		if err != nil {
+			return nil, err
+		}
+		var out []ctItem
+		if err := q.Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&out).Error; err != nil {
+			return nil, contract.WithContext(ctx, contract.Internal("list"))
+		}
+		return &ctListOutput{Body: contract.DataMeta[[]ctItem, contract.PageMeta]{Data: out, Meta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total}}}, nil
+	}
+
+	_, api := humatest.New(t)
+	huma.Register(api, huma.Operation{OperationID: "list-ct", Method: http.MethodGet, Path: "/items"}, list)
+
+	// Filter by FK: author_id=1 -> 2 rows.
+	if got := decodeList(t, api.Get("/items?author_id=1")); len(got.Meta) == 0 || got.total() != 2 || len(got.Data) != 2 {
+		t.Fatalf("author_id=1 total=%d rows=%d", got.total(), len(got.Data))
+	}
+	// Filter by bool: done=true -> 2 rows.
+	if got := decodeList(t, api.Get("/items?done=true")); got.total() != 2 {
+		t.Fatalf("done=true total=%d, want 2", got.total())
+	}
+	// Search: q=al -> Alpha only.
+	if got := decodeList(t, api.Get("/items?q=al")); got.total() != 1 || got.Data[0].Title != "Alpha" {
+		t.Fatalf("q=al = %+v", got.Data)
+	}
+	// Sort desc by title -> Zulu first.
+	if got := decodeList(t, api.Get("/items?sort=title&order=desc")); got.Data[0].Title != "Zulu" {
+		t.Fatalf("sort desc first = %q, want Zulu", got.Data[0].Title)
+	}
+	// Default order (no ?sort) is by id -> first inserted (Zulu) first.
+	if got := decodeList(t, api.Get("/items")); got.Data[0].Title != "Zulu" {
+		t.Fatalf("default first = %q, want Zulu (id order)", got.Data[0].Title)
+	}
+	// Undeclared sort field -> 422.
+	if resp := api.Get("/items?sort=author_id"); resp.Code != 422 {
+		t.Fatalf("sort=author_id code = %d, want 422; body=%s", resp.Code, resp.Body.String())
+	}
+	// Bad filter value -> 422.
+	if resp := api.Get("/items?author_id=nope"); resp.Code != 422 {
+		t.Fatalf("author_id=nope code = %d, want 422; body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+type ctDecoded struct {
+	Data []ctItem       `json:"data"`
+	Meta map[string]any `json:"meta"`
+}
+
+func (d ctDecoded) total() int {
+	if v, ok := d.Meta["total"].(float64); ok {
+		return int(v)
+	}
+	return -1
+}
+
+func decodeList(t *testing.T, resp *httptest.ResponseRecorder) ctDecoded {
+	t.Helper()
+	if resp.Code != 200 {
+		t.Fatalf("code = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	var out ctDecoded
+	if err := json.Unmarshal(resp.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode %s: %v", resp.Body.String(), err)
+	}
+	return out
+}

--- a/database/listquery_test.go
+++ b/database/listquery_test.go
@@ -89,14 +89,14 @@ func assertListQueryHelpers(t *testing.T, db *DB) {
 		}
 	})
 
-	t.Run("SortBy", func(t *testing.T) {
+	t.Run("Ordering", func(t *testing.T) {
 		ctx := context.Background()
 		allowed := []string{"views"}
-		firstView := func(order string) int {
+		firstView := func(ordering string) int {
 			t.Helper()
-			q, err := SortBy(ctx, db.Model(&lqItem{}), "views", order, allowed, "id")
+			q, err := Ordering(ctx, db.Model(&lqItem{}), ordering, allowed, "id")
 			if err != nil {
-				t.Fatalf("SortBy(order=%q) error = %v", order, err)
+				t.Fatalf("Ordering(%q) error = %v", ordering, err)
 			}
 			var rows []lqItem
 			if err := q.Find(&rows).Error; err != nil {
@@ -104,19 +104,16 @@ func assertListQueryHelpers(t *testing.T, db *DB) {
 			}
 			return rows[0].Views
 		}
-		if got := firstView("asc"); got != 10 {
-			t.Fatalf("asc first Views = %d, want 10", got)
+		if got := firstView("views"); got != 10 {
+			t.Fatalf("ascending 'views' first Views = %d, want 10", got)
 		}
-		if got := firstView("desc"); got != 30 {
-			t.Fatalf("desc first Views = %d, want 30", got)
+		if got := firstView("-views"); got != 30 {
+			t.Fatalf("descending '-views' first Views = %d, want 30", got)
 		}
-		if got := firstView(""); got != 10 {
-			t.Fatalf("default first Views = %d, want 10 (asc)", got)
-		}
-		// Fallback ordering when sort is empty.
-		q, err := SortBy(ctx, db.Model(&lqItem{}), "", "", allowed, "id")
+		// Fallback ordering when ordering is empty.
+		q, err := Ordering(ctx, db.Model(&lqItem{}), "", allowed, "id")
 		if err != nil {
-			t.Fatalf("fallback SortBy error = %v", err)
+			t.Fatalf("fallback Ordering error = %v", err)
 		}
 		var rows []lqItem
 		if err := q.Find(&rows).Error; err != nil {
@@ -127,12 +124,12 @@ func assertListQueryHelpers(t *testing.T, db *DB) {
 		}
 	})
 
-	t.Run("SortByRejectsUndeclared", func(t *testing.T) {
+	t.Run("OrderingRejectsUndeclared", func(t *testing.T) {
 		ctx := context.Background()
-		_, err := SortBy(ctx, db.Model(&lqItem{}), "author_id", "asc", []string{"views"}, "id")
-		assertValidationField(t, err, "sort")
-		_, err = SortBy(ctx, db.Model(&lqItem{}), "views", "sideways", []string{"views"}, "id")
-		assertValidationField(t, err, "order")
+		_, err := Ordering(ctx, db.Model(&lqItem{}), "author_id", []string{"views"}, "id")
+		assertValidationField(t, err, "ordering")
+		_, err = Ordering(ctx, db.Model(&lqItem{}), "-author_id", []string{"views"}, "id")
+		assertValidationField(t, err, "ordering")
 	})
 }
 
@@ -189,9 +186,8 @@ type ctItem struct {
 type ctListInput struct {
 	Page     int    `query:"page" doc:"1-based page"`
 	PerPage  int    `query:"per_page" doc:"Page size"`
-	Q        string `query:"q" doc:"Search"`
-	Sort     string `query:"sort" enum:"title" doc:"Sort field"`
-	Order    string `query:"order" enum:"asc,desc" doc:"Sort direction"`
+	Search   string `query:"search" doc:"Search"`
+	Ordering string `query:"ordering" doc:"Order field; - prefix for DESC"`
 	Done     string `query:"done" enum:"true,false" doc:"Filter by Done"`
 	AuthorID string `query:"author_id" doc:"Filter by AuthorID"`
 }
@@ -228,12 +224,12 @@ func TestGeneratedListContractRuntime(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		q = Search(q, []string{"title"}, in.Q)
+		q = Search(q, []string{"title"}, in.Search)
 		var total int64
 		if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
 			return nil, contract.WithContext(ctx, contract.Internal("count"))
 		}
-		q, err = SortBy(ctx, q, in.Sort, in.Order, []string{"title"}, "id")
+		q, err = Ordering(ctx, q, in.Ordering, []string{"title"}, "id")
 		if err != nil {
 			return nil, err
 		}
@@ -255,21 +251,21 @@ func TestGeneratedListContractRuntime(t *testing.T) {
 	if got := decodeList(t, api.Get("/items?done=true")); got.total() != 2 {
 		t.Fatalf("done=true total=%d, want 2", got.total())
 	}
-	// Search: q=al -> Alpha only.
-	if got := decodeList(t, api.Get("/items?q=al")); got.total() != 1 || got.Data[0].Title != "Alpha" {
-		t.Fatalf("q=al = %+v", got.Data)
+	// Search: search=al -> Alpha only.
+	if got := decodeList(t, api.Get("/items?search=al")); got.total() != 1 || got.Data[0].Title != "Alpha" {
+		t.Fatalf("search=al = %+v", got.Data)
 	}
-	// Sort desc by title -> Zulu first.
-	if got := decodeList(t, api.Get("/items?sort=title&order=desc")); got.Data[0].Title != "Zulu" {
-		t.Fatalf("sort desc first = %q, want Zulu", got.Data[0].Title)
+	// Order desc by title (-title) -> Zulu first.
+	if got := decodeList(t, api.Get("/items?ordering=-title")); got.Data[0].Title != "Zulu" {
+		t.Fatalf("ordering=-title first = %q, want Zulu", got.Data[0].Title)
 	}
-	// Default order (no ?sort) is by id -> first inserted (Zulu) first.
+	// Default order (no ?ordering) is by id -> first inserted (Zulu) first.
 	if got := decodeList(t, api.Get("/items")); got.Data[0].Title != "Zulu" {
 		t.Fatalf("default first = %q, want Zulu (id order)", got.Data[0].Title)
 	}
-	// Undeclared sort field -> 422.
-	if resp := api.Get("/items?sort=author_id"); resp.Code != 422 {
-		t.Fatalf("sort=author_id code = %d, want 422; body=%s", resp.Code, resp.Body.String())
+	// Undeclared ordering field -> 422.
+	if resp := api.Get("/items?ordering=author_id"); resp.Code != 422 {
+		t.Fatalf("ordering=author_id code = %d, want 422; body=%s", resp.Code, resp.Body.String())
 	}
 	// Bad filter value -> 422.
 	if resp := api.Get("/items?author_id=nope"); resp.Code != 422 {

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -75,6 +75,39 @@ Body: contract.DataMeta[[]Widget, contract.PageMeta]{
 }
 ```
 
+### List query: filter / sort / search
+
+Beyond pagination, `gombit make resource` opts declared fields into a list-query
+surface (issue #260). Declaration keeps the surface a safe, indexable subset —
+a field is queryable only when it opts in, mirroring how list columns are a
+declared subset. Add modifiers to the field grammar:
+
+| Modifier     | Query parameter                     | Types                                         |
+| ------------ | ----------------------------------- | --------------------------------------------- |
+| `filterable` | `?<field>=<value>` (exact match)    | string, int, int64, uint, bool, enum          |
+| `sortable`   | `?sort=<field>&order=asc\|desc`     | any scalar (and belongs_to FK)                |
+| `searchable` | `?q=<term>` (case-insensitive LIKE) | string, text, enum                            |
+
+A `belongs_to` foreign key is **filterable by default** — no modifier needed —
+so a detail page can list a record's `has_many` children with
+`GET /api/v1/invoices?customer_id=<id>`.
+
+```bash
+gombit make resource Article \
+  title:string:required,searchable,sortable \
+  body:text:searchable \
+  status:enum(draft,published):filterable,sortable \
+  author:belongs_to:Author
+```
+
+The generated handler applies filters and `?q=` before the `COUNT`, so
+`meta.total` reflects the filtered set; `?sort=` replaces the fixed `id` order
+(`id` stays the default when `?sort=` is absent) and is validated against the
+declared sortable set. An undeclared sort field or a bad `order` returns a D10
+`validation_error` (422). The shared primitives live in `database` (`FilterEq`,
+`Search`, `SortBy`) and are the same behavior the admin data plane applies.
+Filter values are exact-match to start; ranges/operators come later.
+
 ## Request DTOs
 
 Go structs are the source of truth. Prefer Huma tags — not a separate

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -78,15 +78,16 @@ Body: contract.DataMeta[[]Widget, contract.PageMeta]{
 ### List query: filter / sort / search
 
 Beyond pagination, `gombit make resource` opts declared fields into a list-query
-surface (issue #260). Declaration keeps the surface a safe, indexable subset —
-a field is queryable only when it opts in, mirroring how list columns are a
-declared subset. Add modifiers to the field grammar:
+surface (issue #260) that uses the **same query spelling as the admin data
+plane** so the two contracts do not diverge. Declaration keeps the surface a
+safe, indexable subset — a field is queryable only when it opts in, mirroring how
+list columns are a declared subset. Add modifiers to the field grammar:
 
-| Modifier     | Query parameter                     | Types                                         |
-| ------------ | ----------------------------------- | --------------------------------------------- |
-| `filterable` | `?<field>=<value>` (exact match)    | string, int, int64, uint, bool, enum          |
-| `sortable`   | `?sort=<field>&order=asc\|desc`     | any scalar (and belongs_to FK)                |
-| `searchable` | `?q=<term>` (case-insensitive LIKE) | string, text, enum                            |
+| Modifier     | Query parameter                          | Types                                |
+| ------------ | ---------------------------------------- | ------------------------------------ |
+| `filterable` | `?<field>=<value>` (exact match)         | string, int, int64, uint, bool, enum |
+| `sortable`   | `?ordering=<field>` (`-<field>` for DESC) | any scalar (and belongs_to FK)       |
+| `searchable` | `?search=<term>` (case-insensitive LIKE) | string, text, enum                   |
 
 A `belongs_to` foreign key is **filterable by default** — no modifier needed —
 so a detail page can list a record's `has_many` children with
@@ -100,12 +101,13 @@ gombit make resource Article \
   author:belongs_to:Author
 ```
 
-The generated handler applies filters and `?q=` before the `COUNT`, so
-`meta.total` reflects the filtered set; `?sort=` replaces the fixed `id` order
-(`id` stays the default when `?sort=` is absent) and is validated against the
-declared sortable set. An undeclared sort field or a bad `order` returns a D10
-`validation_error` (422). The shared primitives live in `database` (`FilterEq`,
-`Search`, `SortBy`) and are the same behavior the admin data plane applies.
+The generated handler applies filters and `?search=` before the `COUNT`, so
+`meta.total` reflects the filtered set; `?ordering=` replaces the fixed `id`
+order (`id` stays the default when `?ordering=` is absent) and is validated
+against the declared sortable set. An undeclared ordering field or an
+uncoercible filter value returns a D10 `validation_error` (422). The shared
+primitives live in `database` (`FilterEq`, `Search`, `Ordering` / `ParseOrdering`)
+and are the same behavior — and now the same code — the admin data plane applies.
 Filter values are exact-match to start; ranges/operators come later.
 
 ## Request DTOs

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -212,8 +212,12 @@ create internal/task/routes.go
 modify internal/task/task.go
 ```
 
-The field grammar is `name:type[:required][,unique][,index]`, over `string`,
-`text`, `int`, `int64`, `bool`, and `uint`.
+The field grammar is
+`name:type[:required][,unique][,index][,filterable][,sortable][,searchable]`,
+over `string`, `text`, `int`, `int64`, `bool`, and `uint`. The
+`filterable` / `sortable` / `searchable` modifiers opt a field into the list
+handler's declared query surface — see the
+[list query](contract.md#list-query-filter--sort--search) section.
 
 Two properties of every Gombit generator matter here:
 

--- a/goldentest/golden_test.go
+++ b/goldentest/golden_test.go
@@ -253,6 +253,40 @@ func TestMakeResourceRelationsCompiles(t *testing.T) {
 	})
 }
 
+// TestMakeResourceListQueryCompiles exercises the #260 declared list-query
+// grammar end to end: a resource declaring searchable / sortable / filterable
+// fields plus a belongs_to (filterable by default) must generate a handler that
+// compiles against the framework's database list-query helpers.
+func TestMakeResourceListQueryCompiles(t *testing.T) {
+	appDir := scaffoldDemo(t)
+	gen := func(name string, fields ...string) {
+		t.Helper()
+		stdout := new(bytes.Buffer)
+		if err := resourcegen.Generate(context.Background(), resourcegen.Options{
+			WorkDir:  appDir,
+			Name:     name,
+			Fields:   fields,
+			AtlasBin: missingAtlas,
+			Stdout:   stdout,
+			Stderr:   io.Discard,
+		}); err != nil {
+			t.Fatalf("gombit make resource %s: %v\nstdout=%s", name, err, stdout.String())
+		}
+	}
+	gen("Author", "name:string:required")
+	gen("Article",
+		"title:string:required,searchable,sortable",
+		"body:text:searchable",
+		"views:int:filterable,sortable",
+		"published:bool:filterable",
+		"status:enum(draft,published):filterable,sortable",
+		"author:belongs_to:Author",
+	)
+	t.Run("compile", func(t *testing.T) {
+		compileBackend(t, appDir)
+	})
+}
+
 func TestMakeCommandGolden(t *testing.T) {
 	appDir := scaffoldDemo(t)
 	stdout := new(bytes.Buffer)

--- a/resourcegen/fields.go
+++ b/resourcegen/fields.go
@@ -19,6 +19,15 @@ type Field struct {
 	Index    bool
 	Nullable bool
 
+	// Filterable / Sortable / Searchable opt this field into the generated list
+	// handler's declared query surface (issue #260): exact-match ?<field>=,
+	// ?sort=<field>&order=, and ?q= respectively. belongs_to fields are
+	// filterable by default (see filterable) so the has_many detail-list case —
+	// GET /children?<parent>_id=<id> — works without extra declaration.
+	Filterable bool
+	Sortable   bool
+	Searchable bool
+
 	// EnumValues holds the allowed values for FieldEnum, in declared order.
 	EnumValues []string
 	// Precision/Scale set the decimal(p,s) column for FieldDecimal.
@@ -419,16 +428,119 @@ func applyModifiers(field *Field, raw string) error {
 			field.Index = true
 		case mod == "nullable":
 			field.Nullable = true
+		case mod == "filterable":
+			field.Filterable = true
+		case mod == "sortable":
+			field.Sortable = true
+		case mod == "searchable":
+			field.Searchable = true
 		case strings.HasPrefix(mod, "default="), strings.HasPrefix(mod, "min="), strings.HasPrefix(mod, "max="), strings.HasPrefix(mod, "references="):
-			return fmt.Errorf("resourcegen: modifier %q is not supported in this milestone (supported: required, unique, index, nullable)", mod)
+			return fmt.Errorf("resourcegen: modifier %q is not supported in this milestone (supported: required, unique, index, nullable, filterable, sortable, searchable)", mod)
 		default:
-			return fmt.Errorf("resourcegen: unknown modifier %q (supported: required, unique, index, nullable)", mod)
+			return fmt.Errorf("resourcegen: unknown modifier %q (supported: required, unique, index, nullable, filterable, sortable, searchable)", mod)
 		}
 	}
 	if field.Required && field.Nullable {
 		return fmt.Errorf("resourcegen: field %q cannot be both required and nullable", field.JSONName)
 	}
+	if field.Filterable && !field.typeAllowsFilter() {
+		return fmt.Errorf("resourcegen: field %q is %s and cannot be filterable (supported: string, int, int64, uint, bool, enum, belongs_to)", field.JSONName, field.Type)
+	}
+	if field.Searchable && !field.typeAllowsSearch() {
+		return fmt.Errorf("resourcegen: field %q is %s and cannot be searchable (supported: string, text, enum)", field.JSONName, field.Type)
+	}
+	if field.Sortable && !field.typeAllowsSort() {
+		return fmt.Errorf("resourcegen: field %q is %s and cannot be sortable", field.JSONName, field.Type)
+	}
 	return nil
+}
+
+// typeAllowsFilter reports whether an exact-match filter query param can be
+// generated for this field's type. Exact-match on decimal/time is fiddly to
+// coerce and rarely useful (ranges come later, #260), and text columns are for
+// search, not equality; both are excluded.
+func (f Field) typeAllowsFilter() bool {
+	switch f.Type {
+	case FieldString, FieldInt, FieldInt64, FieldUint, FieldBool, FieldEnum, FieldBelongsTo:
+		return true
+	default:
+		return false
+	}
+}
+
+// typeAllowsSearch reports whether the field is a text-like column ?q= can LIKE.
+func (f Field) typeAllowsSearch() bool {
+	switch f.Type {
+	case FieldString, FieldText, FieldEnum:
+		return true
+	default:
+		return false
+	}
+}
+
+// typeAllowsSort reports whether the field maps to a single orderable column.
+// Every scalar and the belongs_to foreign key qualifies; has_many / many_to_many
+// (multi-row associations) do not.
+func (f Field) typeAllowsSort() bool {
+	switch f.Type {
+	case FieldHasMany, FieldManyToMany:
+		return false
+	default:
+		return true
+	}
+}
+
+// isFilterable reports whether the generated list handler exposes an exact-match
+// filter for this field. belongs_to foreign keys are filterable by default so
+// the has_many detail-list case (GET /children?<parent>_id=<id>, issue #260 /
+// Forge #53) needs no extra declaration; every other field opts in.
+func (f Field) isFilterable() bool {
+	return f.Filterable || f.Type == FieldBelongsTo
+}
+
+// filterColumn / searchColumn / sortColumn are the DB column names the list
+// query references. For our naming they equal the DTO JSON name (toSnake of the
+// Go field), which is what GORM's default naming strategy derives for the model
+// column — belongs_to resolves to its <name>_id foreign key.
+func (f Field) filterColumn() string { return f.dtoJSONName() }
+func (f Field) searchColumn() string { return f.JSONName }
+func (f Field) sortColumn() string   { return f.dtoJSONName() }
+
+// filterInputField names the field on the generated list-input struct. Filters
+// are string query params (Huma has no optional/pointer query params, so empty
+// string is the "absent" signal); the value is coerced server-side by kind.
+func (f Field) filterInputField() string { return f.dtoGoName() }
+
+// filterKindExpr is the database.FilterKind the generated handler passes to
+// database.FilterEq so it coerces the raw filter string to the column's type.
+func (f Field) filterKindExpr() string {
+	switch f.Type {
+	case FieldInt:
+		return "database.FilterInt"
+	case FieldInt64:
+		return "database.FilterInt64"
+	case FieldUint, FieldBelongsTo:
+		return "database.FilterUint"
+	case FieldBool:
+		return "database.FilterBool"
+	default: // FieldString, FieldEnum
+		return "database.FilterString"
+	}
+}
+
+// filterQueryTag builds the Huma struct tag for a filter query param: the query
+// name, an enum constraint for bool (true/false) and enum columns so Huma
+// rejects bad values before the handler, and a doc string.
+func (f Field) filterQueryTag() string {
+	tag := `query:"` + f.filterColumn() + `"`
+	switch f.Type {
+	case FieldEnum:
+		tag += ` enum:"` + strings.Join(f.EnumValues, ",") + `"`
+	case FieldBool:
+		tag += ` enum:"true,false"`
+	}
+	tag += ` doc:"Filter by ` + f.filterInputField() + ` (exact match)"`
+	return tag
 }
 
 func (f Field) gormTag() string {

--- a/resourcegen/fields.go
+++ b/resourcegen/fields.go
@@ -21,8 +21,9 @@ type Field struct {
 
 	// Filterable / Sortable / Searchable opt this field into the generated list
 	// handler's declared query surface (issue #260): exact-match ?<field>=,
-	// ?sort=<field>&order=, and ?q= respectively. belongs_to fields are
-	// filterable by default (see filterable) so the has_many detail-list case —
+	// ?ordering=<field> (- prefix for DESC), and ?search= respectively — the same
+	// spelling as the admin data plane. belongs_to fields are filterable by
+	// default (see isFilterable) so the has_many detail-list case —
 	// GET /children?<parent>_id=<id> — works without extra declaration.
 	Filterable bool
 	Sortable   bool
@@ -268,6 +269,9 @@ func parseField(spec, resourcePkg string) (Field, error) {
 	if _, reserved := reservedFields[jsonName]; reserved {
 		return Field{}, fmt.Errorf("resourcegen: field %q conflicts with gorm.Model", jsonName)
 	}
+	if _, reserved := reservedQueryFields[jsonName]; reserved {
+		return Field{}, fmt.Errorf("resourcegen: field %q is reserved for the list-query params (page, per_page, search, ordering); rename it", jsonName)
+	}
 
 	// Relations (name:kind:Target) use parts[2] as the target model, not
 	// modifiers.
@@ -468,7 +472,7 @@ func (f Field) typeAllowsFilter() bool {
 	}
 }
 
-// typeAllowsSearch reports whether the field is a text-like column ?q= can LIKE.
+// typeAllowsSearch reports whether the field is a text-like column ?search= can LIKE.
 func (f Field) typeAllowsSearch() bool {
 	switch f.Type {
 	case FieldString, FieldText, FieldEnum:

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -211,6 +211,41 @@ func modelFieldLines(f Field, resourcePkg string) string {
 	}
 }
 
+// filterFields returns the fields the generated list handler exposes as
+// exact-match query filters, in declared order (belongs_to FKs are included by
+// default; see Field.isFilterable).
+func filterFields(fields []Field) []Field {
+	out := make([]Field, 0, len(fields))
+	for _, f := range fields {
+		if f.isFilterable() {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// searchColumns returns the DB columns ?q= searches, in declared order.
+func searchColumns(fields []Field) []string {
+	var out []string
+	for _, f := range fields {
+		if f.Searchable {
+			out = append(out, f.searchColumn())
+		}
+	}
+	return out
+}
+
+// sortColumns returns the DB columns ?sort= may order by, in declared order.
+func sortColumns(fields []Field) []string {
+	var out []string
+	for _, f := range fields {
+		if f.Sortable {
+			out = append(out, f.sortColumn())
+		}
+	}
+	return out
+}
+
 func renderHandler(ctx renderContext) string {
 	var b strings.Builder
 	pkg := ctx.Resource.Package
@@ -250,9 +285,23 @@ func renderHandler(ctx renderContext) string {
 	listIn := "list" + ctx.Resource.Tag + "Input"
 	b.WriteString("type " + listOut + " struct {\n")
 	b.WriteString("\tBody contract.DataMeta[[]" + data + ", contract.PageMeta]\n}\n\n")
+	filters := filterFields(ctx.Fields)
+	searchCols := searchColumns(ctx.Fields)
+	sortCols := sortColumns(ctx.Fields)
 	b.WriteString("type " + listIn + " struct {\n")
 	b.WriteString("\tPage    int `query:\"page\" doc:\"1-based page\"`\n")
-	b.WriteString("\tPerPage int `query:\"per_page\" doc:\"Page size\"`\n}\n\n")
+	b.WriteString("\tPerPage int `query:\"per_page\" doc:\"Page size\"`\n")
+	if len(searchCols) > 0 {
+		b.WriteString("\tQ string `query:\"q\" doc:\"Search term matched across searchable fields\"`\n")
+	}
+	if len(sortCols) > 0 {
+		b.WriteString("\tSort  string `query:\"sort\" enum:\"" + strings.Join(sortCols, ",") + "\" doc:\"Field to sort by\"`\n")
+		b.WriteString("\tOrder string `query:\"order\" enum:\"asc,desc\" doc:\"Sort direction (default asc)\"`\n")
+	}
+	for _, f := range filters {
+		b.WriteString("\t" + f.filterInputField() + " string `" + f.filterQueryTag() + "`\n")
+	}
+	b.WriteString("}\n\n")
 	b.WriteString("type get" + typ + "Input struct {\n")
 	b.WriteString("\tID string `path:\"id\" doc:\"" + typ + " identifier\"`\n}\n\n")
 	b.WriteString("type get" + typ + "Output struct {\n")
@@ -271,12 +320,43 @@ func renderHandler(ctx renderContext) string {
 	b.WriteString("func (h *Handler) list(ctx context.Context, input *" + listIn + ") (*" + listOut + ", error) {\n")
 	b.WriteString("\tpage, perPage := contract.ClampPage(input.Page, input.PerPage)\n")
 	b.WriteString("\tq := h.DB.WithContext(ctx).Model(&" + typ + "{})\n")
+	// Declared filters and search narrow the set before the count, so meta.total
+	// reflects the filtered collection, not the whole table. errDeclared tracks
+	// whether the function-scope err exists yet so the first assignment uses :=.
+	errDeclared := false
+	for _, f := range filters {
+		assign := "="
+		if !errDeclared {
+			assign = ":="
+			errDeclared = true
+		}
+		b.WriteString("\tq, err " + assign + " database.FilterEq(ctx, q, \"" + f.filterColumn() + "\", " + f.filterKindExpr() + ", input." + f.filterInputField() + ")\n")
+		b.WriteString("\tif err != nil {\n\t\treturn nil, err\n\t}\n")
+	}
+	if len(searchCols) > 0 {
+		b.WriteString("\tq = database.Search(q, []string{\"" + strings.Join(searchCols, "\", \"") + "\"}, input.Q)\n")
+	}
 	b.WriteString("\tvar total int64\n")
 	b.WriteString("\tif err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {\n")
 	b.WriteString("\t\treturn nil, contract.WithContext(ctx, contract.Internal(\"list " + ctx.Resource.PluralSnake + "\"))\n")
 	b.WriteString("\t}\n")
+	if len(sortCols) > 0 {
+		// Declared sort replaces the fixed Order("id"), which stays the fallback
+		// when ?sort= is absent so the default page order is unchanged.
+		assign := "="
+		if !errDeclared {
+			assign = ":="
+			errDeclared = true
+		}
+		b.WriteString("\tq, err " + assign + " database.SortBy(ctx, q, input.Sort, input.Order, []string{\"" + strings.Join(sortCols, "\", \"") + "\"}, \"id\")\n")
+		b.WriteString("\tif err != nil {\n\t\treturn nil, err\n\t}\n")
+	}
 	b.WriteString("\tvar rows []" + typ + "\n")
-	b.WriteString("\tif err := q.Order(\"id\").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {\n")
+	if len(sortCols) > 0 {
+		b.WriteString("\tif err := q.Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {\n")
+	} else {
+		b.WriteString("\tif err := q.Order(\"id\").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&rows).Error; err != nil {\n")
+	}
 	b.WriteString("\t\treturn nil, contract.WithContext(ctx, contract.Internal(\"list " + ctx.Resource.PluralSnake + "\"))\n")
 	b.WriteString("\t}\n")
 	b.WriteString("\titems := make([]" + data + ", 0, len(rows))\n")

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -292,11 +292,10 @@ func renderHandler(ctx renderContext) string {
 	b.WriteString("\tPage    int `query:\"page\" doc:\"1-based page\"`\n")
 	b.WriteString("\tPerPage int `query:\"per_page\" doc:\"Page size\"`\n")
 	if len(searchCols) > 0 {
-		b.WriteString("\tQ string `query:\"q\" doc:\"Search term matched across searchable fields\"`\n")
+		b.WriteString("\tSearch string `query:\"search\" doc:\"Search term matched across searchable fields\"`\n")
 	}
 	if len(sortCols) > 0 {
-		b.WriteString("\tSort  string `query:\"sort\" enum:\"" + strings.Join(sortCols, ",") + "\" doc:\"Field to sort by\"`\n")
-		b.WriteString("\tOrder string `query:\"order\" enum:\"asc,desc\" doc:\"Sort direction (default asc)\"`\n")
+		b.WriteString("\tOrdering string `query:\"ordering\" doc:\"Field to order by; prefix with - for DESC (allowed: " + strings.Join(sortCols, ", ") + ")\"`\n")
 	}
 	for _, f := range filters {
 		b.WriteString("\t" + f.filterInputField() + " string `" + f.filterQueryTag() + "`\n")
@@ -334,21 +333,24 @@ func renderHandler(ctx renderContext) string {
 		b.WriteString("\tif err != nil {\n\t\treturn nil, err\n\t}\n")
 	}
 	if len(searchCols) > 0 {
-		b.WriteString("\tq = database.Search(q, []string{\"" + strings.Join(searchCols, "\", \"") + "\"}, input.Q)\n")
+		b.WriteString("\tq = database.Search(q, []string{\"" + strings.Join(searchCols, "\", \"") + "\"}, input.Search)\n")
 	}
 	b.WriteString("\tvar total int64\n")
 	b.WriteString("\tif err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {\n")
 	b.WriteString("\t\treturn nil, contract.WithContext(ctx, contract.Internal(\"list " + ctx.Resource.PluralSnake + "\"))\n")
 	b.WriteString("\t}\n")
 	if len(sortCols) > 0 {
-		// Declared sort replaces the fixed Order("id"), which stays the fallback
-		// when ?sort= is absent so the default page order is unchanged.
+		// Declared ordering replaces the fixed Order("id"), which stays the
+		// fallback when ?ordering= is absent so the default page order is
+		// unchanged. Same `?ordering=<field>` / `-<field>` spelling as the admin
+		// data plane.
+		// Ordering is the last consumer of the function-scope err, so this branch
+		// only reads errDeclared (never needs to set it).
 		assign := "="
 		if !errDeclared {
 			assign = ":="
-			errDeclared = true
 		}
-		b.WriteString("\tq, err " + assign + " database.SortBy(ctx, q, input.Sort, input.Order, []string{\"" + strings.Join(sortCols, "\", \"") + "\"}, \"id\")\n")
+		b.WriteString("\tq, err " + assign + " database.Ordering(ctx, q, input.Ordering, []string{\"" + strings.Join(sortCols, "\", \"") + "\"}, \"id\")\n")
 		b.WriteString("\tif err != nil {\n\t\treturn nil, err\n\t}\n")
 	}
 	b.WriteString("\tvar rows []" + typ + "\n")

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -224,7 +224,7 @@ func filterFields(fields []Field) []Field {
 	return out
 }
 
-// searchColumns returns the DB columns ?q= searches, in declared order.
+// searchColumns returns the DB columns ?search= searches, in declared order.
 func searchColumns(fields []Field) []string {
 	var out []string
 	for _, f := range fields {
@@ -235,7 +235,7 @@ func searchColumns(fields []Field) []string {
 	return out
 }
 
-// sortColumns returns the DB columns ?sort= may order by, in declared order.
+// sortColumns returns the DB columns ?ordering= may order by, in declared order.
 func sortColumns(fields []Field) []string {
 	var out []string
 	for _, f := range fields {

--- a/resourcegen/listquery_test.go
+++ b/resourcegen/listquery_test.go
@@ -1,0 +1,135 @@
+package resourcegen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseListQueryModifiers(t *testing.T) {
+	t.Parallel()
+	fields, err := parseFields([]string{
+		"title:string:required,searchable,sortable",
+		"views:int:filterable,sortable",
+		"published:bool:filterable",
+	}, "post")
+	if err != nil {
+		t.Fatalf("parseFields() error = %v", err)
+	}
+	title, views, published := fields[0], fields[1], fields[2]
+	if !title.Searchable || !title.Sortable || title.Filterable {
+		t.Fatalf("title flags = %+v, want searchable+sortable only", title)
+	}
+	if !views.Filterable || !views.Sortable || views.Searchable {
+		t.Fatalf("views flags = %+v, want filterable+sortable only", views)
+	}
+	if !published.Filterable || published.Sortable || published.Searchable {
+		t.Fatalf("published flags = %+v, want filterable only", published)
+	}
+}
+
+func TestListQueryModifierTypeErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		spec    string
+		wantErr string
+	}{
+		{"searchable int", "views:int:searchable", "cannot be searchable"},
+		{"filterable decimal", "price:decimal:filterable", "cannot be filterable"},
+		{"filterable time", "starts_at:time:filterable", "cannot be filterable"},
+		{"filterable text", "body:text:filterable", "cannot be filterable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseFields([]string{tt.spec}, "widget")
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("parseFields(%q) error = %v, want %q", tt.spec, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestBelongsToFilterableByDefault documents that a belongs_to foreign key is a
+// filter without any modifier — the has_many detail-list contract (#260).
+func TestBelongsToFilterableByDefault(t *testing.T) {
+	t.Parallel()
+	fields, err := parseFields([]string{"author:belongs_to:Author"}, "post")
+	if err != nil {
+		t.Fatalf("parseFields() error = %v", err)
+	}
+	if !fields[0].isFilterable() {
+		t.Fatal("belongs_to field should be filterable by default")
+	}
+	if fields[0].filterColumn() != "author_id" {
+		t.Fatalf("belongs_to filter column = %q, want author_id", fields[0].filterColumn())
+	}
+}
+
+func TestRenderHandlerListQuery(t *testing.T) {
+	t.Parallel()
+	fields, err := parseFields([]string{
+		"title:string:required,searchable,sortable",
+		"body:text:searchable",
+		"views:int:filterable,sortable",
+		"published:bool:filterable",
+		"author:belongs_to:Author",
+	}, "post")
+	if err != nil {
+		t.Fatalf("parseFields() error = %v", err)
+	}
+	name, err := parseResourceName("Post")
+	if err != nil {
+		t.Fatalf("parseResourceName() error = %v", err)
+	}
+	src := string(mustFormatGo(renderHandler(newRenderContext("example.com/demo", name, fields, "/api/v1", "minimal", false, false))))
+	if strings.Contains(src, "format error") {
+		t.Fatalf("generated handler does not format:\n%s", src)
+	}
+	wantContains := []string{
+		`query:"q" doc:"Search term`,
+		`query:"sort" enum:"title,views"`,
+		`query:"order" enum:"asc,desc"`,
+		`query:"views" doc:"Filter by Views (exact match)"`,
+		`query:"published" enum:"true,false" doc:"Filter by Published (exact match)"`,
+		`query:"author_id" doc:"Filter by AuthorID (exact match)"`,
+		`database.FilterEq(ctx, q, "views", database.FilterInt, input.Views)`,
+		`database.FilterEq(ctx, q, "published", database.FilterBool, input.Published)`,
+		`database.FilterEq(ctx, q, "author_id", database.FilterUint, input.AuthorID)`,
+		`database.Search(q, []string{"title", "body"}, input.Q)`,
+		`database.SortBy(ctx, q, input.Sort, input.Order, []string{"title", "views"}, "id")`,
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(src, want) {
+			t.Fatalf("generated handler missing %q\n%s", want, src)
+		}
+	}
+	// Body is searchable but not filterable/sortable: no filter param, no sort entry.
+	if strings.Contains(src, `query:"body"`) {
+		t.Fatalf("body must not be a filter param:\n%s", src)
+	}
+}
+
+// TestRenderHandlerNoListQuery is the regression guard that a resource declaring
+// no list-query modifiers keeps the original fixed Order("id") page and adds no
+// filter/search/sort query params.
+func TestRenderHandlerNoListQuery(t *testing.T) {
+	t.Parallel()
+	fields, err := parseFields([]string{"title:string:required"}, "post")
+	if err != nil {
+		t.Fatalf("parseFields() error = %v", err)
+	}
+	name, err := parseResourceName("Post")
+	if err != nil {
+		t.Fatalf("parseResourceName() error = %v", err)
+	}
+	src := string(mustFormatGo(renderHandler(newRenderContext("example.com/demo", name, fields, "/api/v1", "minimal", false, false))))
+	if !strings.Contains(src, `q.Order("id").Offset(`) {
+		t.Fatalf("handler without sort must keep fixed Order(\"id\"):\n%s", src)
+	}
+	for _, unwanted := range []string{`query:"q"`, `query:"sort"`, `database.SortBy`, `database.Search`, `database.FilterEq`} {
+		if strings.Contains(src, unwanted) {
+			t.Fatalf("handler without modifiers must not contain %q:\n%s", unwanted, src)
+		}
+	}
+}

--- a/resourcegen/listquery_test.go
+++ b/resourcegen/listquery_test.go
@@ -50,6 +50,32 @@ func TestListQueryModifierTypeErrors(t *testing.T) {
 	}
 }
 
+// TestReservedQueryFieldNamesRejected guards the collision the generated list
+// input would otherwise hit: a field named after a list-query param (page,
+// per_page, search, ordering) becomes a duplicate struct field with a duplicate
+// `query` tag — gofmt accepts it, go build does not. parseFields must refuse it
+// upfront, with or without a modifier.
+func TestReservedQueryFieldNamesRejected(t *testing.T) {
+	t.Parallel()
+	specs := []string{
+		"page:int:filterable",
+		"page:int",
+		"per_page:int:filterable",
+		"search:string:filterable",
+		"ordering:string:filterable",
+		"search:string",
+		"ordering:string:sortable",
+	}
+	for _, spec := range specs {
+		t.Run(spec, func(t *testing.T) {
+			t.Parallel()
+			if _, err := parseFields([]string{spec}, "post"); err == nil || !strings.Contains(err.Error(), "reserved for the list-query params") {
+				t.Fatalf("parseFields(%q) error = %v, want reserved-name rejection", spec, err)
+			}
+		})
+	}
+}
+
 // TestBelongsToFilterableByDefault documents that a belongs_to foreign key is a
 // filter without any modifier — the has_many detail-list contract (#260).
 func TestBelongsToFilterableByDefault(t *testing.T) {

--- a/resourcegen/listquery_test.go
+++ b/resourcegen/listquery_test.go
@@ -87,17 +87,16 @@ func TestRenderHandlerListQuery(t *testing.T) {
 		t.Fatalf("generated handler does not format:\n%s", src)
 	}
 	wantContains := []string{
-		`query:"q" doc:"Search term`,
-		`query:"sort" enum:"title,views"`,
-		`query:"order" enum:"asc,desc"`,
+		`query:"search" doc:"Search term`,
+		`query:"ordering" doc:"Field to order by; prefix with - for DESC (allowed: title, views)"`,
 		`query:"views" doc:"Filter by Views (exact match)"`,
 		`query:"published" enum:"true,false" doc:"Filter by Published (exact match)"`,
 		`query:"author_id" doc:"Filter by AuthorID (exact match)"`,
 		`database.FilterEq(ctx, q, "views", database.FilterInt, input.Views)`,
 		`database.FilterEq(ctx, q, "published", database.FilterBool, input.Published)`,
 		`database.FilterEq(ctx, q, "author_id", database.FilterUint, input.AuthorID)`,
-		`database.Search(q, []string{"title", "body"}, input.Q)`,
-		`database.SortBy(ctx, q, input.Sort, input.Order, []string{"title", "views"}, "id")`,
+		`database.Search(q, []string{"title", "body"}, input.Search)`,
+		`database.Ordering(ctx, q, input.Ordering, []string{"title", "views"}, "id")`,
 	}
 	for _, want := range wantContains {
 		if !strings.Contains(src, want) {
@@ -127,7 +126,7 @@ func TestRenderHandlerNoListQuery(t *testing.T) {
 	if !strings.Contains(src, `q.Order("id").Offset(`) {
 		t.Fatalf("handler without sort must keep fixed Order(\"id\"):\n%s", src)
 	}
-	for _, unwanted := range []string{`query:"q"`, `query:"sort"`, `database.SortBy`, `database.Search`, `database.FilterEq`} {
+	for _, unwanted := range []string{`query:"search"`, `query:"ordering"`, `database.Ordering`, `database.Search`, `database.FilterEq`} {
 		if strings.Contains(src, unwanted) {
 			t.Fatalf("handler without modifiers must not contain %q:\n%s", unwanted, src)
 		}

--- a/resourcegen/names.go
+++ b/resourcegen/names.go
@@ -27,6 +27,16 @@ var reservedFields = map[string]struct{}{
 	"id": {}, "created_at": {}, "updated_at": {}, "deleted_at": {},
 }
 
+// reservedQueryFields are the query keys the generated list handler owns for its
+// declared list-query surface (#260): pagination plus the admin-aligned search /
+// ordering params. A resource field claiming one of these would be emitted as a
+// second list-input struct field with a duplicate `query` tag (e.g. a
+// filterable `page`), so the name is rejected at parse time — the same upfront
+// treatment reservedFields gives gorm.Model columns.
+var reservedQueryFields = map[string]struct{}{
+	"page": {}, "per_page": {}, "search": {}, "ordering": {},
+}
+
 // ResourceName is the derived identifiers for one generated feature-package.
 type ResourceName struct {
 	Input       string


### PR DESCRIPTION
## Summary

Adds opt-in, **declared** list-query support to the generated resource list handler — the shared contract the Forge page builder consumes for table search/filter/sort (gombit-dev/gombit-forge#51) and detail-page related-record lists (gombit-dev/gombit-forge#53).

Field-grammar modifiers opt specific fields into a safe, indexable query surface:

- **filter** — `?<field>=<value>` (exact match): `string, int, int64, uint, bool, enum`
- **sort** — `?ordering=<field>` (`-<field>` for DESC): any scalar + belongs_to FK
- **search** — `?search=<term>` (case-insensitive LIKE): `string, text, enum`

A `belongs_to` foreign key is **filterable by default**, so a detail page lists a record's `has_many` children with `GET /api/v1/invoices?customer_id=<id>` and no extra declaration. Filters + search apply before the `COUNT`, so `meta.total` reflects the filtered set; `?ordering=` replaces the fixed `id` order (`id` stays the default when absent) and is validated against the declared sortable set.

The query spelling **matches Gombit's shipped admin data plane** so the framework speaks one dialect. The shared spelling/SQL now lives in one place (`database.Search`, `database.Ordering`/`ParseOrdering`, `database.FilterEq`); `admin.applySearch`/`applyOrdering` were refactored to delegate to it (duplicate `escapeLike`/`quoteIdent` removed) — the admin wire contract and SPA are unchanged.

Closes #260

## Acceptance criteria

- [x] **Filter** by a declared set of filterable fields and belongs_to FKs (`?<field>=<value>`, exact match)
- [x] **Sort** by a declared set of sortable fields (`?ordering=<field>`, `-` prefix for DESC), replacing the fixed `Order("id")`
- [x] **Search** across a declared set of searchable text fields (`?search=<term>`)
- [x] "Declared" = per-field opt-in (grammar modifiers), mirroring the declared-subset approach
- [x] One contract Forge can drive both #51 (table) and #53 (related records) from — aligned with the admin data-plane spelling

## Scope notes

- Filters are exact-match only; ranges/operators are explicitly deferred (noted in docs).
- Admin's filter *plumbing* still uses its registry-driven `coerceFilter` while the generated handler coerces string query params by declared kind — same spelling/semantics, different internals. Fully unifying that path is a reasonable follow-up; this PR unifies search + ordering.
- Generated frontend list pages are unchanged (server-side contract only; Forge is the consumer).

## Validation

- [x] `go test ./...` — green
- [x] `golangci-lint run` (v2.12.2) — 0 issues
- [ ] Project `code-review` skill run against this diff
- DB helpers covered on SQLite plus PostgreSQL/MySQL integration entries (`TestListQueryHelpers{SQLite,Postgres,MySQL}`); a Huma runtime contract test proves the generated input shape registers and behaves; resourcegen unit tests cover modifier parsing/validation and handler output (incl. a guard that a resource with no modifiers is byte-unchanged); a goldentest end-to-end fixture compiles a resource using all modifiers + a belongs_to.

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (SQLite in unit tests; PG/MySQL via `-tags integration` DSN flags)
- [x] Stable features ship docs and appear in an example app (docs/contract.md, tutorial; goldentest compile fixture as the executable example)
- [x] Extraction preserves contracts — admin refactor is move-and-delegate; admin tests unchanged and passing
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files (no-modifier output is byte-identical; guarded by a regression test)
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A: no framework endpoint changes; this affects *generated apps*, whose OpenAPI/TS is produced by `gombit client generate` at app build time
- [x] No secrets in generated frontend source; `VITE_*` is treated as public — N/A (no frontend change)
- [x] Scope stays inside the issue's milestone — no M6 battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies

🤖 Generated with [Claude Code](https://claude.com/claude-code)