### PR TITLE
[feature] Declared server-side numeric aggregates for list resources (#272)

### DIFF
--- a/cli/make.go
+++ b/cli/make.go
@@ -76,8 +76,10 @@ aggregates:
   aggregatable       server-side ?aggregate=<func>:<field> (func: sum, avg,
                      min, max), computed over the filtered set before
                      pagination and returned in meta.aggregates. Types: int,
-                     int64, uint, decimal. Exact on Postgres/MySQL; SQLite
-                     computes AVG and fractional decimal SUM in float.
+                     int64, uint, decimal. Integer aggregates and decimal sum
+                     are exact on Postgres/MySQL; SQLite computes avg and
+                     fractional decimal sum in float. avg is an approximation
+                     on any driver.
 
 Relations use name:kind:Target, where Target is a model in internal/<target>/:
 

--- a/cli/make.go
+++ b/cli/make.go
@@ -46,7 +46,7 @@ regex), next to product.Register(app). AutoMigrate is updated the same way.
 
 Field grammar (design §27 subset):
 
-  name:type[:required][,unique][,index][,filterable][,sortable][,searchable]
+  name:type[:required][,unique][,index][,filterable][,sortable][,searchable][,aggregatable]
 
 Supported types: string, text, int, int64, bool, uint, decimal, time, enum,
 belongs_to, has_many, many_to_many.
@@ -69,6 +69,10 @@ admin data plane so the two contracts stay in sync:
                      stays the default when ?ordering= is absent.
   searchable         case-insensitive ?search=<term> LIKE across searchable
                      text fields. Types: string, text, enum.
+  aggregatable       server-side ?aggregate=<func>:<field> (func: sum, avg,
+                     min, max), computed over the filtered set before
+                     pagination and returned in meta.aggregates. Types: int,
+                     int64, uint, decimal.
 
 Relations use name:kind:Target, where Target is a model in internal/<target>/:
 
@@ -90,6 +94,8 @@ Examples:
   gombit make resource Widget name:string:required price:int
   gombit make resource Article title:string:required,searchable,sortable \
     status:enum(draft,published):filterable author:belongs_to:Author
+  gombit make resource Invoice total:decimal:required,aggregatable \
+    quantity:int:aggregatable,filterable customer:belongs_to:Customer
   gombit make resource Rental price:decimal:required starts_at:time \
     status:enum(requested,confirmed,active,returned,cancelled) \
     engine:belongs_to:Engine warehouses:many_to_many:Warehouse

--- a/cli/make.go
+++ b/cli/make.go
@@ -69,10 +69,15 @@ admin data plane so the two contracts stay in sync:
                      stays the default when ?ordering= is absent.
   searchable         case-insensitive ?search=<term> LIKE across searchable
                      text fields. Types: string, text, enum.
+
+The generated list handler (not the admin data plane) also supports numeric
+aggregates:
+
   aggregatable       server-side ?aggregate=<func>:<field> (func: sum, avg,
                      min, max), computed over the filtered set before
                      pagination and returned in meta.aggregates. Types: int,
-                     int64, uint, decimal.
+                     int64, uint, decimal. Exact on Postgres/MySQL; SQLite
+                     computes AVG and fractional decimal SUM in float.
 
 Relations use name:kind:Target, where Target is a model in internal/<target>/:
 

--- a/contract/envelope.go
+++ b/contract/envelope.go
@@ -1,5 +1,7 @@
 package contract
 
+import "github.com/gombit-dev/gombit/types"
+
 // Data is the D10 success envelope without meta: {"data": ...}.
 type Data[T any] struct {
 	Data T `json:"data"`
@@ -30,6 +32,23 @@ type PageMeta struct {
 	Page    int   `json:"page"`
 	PerPage int   `json:"per_page"`
 	Total   int64 `json:"total"`
+}
+
+// ListMeta is PageMeta plus optional server-side aggregates. It is the meta
+// type for list endpoints whose resource declares aggregatable fields (issue
+// #272): a request may ask for SUM/AVG/MIN/MAX over declared numeric columns
+// via ?aggregate=sum:total,avg:total, computed over the same filtered/searched
+// set as the list, before pagination.
+//
+// Aggregates is keyed "<func>:<field>" (e.g. "sum:total") with types.Decimal
+// values — exact JSON strings, so money totals never round through float. When
+// no ?aggregate= is requested the map is nil and omitempty drops it, so the
+// response is byte-identical to a PageMeta envelope.
+type ListMeta struct {
+	Page       int                      `json:"page"`
+	PerPage    int                      `json:"per_page"`
+	Total      int64                    `json:"total"`
+	Aggregates map[string]types.Decimal `json:"aggregates,omitempty" doc:"Server-side aggregates keyed \"<func>:<field>\", present when ?aggregate= is requested"`
 }
 
 const (

--- a/contract/envelope.go
+++ b/contract/envelope.go
@@ -41,8 +41,11 @@ type PageMeta struct {
 // set as the list, before pagination.
 //
 // Aggregates is keyed "<func>:<field>" (e.g. "sum:total") with types.Decimal
-// values — exact JSON strings, so money totals never round through float. When
-// no ?aggregate= is requested the map is nil and omitempty drops it, so the
+// values — canonical decimal strings. Precision follows the driver: exact for a
+// decimal SUM and all integer aggregates on Postgres/MySQL (and integer SUM/MIN/
+// MAX on SQLite); SQLite computes AVG and fractional decimal SUM in float, so
+// those may round. See the database package's Aggregate and docs/contract.md.
+// When no ?aggregate= is requested the map is nil and omitempty drops it, so the
 // response is byte-identical to a PageMeta envelope.
 type ListMeta struct {
 	Page       int                      `json:"page"`

--- a/database/aggregate.go
+++ b/database/aggregate.go
@@ -117,10 +117,17 @@ func ParseAggregates(ctx context.Context, raw string, allowed map[string]Aggrega
 // ("<func>:<field>"). All aggregates are evaluated in a single SELECT with no
 // GROUP BY, so the query returns exactly one row and runs before pagination.
 //
-// Values come back as types.Decimal (exact, JSON-string) regardless of driver
-// or column type, so money totals never round through float. A NULL result — an
-// aggregate over an empty matching set (SUM/AVG/MIN/MAX all yield NULL) —
-// becomes decimal zero, so a card renders 0 rather than null.
+// Values are the database's own aggregate, encoded as a types.Decimal (a
+// canonical JSON string). Precision therefore follows the driver: Postgres and
+// MySQL compute SUM/AVG/MIN/MAX over numeric/decimal in fixed point, so a
+// decimal SUM (and integer aggregates on every driver) is exact; SQLite has no
+// native fixed-point aggregate and computes AVG — and SUM of a fractional
+// decimal column — in IEEE double, so those may carry float rounding and can
+// differ from Postgres/MySQL for the same data. AVG is fractional by nature
+// (rounded to each driver's default scale) and is an approximation everywhere.
+// See docs/contract.md "List query: numeric aggregates" for the per-driver
+// contract. A NULL result — an aggregate over an empty matching set (SUM/AVG/
+// MIN/MAX all yield NULL) — becomes decimal zero, so a card renders 0 not null.
 //
 // An empty specs list is a no-op (nil map, no query). Column names in specs are
 // generator-controlled; nothing here is derived from user input.
@@ -158,11 +165,14 @@ func Aggregate(ctx context.Context, q *gorm.DB, specs []AggregateSpec) (map[stri
 }
 
 // toDecimal normalizes a driver-scanned aggregate value into a types.Decimal.
-// Drivers return aggregate results with different Go types: SQLite yields int64
-// or float64, Postgres yields int64 for SUM(int) and []byte/string for numeric
-// AVG, MySQL yields []byte for its decimal results. A NULL result (nil) becomes
-// decimal zero. AVG is inherently fractional, so a float64 is converted through
-// its shortest exact decimal representation.
+// Drivers return aggregate results with different Go types: Postgres yields int64
+// for SUM(int) and a numeric string/[]byte for fixed-point AVG/decimal SUM,
+// MySQL yields []byte for its decimal results — both exact. SQLite yields int64
+// for integer aggregates but float64 for AVG and for SUM of a fractional decimal
+// column, because it has no fixed-point aggregate; that float64 is encoded via
+// its shortest round-tripping decimal string, so the value is faithful to what
+// SQLite computed (float rounding included) rather than silently reshaped. A
+// NULL result (nil) becomes decimal zero.
 func toDecimal(v any) (types.Decimal, error) {
 	switch val := v.(type) {
 	case nil:

--- a/database/aggregate.go
+++ b/database/aggregate.go
@@ -1,0 +1,185 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gombit-dev/gombit/contract"
+	"github.com/gombit-dev/gombit/types"
+	"gorm.io/gorm"
+)
+
+// This file holds the reusable server-side aggregate primitives (SUM / AVG /
+// MIN / MAX over a declared numeric column) that the generated resource list
+// handler calls. Like the list-query helpers in listquery.go, the generator
+// only emits calls for fields a resource declares aggregatable, so the surface
+// stays a safe, declared subset. Aggregates run over the same filtered/searched
+// query the list uses, computed before pagination — so a "total invoiced this
+// month" card reflects the whole matching set, not one page (issue #272).
+
+// AggregateFunc is a supported SQL aggregate function.
+type AggregateFunc string
+
+const (
+	AggSum AggregateFunc = "sum"
+	AggAvg AggregateFunc = "avg"
+	AggMin AggregateFunc = "min"
+	AggMax AggregateFunc = "max"
+)
+
+// aggregateSQL maps a validated func to its SQL keyword. Only these four are
+// reachable — ParseAggregates rejects anything else before it becomes a spec —
+// so the keyword is never derived from user input.
+var aggregateSQL = map[AggregateFunc]string{
+	AggSum: "SUM",
+	AggAvg: "AVG",
+	AggMin: "MIN",
+	AggMax: "MAX",
+}
+
+// AggregateColumn declares one field a resource exposes to aggregates: the DB
+// column the SQL function is applied to. It is generator-controlled — built
+// from a field declared `aggregatable` — so only a declared numeric column can
+// reach the query.
+type AggregateColumn struct {
+	Column string
+}
+
+// AggregateSpec is one resolved aggregate request: Func over Column, returned in
+// the response keyed as "<func>:<field>" (Key).
+type AggregateSpec struct {
+	Func   AggregateFunc
+	Column string
+	Key    string
+}
+
+// ParseAggregates turns the raw `aggregate` query param — a comma-separated list
+// of "<func>:<field>" pairs, e.g. "sum:total,avg:total" — into resolved specs.
+//
+//   - An empty (or whitespace-only) raw value returns nil (no aggregates asked
+//     for), so a plain list request is unchanged.
+//   - func is matched case-insensitively against sum / avg / min / max.
+//   - field must be a key in allowed (a declared aggregatable field); the value
+//     supplies the DB column. allowed is generator-controlled; only raw is user
+//     input, so an undeclared field cannot reach the query.
+//   - A malformed pair, unknown func, or undeclared field returns a D10
+//     validation error (422) keyed on "aggregate".
+//   - Duplicate pairs collapse to one spec (same key), so the response map has
+//     one entry per requested aggregate.
+func ParseAggregates(ctx context.Context, raw string, allowed map[string]AggregateColumn) ([]AggregateSpec, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	invalid := func() error {
+		return contract.WithContext(ctx, contract.Validation(
+			"The request contains invalid fields.",
+			map[string][]string{"aggregate": {"must be a comma-separated list of <func>:<field>, e.g. sum:total,avg:total"}},
+		))
+	}
+	specs := make([]AggregateSpec, 0)
+	seen := make(map[string]struct{})
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		fnRaw, field, ok := strings.Cut(part, ":")
+		if !ok {
+			return nil, invalid()
+		}
+		fn := AggregateFunc(strings.ToLower(strings.TrimSpace(fnRaw)))
+		if _, ok := aggregateSQL[fn]; !ok {
+			return nil, invalid()
+		}
+		field = strings.TrimSpace(field)
+		col, ok := allowed[field]
+		if !ok {
+			return nil, invalid()
+		}
+		key := string(fn) + ":" + field
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		specs = append(specs, AggregateSpec{Func: fn, Column: col.Column, Key: key})
+	}
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	return specs, nil
+}
+
+// Aggregate computes the requested aggregates over q — which already carries the
+// list's filters and search — and returns a map keyed by each spec's Key
+// ("<func>:<field>"). All aggregates are evaluated in a single SELECT with no
+// GROUP BY, so the query returns exactly one row and runs before pagination.
+//
+// Values come back as types.Decimal (exact, JSON-string) regardless of driver
+// or column type, so money totals never round through float. A NULL result — an
+// aggregate over an empty matching set (SUM/AVG/MIN/MAX all yield NULL) —
+// becomes decimal zero, so a card renders 0 rather than null.
+//
+// An empty specs list is a no-op (nil map, no query). Column names in specs are
+// generator-controlled; nothing here is derived from user input.
+func Aggregate(ctx context.Context, q *gorm.DB, specs []AggregateSpec) (map[string]types.Decimal, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	selects := make([]string, len(specs))
+	aliasKey := make(map[string]string, len(specs))
+	for i, s := range specs {
+		alias := fmt.Sprintf("agg%d", i)
+		selects[i] = aggregateSQL[s.Func] + "(" + quoteIdent(q, s.Column) + ") AS " + alias
+		aliasKey[alias] = s.Key
+	}
+	// A no-GROUP-BY aggregate SELECT returns exactly one row. Find into a slice
+	// of maps (not Scan into a single map, which returns *interface{} pointers
+	// per column rather than the scanned values) yields driver-typed scalars.
+	var scanned []map[string]any
+	if err := q.WithContext(ctx).Select(strings.Join(selects, ", ")).Find(&scanned).Error; err != nil {
+		return nil, contract.WithContext(ctx, contract.Internal("aggregate resources"))
+	}
+	var row map[string]any
+	if len(scanned) > 0 {
+		row = scanned[0]
+	}
+	out := make(map[string]types.Decimal, len(specs))
+	for alias, key := range aliasKey {
+		dec, err := toDecimal(row[alias])
+		if err != nil {
+			return nil, contract.WithContext(ctx, contract.Internal("aggregate resources"))
+		}
+		out[key] = dec
+	}
+	return out, nil
+}
+
+// toDecimal normalizes a driver-scanned aggregate value into a types.Decimal.
+// Drivers return aggregate results with different Go types: SQLite yields int64
+// or float64, Postgres yields int64 for SUM(int) and []byte/string for numeric
+// AVG, MySQL yields []byte for its decimal results. A NULL result (nil) becomes
+// decimal zero. AVG is inherently fractional, so a float64 is converted through
+// its shortest exact decimal representation.
+func toDecimal(v any) (types.Decimal, error) {
+	switch val := v.(type) {
+	case nil:
+		return types.Decimal{}, nil
+	case []byte:
+		return types.NewDecimalFromString(strings.TrimSpace(string(val)))
+	case string:
+		return types.NewDecimalFromString(strings.TrimSpace(val))
+	case int64:
+		return types.NewDecimalFromString(strconv.FormatInt(val, 10))
+	case int32:
+		return types.NewDecimalFromString(strconv.FormatInt(int64(val), 10))
+	case float64:
+		return types.NewDecimalFromString(strconv.FormatFloat(val, 'f', -1, 64))
+	case float32:
+		return types.NewDecimalFromString(strconv.FormatFloat(float64(val), 'f', -1, 32))
+	default:
+		return types.NewDecimalFromString(fmt.Sprintf("%v", val))
+	}
+}

--- a/database/aggregate_test.go
+++ b/database/aggregate_test.go
@@ -1,0 +1,279 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/gombit-dev/gombit/contract"
+	"github.com/gombit-dev/gombit/types"
+	"gorm.io/gorm"
+)
+
+type aggItem struct {
+	ID       uint `gorm:"primaryKey"`
+	AuthorID uint
+	Amount   int
+}
+
+// TestAggregateHelpersSQLite exercises ParseAggregates / Aggregate on SQLite.
+// The same assertions run against Postgres and MySQL from the integration suite
+// (TestAggregateHelpers{Postgres,MySQL}), so the SQLite+PG+MySQL matrix the
+// working agreement requires is covered.
+func TestAggregateHelpersSQLite(t *testing.T) {
+	assertAggregateHelpers(t, openSQLite(t))
+}
+
+func assertAggregateHelpers(t *testing.T, db *DB) {
+	t.Helper()
+	seedAggregate(t, db)
+	ctx := context.Background()
+	allowed := map[string]AggregateColumn{"amount": {Column: "amount"}}
+
+	t.Run("EmptyRawIsNoOp", func(t *testing.T) {
+		specs, err := ParseAggregates(ctx, "  ", allowed)
+		if err != nil {
+			t.Fatalf("ParseAggregates empty: %v", err)
+		}
+		if specs != nil {
+			t.Fatalf("specs = %v, want nil for empty raw", specs)
+		}
+		out, err := Aggregate(ctx, db.Model(&aggItem{}), specs)
+		if err != nil {
+			t.Fatalf("Aggregate(nil specs): %v", err)
+		}
+		if out != nil {
+			t.Fatalf("Aggregate(nil) = %v, want nil", out)
+		}
+	})
+
+	t.Run("SumAvgMinMaxOverWholeSet", func(t *testing.T) {
+		specs, err := ParseAggregates(ctx, "sum:amount,avg:amount,min:amount,max:amount", allowed)
+		if err != nil {
+			t.Fatalf("ParseAggregates: %v", err)
+		}
+		out, err := Aggregate(ctx, db.Model(&aggItem{}), specs)
+		if err != nil {
+			t.Fatalf("Aggregate: %v", err)
+		}
+		// Rows: 10, 20, 30, 40 -> sum 100, avg 25, min 10, max 40.
+		wantString(t, out, "sum:amount", "100")
+		wantString(t, out, "avg:amount", "25")
+		wantString(t, out, "min:amount", "10")
+		wantString(t, out, "max:amount", "40")
+	})
+
+	t.Run("RespectsFilteredQuery", func(t *testing.T) {
+		specs, err := ParseAggregates(ctx, "sum:amount", allowed)
+		if err != nil {
+			t.Fatalf("ParseAggregates: %v", err)
+		}
+		// author_id=1 -> rows 10 + 20 = 30, not the whole-table 100.
+		q := db.Model(&aggItem{}).Where("author_id = ?", 1)
+		out, err := Aggregate(ctx, q, specs)
+		if err != nil {
+			t.Fatalf("Aggregate: %v", err)
+		}
+		wantString(t, out, "sum:amount", "30")
+	})
+
+	t.Run("EmptySetIsZero", func(t *testing.T) {
+		specs, err := ParseAggregates(ctx, "sum:amount,max:amount", allowed)
+		if err != nil {
+			t.Fatalf("ParseAggregates: %v", err)
+		}
+		// A filter that matches nothing: SQL SUM/MAX return NULL, normalized to 0.
+		q := db.Model(&aggItem{}).Where("author_id = ?", 999)
+		out, err := Aggregate(ctx, q, specs)
+		if err != nil {
+			t.Fatalf("Aggregate: %v", err)
+		}
+		wantString(t, out, "sum:amount", "0")
+		wantString(t, out, "max:amount", "0")
+	})
+
+	t.Run("RejectsUnknownFuncOrField", func(t *testing.T) {
+		if _, err := ParseAggregates(ctx, "median:amount", allowed); err == nil {
+			t.Fatal("median: want validation error")
+		} else {
+			assertValidationField(t, err, "aggregate")
+		}
+		if _, err := ParseAggregates(ctx, "sum:secret", allowed); err == nil {
+			t.Fatal("undeclared field: want validation error")
+		} else {
+			assertValidationField(t, err, "aggregate")
+		}
+		if _, err := ParseAggregates(ctx, "notapair", allowed); err == nil {
+			t.Fatal("malformed pair: want validation error")
+		} else {
+			assertValidationField(t, err, "aggregate")
+		}
+	})
+
+	t.Run("DedupesRepeatedPairs", func(t *testing.T) {
+		specs, err := ParseAggregates(ctx, "sum:amount,sum:amount", allowed)
+		if err != nil {
+			t.Fatalf("ParseAggregates: %v", err)
+		}
+		if len(specs) != 1 {
+			t.Fatalf("len(specs) = %d, want 1 (deduped)", len(specs))
+		}
+	})
+}
+
+func wantString(t *testing.T, out map[string]types.Decimal, key, want string) {
+	t.Helper()
+	v, ok := out[key]
+	if !ok {
+		t.Fatalf("aggregate %q missing from %v", key, out)
+	}
+	if got := v.String(); got != want {
+		t.Fatalf("aggregate %q = %q, want %q", key, got, want)
+	}
+}
+
+func seedAggregate(t *testing.T, db *DB) {
+	t.Helper()
+	if err := db.AutoMigrate(&aggItem{}); err != nil {
+		t.Fatalf("AutoMigrate() error = %v", err)
+	}
+	if err := db.Where("1 = 1").Delete(&aggItem{}).Error; err != nil {
+		t.Fatalf("reset table: %v", err)
+	}
+	rows := []aggItem{
+		{AuthorID: 1, Amount: 10},
+		{AuthorID: 1, Amount: 20},
+		{AuthorID: 2, Amount: 30},
+		{AuthorID: 2, Amount: 40},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+// --- Runtime contract test -------------------------------------------------
+// TestGeneratedAggregateContractRuntime mirrors the exact list input, ListMeta
+// meta type, and aggregate wiring the resource generator emits for a resource
+// declaring aggregatable fields, and drives it through Huma end to end. It
+// proves the generated shape registers with Huma and that aggregates respect
+// the list's filters and land in meta.aggregates as exact strings.
+
+type acItem struct {
+	ID       uint `gorm:"primaryKey"`
+	AuthorID uint
+	Amount   int
+}
+
+type acListInput struct {
+	Page      int    `query:"page" doc:"1-based page"`
+	PerPage   int    `query:"per_page" doc:"Page size"`
+	Aggregate string `query:"aggregate" doc:"Aggregates"`
+	AuthorID  string `query:"author_id" doc:"Filter by AuthorID"`
+}
+
+type acListOutput struct {
+	Body contract.DataMeta[[]acItem, contract.ListMeta]
+}
+
+func TestGeneratedAggregateContractRuntime(t *testing.T) {
+	db := openSQLite(t)
+	if err := db.AutoMigrate(&acItem{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := db.Where("1 = 1").Delete(&acItem{}).Error; err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	rows := []acItem{
+		{AuthorID: 1, Amount: 10},
+		{AuthorID: 1, Amount: 20},
+		{AuthorID: 2, Amount: 30},
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	list := func(ctx context.Context, in *acListInput) (*acListOutput, error) {
+		page, perPage := contract.ClampPage(in.Page, in.PerPage)
+		q := db.WithContext(ctx).Model(&acItem{})
+		q, err := FilterEq(ctx, q, "author_id", FilterUint, in.AuthorID)
+		if err != nil {
+			return nil, err
+		}
+		var total int64
+		if err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {
+			return nil, contract.WithContext(ctx, contract.Internal("count"))
+		}
+		aggs, err := ParseAggregates(ctx, in.Aggregate, map[string]AggregateColumn{"amount": {Column: "amount"}})
+		if err != nil {
+			return nil, err
+		}
+		aggregates, err := Aggregate(ctx, q.Session(&gorm.Session{}), aggs)
+		if err != nil {
+			return nil, err
+		}
+		var out []acItem
+		if err := q.Order("id").Offset(contract.PageOffset(page, perPage)).Limit(perPage).Find(&out).Error; err != nil {
+			return nil, contract.WithContext(ctx, contract.Internal("list"))
+		}
+		return &acListOutput{Body: contract.DataMeta[[]acItem, contract.ListMeta]{
+			Data: out,
+			Meta: &contract.ListMeta{Page: page, PerPage: perPage, Total: total, Aggregates: aggregates},
+		}}, nil
+	}
+
+	_, api := humatest.New(t)
+	huma.Register(api, huma.Operation{OperationID: "list-ac", Method: http.MethodGet, Path: "/items"}, list)
+
+	// No ?aggregate= -> aggregates omitted from meta.
+	if got := decodeAgg(t, api.Get("/items")); got.Meta["aggregates"] != nil {
+		t.Fatalf("no aggregate requested but meta.aggregates=%v", got.Meta["aggregates"])
+	}
+	// Whole set: sum=60, avg=20.
+	got := decodeAgg(t, api.Get("/items?aggregate=sum:amount,avg:amount"))
+	if got.agg(t, "sum:amount") != "60" || got.agg(t, "avg:amount") != "20" {
+		t.Fatalf("whole-set aggregates = %v", got.Meta["aggregates"])
+	}
+	// Aggregates respect the filter: author_id=1 -> sum=30.
+	got = decodeAgg(t, api.Get("/items?author_id=1&aggregate=sum:amount"))
+	if got.agg(t, "sum:amount") != "30" {
+		t.Fatalf("filtered sum = %q, want 30", got.agg(t, "sum:amount"))
+	}
+	// Bad aggregate spec -> 422.
+	if resp := api.Get("/items?aggregate=median:amount"); resp.Code != 422 {
+		t.Fatalf("median code = %d, want 422; body=%s", resp.Code, resp.Body.String())
+	}
+}
+
+type aggDecoded struct {
+	Data []acItem       `json:"data"`
+	Meta map[string]any `json:"meta"`
+}
+
+func (d aggDecoded) agg(t *testing.T, key string) string {
+	t.Helper()
+	m, ok := d.Meta["aggregates"].(map[string]any)
+	if !ok {
+		t.Fatalf("meta.aggregates missing or wrong type: %v", d.Meta["aggregates"])
+	}
+	s, ok := m[key].(string)
+	if !ok {
+		t.Fatalf("aggregate %q missing or not a string: %v", key, m)
+	}
+	return s
+}
+
+func decodeAgg(t *testing.T, resp *httptest.ResponseRecorder) aggDecoded {
+	t.Helper()
+	if resp.Code != 200 {
+		t.Fatalf("code = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	var out aggDecoded
+	if err := json.Unmarshal(resp.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode %s: %v", resp.Body.String(), err)
+	}
+	return out
+}

--- a/database/aggregate_test.go
+++ b/database/aggregate_test.go
@@ -134,11 +134,16 @@ func assertAggregateHelpers(t *testing.T, db *DB) {
 
 	// DecimalPrecision pins the per-driver contract the docs promise (rather than
 	// only the evenly-dividing integer cases above): a fractional decimal SUM and
-	// a non-integer AVG. Postgres/MySQL compute these in fixed point (exact);
-	// SQLite computes them in IEEE float, so the returned string differs slightly
-	// between drivers — the assertion compares the decimal value within a
-	// tolerance rather than a fixed string, which is exactly the contract
-	// (exact on PG/MySQL, float-approximate on SQLite, AVG approximate anywhere).
+	// a non-integer AVG over a decimal(19,4) column.
+	//
+	//   - decimal SUM is exact on Postgres/MySQL (fixed point), so those drivers
+	//     assert the exact string "30.31"; SQLite computes it in float, so it
+	//     asserts the value within tolerance. Asserting the string on SQLite, or
+	//     only asserting the value on PG/MySQL, would not lock "exact on PG/MySQL"
+	//     — a PG path that scanned SUM through float would still pass a value
+	//     check.
+	//   - AVG is fractional and rounded to each driver's numeric scale, so it is
+	//     an approximation on every driver: value within tolerance, everywhere.
 	t.Run("DecimalPrecision", func(t *testing.T) {
 		seedAggregateMoney(t, db)
 		moneyAllowed := map[string]AggregateColumn{"amount": {Column: "amount"}}
@@ -151,7 +156,12 @@ func assertAggregateHelpers(t *testing.T, db *DB) {
 			t.Fatalf("Aggregate: %v", err)
 		}
 		// 10.10 + 20.20 + 0.01 = 30.31; avg = 10.1033...
-		wantApprox(t, out, "sum:amount", 30.31, 1e-6)
+		switch db.Driver() {
+		case DriverPostgres, DriverMySQL:
+			wantString(t, out, "sum:amount", "30.31") // exact fixed-point SUM
+		default: // SQLite: float-approximate
+			wantApprox(t, out, "sum:amount", 30.31, 1e-6)
+		}
 		wantApprox(t, out, "avg:amount", 30.31/3, 1e-3)
 	})
 }

--- a/database/aggregate_test.go
+++ b/database/aggregate_test.go
@@ -20,6 +20,14 @@ type aggItem struct {
 	Amount   int
 }
 
+// aggMoney carries a fixed-point decimal column so the precision contract can be
+// exercised: a fractional decimal SUM and a non-integer AVG, the two cases the
+// integer-only aggItem cannot reach.
+type aggMoney struct {
+	ID     uint          `gorm:"primaryKey"`
+	Amount types.Decimal `gorm:"type:decimal(19,4)"`
+}
+
 // TestAggregateHelpersSQLite exercises ParseAggregates / Aggregate on SQLite.
 // The same assertions run against Postgres and MySQL from the integration suite
 // (TestAggregateHelpers{Postgres,MySQL}), so the SQLite+PG+MySQL matrix the
@@ -123,6 +131,67 @@ func assertAggregateHelpers(t *testing.T, db *DB) {
 			t.Fatalf("len(specs) = %d, want 1 (deduped)", len(specs))
 		}
 	})
+
+	// DecimalPrecision pins the per-driver contract the docs promise (rather than
+	// only the evenly-dividing integer cases above): a fractional decimal SUM and
+	// a non-integer AVG. Postgres/MySQL compute these in fixed point (exact);
+	// SQLite computes them in IEEE float, so the returned string differs slightly
+	// between drivers — the assertion compares the decimal value within a
+	// tolerance rather than a fixed string, which is exactly the contract
+	// (exact on PG/MySQL, float-approximate on SQLite, AVG approximate anywhere).
+	t.Run("DecimalPrecision", func(t *testing.T) {
+		seedAggregateMoney(t, db)
+		moneyAllowed := map[string]AggregateColumn{"amount": {Column: "amount"}}
+		specs, err := ParseAggregates(ctx, "sum:amount,avg:amount", moneyAllowed)
+		if err != nil {
+			t.Fatalf("ParseAggregates: %v", err)
+		}
+		out, err := Aggregate(ctx, db.Model(&aggMoney{}), specs)
+		if err != nil {
+			t.Fatalf("Aggregate: %v", err)
+		}
+		// 10.10 + 20.20 + 0.01 = 30.31; avg = 10.1033...
+		wantApprox(t, out, "sum:amount", 30.31, 1e-6)
+		wantApprox(t, out, "avg:amount", 30.31/3, 1e-3)
+	})
+}
+
+// wantApprox parses an aggregate's decimal string and asserts it is within eps of
+// want. Aggregate values are exact on Postgres/MySQL but float-approximate on
+// SQLite (and AVG is approximate everywhere), so the string is not identical
+// across drivers; the numeric value is.
+func wantApprox(t *testing.T, out map[string]types.Decimal, key string, want, eps float64) {
+	t.Helper()
+	v, ok := out[key]
+	if !ok {
+		t.Fatalf("aggregate %q missing from %v", key, out)
+	}
+	got, _ := v.Float64()
+	if diff := got - want; diff < -eps || diff > eps {
+		t.Fatalf("aggregate %q = %s (%.10f), want ~%.10f (±%g)", key, v.String(), got, want, eps)
+	}
+}
+
+func seedAggregateMoney(t *testing.T, db *DB) {
+	t.Helper()
+	if err := db.AutoMigrate(&aggMoney{}); err != nil {
+		t.Fatalf("AutoMigrate(aggMoney) error = %v", err)
+	}
+	if err := db.Where("1 = 1").Delete(&aggMoney{}).Error; err != nil {
+		t.Fatalf("reset money table: %v", err)
+	}
+	amounts := []string{"10.10", "20.20", "0.01"}
+	rows := make([]aggMoney, len(amounts))
+	for i, s := range amounts {
+		d, err := types.NewDecimalFromString(s)
+		if err != nil {
+			t.Fatalf("decimal %q: %v", s, err)
+		}
+		rows[i] = aggMoney{Amount: d}
+	}
+	if err := db.Create(&rows).Error; err != nil {
+		t.Fatalf("seed money: %v", err)
+	}
 }
 
 func wantString(t *testing.T, out map[string]types.Decimal, key, want string) {
@@ -241,6 +310,12 @@ func TestGeneratedAggregateContractRuntime(t *testing.T) {
 	got = decodeAgg(t, api.Get("/items?author_id=1&aggregate=sum:amount"))
 	if got.agg(t, "sum:amount") != "30" {
 		t.Fatalf("filtered sum = %q, want 30", got.agg(t, "sum:amount"))
+	}
+	// Pagination must not shrink the aggregate: one row per page, but sum:amount is
+	// still computed over all three matching rows (60), not the single page row.
+	got = decodeAgg(t, api.Get("/items?page=1&per_page=1&aggregate=sum:amount"))
+	if got.agg(t, "sum:amount") != "60" || len(got.Data) != 1 {
+		t.Fatalf("paginated aggregate = %v, data len = %d; want sum 60 over 1 page row", got.Meta["aggregates"], len(got.Data))
 	}
 	// Bad aggregate spec -> 422.
 	if resp := api.Get("/items?aggregate=median:amount"); resp.Code != 422 {

--- a/database/integration_test.go
+++ b/database/integration_test.go
@@ -81,6 +81,26 @@ func TestListQueryHelpersMySQL(t *testing.T) {
 	}))
 }
 
+func TestAggregateHelpersPostgres(t *testing.T) {
+	if *postgresDSN == "" {
+		t.Skip("set -database.postgres-dsn to run Postgres integration tests")
+	}
+	assertAggregateHelpers(t, openIntegrationDB(t, config.DatabaseConfig{
+		Driver: config.DatabaseDriverPostgres,
+		DSN:    *postgresDSN,
+	}))
+}
+
+func TestAggregateHelpersMySQL(t *testing.T) {
+	if *mysqlDSN == "" {
+		t.Skip("set -database.mysql-dsn to run MySQL integration tests")
+	}
+	assertAggregateHelpers(t, openIntegrationDB(t, config.DatabaseConfig{
+		Driver: config.DatabaseDriverMySQL,
+		DSN:    *mysqlDSN,
+	}))
+}
+
 type integrationFKCategory struct {
 	ID uint `gorm:"primaryKey"`
 }

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -110,6 +110,60 @@ primitives live in `database` (`FilterEq`, `Search`, `Ordering` / `ParseOrdering
 and are the same behavior — and now the same code — the admin data plane applies.
 Filter values are exact-match to start; ranges/operators come later.
 
+### List query: numeric aggregates
+
+A numeric field marked `aggregatable` (issue #272) opts into server-side
+`SUM`/`AVG`/`MIN`/`MAX` over the list. The dashboard "total invoiced this month"
+card is the motivating consumer: client-side aggregation is unsafe once a list is
+paginated or filtered, so the sum is computed on the server over the whole
+matching set.
+
+| Modifier       | Query parameter                                    | Types                        |
+| -------------- | -------------------------------------------------- | ---------------------------- |
+| `aggregatable` | `?aggregate=<func>:<field>[,<func>:<field>...]`    | int, int64, uint, decimal    |
+
+`<func>` is one of `sum`, `avg`, `min`, `max`. Aggregates are computed over the
+**same filtered and searched set as the list, before pagination**, so they
+reflect every matching row — not one page:
+
+```bash
+gombit make resource Invoice \
+  total:decimal:required,aggregatable \
+  quantity:int:aggregatable,filterable \
+  status:enum(draft,paid):filterable \
+  customer:belongs_to:Customer
+```
+
+```
+GET /api/v1/invoices?status=paid&aggregate=sum:total,avg:total,max:total
+```
+
+The values land in `meta.aggregates`, keyed `"<func>:<field>"`, as exact decimal
+strings (the same canonical string encoding as a `decimal` field — trailing
+zeros trimmed, so the value is identical across SQLite/Postgres/MySQL and money
+totals never round through float):
+
+```json
+{
+  "data": [ /* one page of paid invoices */ ],
+  "meta": {
+    "page": 1,
+    "per_page": 20,
+    "total": 42,
+    "aggregates": { "sum:total": "15230.5", "avg:total": "362.63", "max:total": "1999" }
+  }
+}
+```
+
+When no `?aggregate=` is requested, `meta.aggregates` is omitted and the envelope
+is byte-identical to a `PageMeta` response. An unknown function, an undeclared
+(or non-`aggregatable`) field, or a malformed pair returns a D10
+`validation_error` (422) on `aggregate`. An aggregate over an empty matching set
+is `0`. The shared primitive lives in `database` (`ParseAggregates`,
+`Aggregate`), and the meta type is `contract.ListMeta` (`PageMeta` plus the
+optional `aggregates` map). Only `sum`/`avg`/`min`/`max` are supported to start;
+grouping and per-bucket aggregates come later.
+
 ## Request DTOs
 
 Go structs are the source of truth. Prefer Huma tags — not a separate

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -138,10 +138,8 @@ gombit make resource Invoice \
 GET /api/v1/invoices?status=paid&aggregate=sum:total,avg:total,max:total
 ```
 
-The values land in `meta.aggregates`, keyed `"<func>:<field>"`, as exact decimal
-strings (the same canonical string encoding as a `decimal` field — trailing
-zeros trimmed, so the value is identical across SQLite/Postgres/MySQL and money
-totals never round through float):
+The values land in `meta.aggregates`, keyed `"<func>:<field>"`, as decimal
+strings (the same canonical `decimal`-field encoding — trailing zeros trimmed):
 
 ```json
 {
@@ -154,6 +152,23 @@ totals never round through float):
   }
 }
 ```
+
+**Precision is per driver.** The value is the database's own aggregate, encoded
+as a string:
+
+- **Postgres and MySQL** compute `SUM`/`AVG`/`MIN`/`MAX` over `numeric`/`decimal`
+  in fixed-point, so a decimal `SUM` (and integer aggregates on every driver) is
+  **exact**. This is the configuration a production money card should run on.
+- **SQLite** — the framework's dev default — has no native fixed-point aggregate:
+  it computes `AVG`, and `SUM` of a fractional `decimal` column, in IEEE double.
+  So `avg:total` and a fractional `sum:total` may carry float rounding on SQLite
+  (e.g. `10.10 + 20.20 + 0.01` can serialize as `30.309999999999995`), and the
+  string can differ from Postgres/MySQL for the same data. Integer `SUM`/`MIN`/
+  `MAX`, and `MIN`/`MAX` of a decimal column, stay exact on SQLite.
+
+For an exact money total, aggregate on Postgres/MySQL. `AVG` is fractional by
+nature and is rounded to each driver's default numeric scale — treat it as an
+approximation, not an exact value, everywhere.
 
 When no `?aggregate=` is requested, `meta.aggregates` is omitted and the envelope
 is byte-identical to a `PageMeta` response. An unknown function, an undeclared

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -213,11 +213,13 @@ modify internal/task/task.go
 ```
 
 The field grammar is
-`name:type[:required][,unique][,index][,filterable][,sortable][,searchable]`,
+`name:type[:required][,unique][,index][,filterable][,sortable][,searchable][,aggregatable]`,
 over `string`, `text`, `int`, `int64`, `bool`, and `uint`. The
 `filterable` / `sortable` / `searchable` modifiers opt a field into the list
 handler's declared query surface — see the
-[list query](contract.md#list-query-filter--sort--search) section.
+[list query](contract.md#list-query-filter--sort--search) section. A numeric
+field can also be `aggregatable` for server-side `?aggregate=sum:<field>` totals
+in `meta.aggregates` — see [numeric aggregates](contract.md#list-query-numeric-aggregates).
 
 Two properties of every Gombit generator matter here:
 

--- a/goldentest/golden_test.go
+++ b/goldentest/golden_test.go
@@ -287,6 +287,38 @@ func TestMakeResourceListQueryCompiles(t *testing.T) {
 	})
 }
 
+// TestMakeResourceAggregatesCompiles exercises the #272 aggregatable grammar end
+// to end: a resource declaring aggregatable numeric fields (int + decimal), mixed
+// with filter/search/sort, must generate a list handler that compiles against the
+// framework's database.Aggregate / contract.ListMeta surface.
+func TestMakeResourceAggregatesCompiles(t *testing.T) {
+	appDir := scaffoldDemo(t)
+	gen := func(name string, fields ...string) {
+		t.Helper()
+		stdout := new(bytes.Buffer)
+		if err := resourcegen.Generate(context.Background(), resourcegen.Options{
+			WorkDir:  appDir,
+			Name:     name,
+			Fields:   fields,
+			AtlasBin: missingAtlas,
+			Stdout:   stdout,
+			Stderr:   io.Discard,
+		}); err != nil {
+			t.Fatalf("gombit make resource %s: %v\nstdout=%s", name, err, stdout.String())
+		}
+	}
+	gen("Customer", "name:string:required")
+	gen("Invoice",
+		"total:decimal:required,aggregatable",
+		"quantity:int:aggregatable,filterable,sortable",
+		"status:enum(draft,paid):filterable",
+		"customer:belongs_to:Customer",
+	)
+	t.Run("compile", func(t *testing.T) {
+		compileBackend(t, appDir)
+	})
+}
+
 func TestMakeCommandGolden(t *testing.T) {
 	appDir := scaffoldDemo(t)
 	stdout := new(bytes.Buffer)

--- a/resourcegen/aggregate_test.go
+++ b/resourcegen/aggregate_test.go
@@ -1,0 +1,103 @@
+package resourcegen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseAggregatableModifier(t *testing.T) {
+	t.Parallel()
+	fields, err := parseFields([]string{
+		"total:decimal:aggregatable",
+		"qty:int:aggregatable,filterable",
+		"name:string:searchable",
+	}, "invoice")
+	if err != nil {
+		t.Fatalf("parseFields() error = %v", err)
+	}
+	total, qty, name := fields[0], fields[1], fields[2]
+	if !total.Aggregatable || total.Filterable || total.Sortable {
+		t.Fatalf("total flags = %+v, want aggregatable only", total)
+	}
+	if !qty.Aggregatable || !qty.Filterable {
+		t.Fatalf("qty flags = %+v, want aggregatable+filterable", qty)
+	}
+	if name.Aggregatable {
+		t.Fatalf("name flags = %+v, want not aggregatable", name)
+	}
+}
+
+func TestAggregatableTypeErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		spec string
+	}{
+		{"string", "name:string:aggregatable"},
+		{"text", "body:text:aggregatable"},
+		{"bool", "paid:bool:aggregatable"},
+		{"time", "starts_at:time:aggregatable"},
+		{"enum", "status:enum(a,b):aggregatable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseFields([]string{tt.spec}, "widget")
+			if err == nil || !strings.Contains(err.Error(), "cannot be aggregatable") {
+				t.Fatalf("parseFields(%q) error = %v, want 'cannot be aggregatable'", tt.spec, err)
+			}
+		})
+	}
+}
+
+func TestAggregatableNumericTypesAllowed(t *testing.T) {
+	t.Parallel()
+	for _, spec := range []string{
+		"a:int:aggregatable",
+		"b:int64:aggregatable",
+		"c:uint:aggregatable",
+		"d:decimal:aggregatable",
+	} {
+		if _, err := parseFields([]string{spec}, "widget"); err != nil {
+			t.Fatalf("parseFields(%q) error = %v, want nil", spec, err)
+		}
+	}
+}
+
+func TestRenderHandlerAggregates(t *testing.T) {
+	t.Parallel()
+	fields, err := parseFields([]string{
+		"total:decimal:aggregatable",
+		"qty:int:aggregatable,sortable",
+		"customer:belongs_to:Customer",
+	}, "invoice")
+	if err != nil {
+		t.Fatalf("parseFields() error = %v", err)
+	}
+	name, err := parseResourceName("Invoice")
+	if err != nil {
+		t.Fatalf("parseResourceName() error = %v", err)
+	}
+	src := string(mustFormatGo(renderHandler(newRenderContext("example.com/demo", name, fields, "/api/v1", "minimal", false, false))))
+	if strings.Contains(src, "format error") {
+		t.Fatalf("generated handler does not format:\n%s", src)
+	}
+	wantContains := []string{
+		`contract.DataMeta[[]invoiceData, contract.ListMeta]`,
+		`query:"aggregate"`,
+		`database.ParseAggregates(ctx, input.Aggregate, map[string]database.AggregateColumn{`,
+		`{Column: "total"}`,
+		`{Column: "qty"}`,
+		`database.Aggregate(ctx, q.Session(&gorm.Session{}), aggs)`,
+		`Aggregates: aggregates`,
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(src, want) {
+			t.Fatalf("generated handler missing %q\n%s", want, src)
+		}
+	}
+	// The belongs_to FK is not aggregatable — it must not appear in the map.
+	if strings.Contains(src, `"customer_id": {Column:`) {
+		t.Fatalf("belongs_to FK must not be aggregatable:\n%s", src)
+	}
+}

--- a/resourcegen/fields.go
+++ b/resourcegen/fields.go
@@ -29,6 +29,13 @@ type Field struct {
 	Sortable   bool
 	Searchable bool
 
+	// Aggregatable opts this numeric field into the generated list handler's
+	// server-side aggregate surface (issue #272): ?aggregate=sum:<field>,
+	// avg:<field>,min:<field>,max:<field>, computed over the same filtered and
+	// searched set as the list, before pagination. Only numeric columns (int,
+	// int64, uint, decimal) may opt in (see typeAllowsAggregate).
+	Aggregatable bool
+
 	// EnumValues holds the allowed values for FieldEnum, in declared order.
 	EnumValues []string
 	// Precision/Scale set the decimal(p,s) column for FieldDecimal.
@@ -270,7 +277,7 @@ func parseField(spec, resourcePkg string) (Field, error) {
 		return Field{}, fmt.Errorf("resourcegen: field %q conflicts with gorm.Model", jsonName)
 	}
 	if _, reserved := reservedQueryFields[jsonName]; reserved {
-		return Field{}, fmt.Errorf("resourcegen: field %q is reserved for the list-query params (page, per_page, search, ordering); rename it", jsonName)
+		return Field{}, fmt.Errorf("resourcegen: field %q is reserved for the list-query params (page, per_page, search, ordering, aggregate); rename it", jsonName)
 	}
 
 	// Relations (name:kind:Target) use parts[2] as the target model, not
@@ -438,10 +445,12 @@ func applyModifiers(field *Field, raw string) error {
 			field.Sortable = true
 		case mod == "searchable":
 			field.Searchable = true
+		case mod == "aggregatable":
+			field.Aggregatable = true
 		case strings.HasPrefix(mod, "default="), strings.HasPrefix(mod, "min="), strings.HasPrefix(mod, "max="), strings.HasPrefix(mod, "references="):
-			return fmt.Errorf("resourcegen: modifier %q is not supported in this milestone (supported: required, unique, index, nullable, filterable, sortable, searchable)", mod)
+			return fmt.Errorf("resourcegen: modifier %q is not supported in this milestone (supported: required, unique, index, nullable, filterable, sortable, searchable, aggregatable)", mod)
 		default:
-			return fmt.Errorf("resourcegen: unknown modifier %q (supported: required, unique, index, nullable, filterable, sortable, searchable)", mod)
+			return fmt.Errorf("resourcegen: unknown modifier %q (supported: required, unique, index, nullable, filterable, sortable, searchable, aggregatable)", mod)
 		}
 	}
 	if field.Required && field.Nullable {
@@ -455,6 +464,9 @@ func applyModifiers(field *Field, raw string) error {
 	}
 	if field.Sortable && !field.typeAllowsSort() {
 		return fmt.Errorf("resourcegen: field %q is %s and cannot be sortable", field.JSONName, field.Type)
+	}
+	if field.Aggregatable && !field.typeAllowsAggregate() {
+		return fmt.Errorf("resourcegen: field %q is %s and cannot be aggregatable (supported: int, int64, uint, decimal)", field.JSONName, field.Type)
 	}
 	return nil
 }
@@ -494,6 +506,19 @@ func (f Field) typeAllowsSort() bool {
 	}
 }
 
+// typeAllowsAggregate reports whether SUM/AVG/MIN/MAX can be applied to this
+// field's column. Only the numeric scalars qualify (issue #272): int, int64,
+// uint, decimal. Booleans, text, time, enum and relations are excluded — a SUM
+// over them is meaningless or driver-dependent.
+func (f Field) typeAllowsAggregate() bool {
+	switch f.Type {
+	case FieldInt, FieldInt64, FieldUint, FieldDecimal:
+		return true
+	default:
+		return false
+	}
+}
+
 // isFilterable reports whether the generated list handler exposes an exact-match
 // filter for this field. belongs_to foreign keys are filterable by default so
 // the has_many detail-list case (GET /children?<parent>_id=<id>, issue #260 /
@@ -502,13 +527,15 @@ func (f Field) isFilterable() bool {
 	return f.Filterable || f.Type == FieldBelongsTo
 }
 
-// filterColumn / searchColumn / sortColumn are the DB column names the list
-// query references. For our naming they equal the DTO JSON name (toSnake of the
-// Go field), which is what GORM's default naming strategy derives for the model
-// column — belongs_to resolves to its <name>_id foreign key.
-func (f Field) filterColumn() string { return f.dtoJSONName() }
-func (f Field) searchColumn() string { return f.JSONName }
-func (f Field) sortColumn() string   { return f.dtoJSONName() }
+// filterColumn / searchColumn / sortColumn / aggregateColumn are the DB column
+// names the list query references. For our naming they equal the DTO JSON name
+// (toSnake of the Go field), which is what GORM's default naming strategy
+// derives for the model column — belongs_to resolves to its <name>_id foreign
+// key. aggregateColumn is only used for numeric scalars, never a relation.
+func (f Field) filterColumn() string    { return f.dtoJSONName() }
+func (f Field) searchColumn() string    { return f.JSONName }
+func (f Field) sortColumn() string      { return f.dtoJSONName() }
+func (f Field) aggregateColumn() string { return f.dtoJSONName() }
 
 // filterInputField names the field on the generated list-input struct. Filters
 // are string query params (Huma has no optional/pointer query params, so empty

--- a/resourcegen/files.go
+++ b/resourcegen/files.go
@@ -246,6 +246,28 @@ func sortColumns(fields []Field) []string {
 	return out
 }
 
+// aggregateFields returns the fields ?aggregate= may compute SUM/AVG/MIN/MAX
+// over, in declared order (issue #272).
+func aggregateFields(fields []Field) []Field {
+	out := make([]Field, 0, len(fields))
+	for _, f := range fields {
+		if f.Aggregatable {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// aggregateColumns returns the DB column names for the given aggregatable
+// fields, in order — used for the ?aggregate= param doc string.
+func aggregateColumns(fields []Field) []string {
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		out = append(out, f.aggregateColumn())
+	}
+	return out
+}
+
 func renderHandler(ctx renderContext) string {
 	var b strings.Builder
 	pkg := ctx.Resource.Package
@@ -281,13 +303,22 @@ func renderHandler(ctx renderContext) string {
 		b.WriteString("\t" + field.dtoGoName() + " " + field.dtoGoType() + " `json:\"" + field.dtoJSONName() + "\" doc:\"" + field.dtoGoName() + "\"`\n")
 	}
 	b.WriteString("}\n\n")
-	listOut := "list" + ctx.Resource.Tag + "Output"
-	listIn := "list" + ctx.Resource.Tag + "Input"
-	b.WriteString("type " + listOut + " struct {\n")
-	b.WriteString("\tBody contract.DataMeta[[]" + data + ", contract.PageMeta]\n}\n\n")
 	filters := filterFields(ctx.Fields)
 	searchCols := searchColumns(ctx.Fields)
 	sortCols := sortColumns(ctx.Fields)
+	aggFields := aggregateFields(ctx.Fields)
+	// A resource with aggregatable fields returns aggregates in meta, so its list
+	// meta is contract.ListMeta (PageMeta + optional aggregates); otherwise the
+	// plain contract.PageMeta is unchanged, keeping a no-modifier resource's
+	// output byte-identical.
+	metaType := "contract.PageMeta"
+	if len(aggFields) > 0 {
+		metaType = "contract.ListMeta"
+	}
+	listOut := "list" + ctx.Resource.Tag + "Output"
+	listIn := "list" + ctx.Resource.Tag + "Input"
+	b.WriteString("type " + listOut + " struct {\n")
+	b.WriteString("\tBody contract.DataMeta[[]" + data + ", " + metaType + "]\n}\n\n")
 	b.WriteString("type " + listIn + " struct {\n")
 	b.WriteString("\tPage    int `query:\"page\" doc:\"1-based page\"`\n")
 	b.WriteString("\tPerPage int `query:\"per_page\" doc:\"Page size\"`\n")
@@ -296,6 +327,9 @@ func renderHandler(ctx renderContext) string {
 	}
 	if len(sortCols) > 0 {
 		b.WriteString("\tOrdering string `query:\"ordering\" doc:\"Field to order by; prefix with - for DESC (allowed: " + strings.Join(sortCols, ", ") + ")\"`\n")
+	}
+	if len(aggFields) > 0 {
+		b.WriteString("\tAggregate string `query:\"aggregate\" doc:\"Comma-separated <func>:<field> aggregates over the filtered set, e.g. sum:" + aggFields[0].aggregateColumn() + " (funcs: sum, avg, min, max; fields: " + strings.Join(aggregateColumns(aggFields), ", ") + ")\"`\n")
 	}
 	for _, f := range filters {
 		b.WriteString("\t" + f.filterInputField() + " string `" + f.filterQueryTag() + "`\n")
@@ -339,6 +373,21 @@ func renderHandler(ctx renderContext) string {
 	b.WriteString("\tif err := q.Session(&gorm.Session{}).Count(&total).Error; err != nil {\n")
 	b.WriteString("\t\treturn nil, contract.WithContext(ctx, contract.Internal(\"list " + ctx.Resource.PluralSnake + "\"))\n")
 	b.WriteString("\t}\n")
+	if len(aggFields) > 0 {
+		// Aggregates run over the same filtered/searched query as the count,
+		// before pagination — so meta.aggregates covers the whole matching set,
+		// not one page (issue #272). ParseAggregates declares err (aggs is new,
+		// so := is always valid); mark it declared so a later Ordering reuses it.
+		b.WriteString("\taggs, err := database.ParseAggregates(ctx, input.Aggregate, map[string]database.AggregateColumn{\n")
+		for _, f := range aggFields {
+			b.WriteString("\t\t\"" + f.aggregateColumn() + "\": {Column: \"" + f.aggregateColumn() + "\"},\n")
+		}
+		b.WriteString("\t})\n")
+		b.WriteString("\tif err != nil {\n\t\treturn nil, err\n\t}\n")
+		b.WriteString("\taggregates, err := database.Aggregate(ctx, q.Session(&gorm.Session{}), aggs)\n")
+		b.WriteString("\tif err != nil {\n\t\treturn nil, err\n\t}\n")
+		errDeclared = true
+	}
 	if len(sortCols) > 0 {
 		// Declared ordering replaces the fixed Order("id"), which stays the
 		// fallback when ?ordering= is absent so the default page order is
@@ -364,9 +413,13 @@ func renderHandler(ctx renderContext) string {
 	b.WriteString("\titems := make([]" + data + ", 0, len(rows))\n")
 	b.WriteString("\tfor _, row := range rows {\n\t\titems = append(items, to" + typ + "Data(row))\n\t}\n")
 	b.WriteString("\treturn &" + listOut + "{\n")
-	b.WriteString("\t\tBody: contract.DataMeta[[]" + data + ", contract.PageMeta]{\n")
+	b.WriteString("\t\tBody: contract.DataMeta[[]" + data + ", " + metaType + "]{\n")
 	b.WriteString("\t\t\tData: items,\n")
-	b.WriteString("\t\t\tMeta: &contract.PageMeta{Page: page, PerPage: perPage, Total: total},\n")
+	if len(aggFields) > 0 {
+		b.WriteString("\t\t\tMeta: &" + metaType + "{Page: page, PerPage: perPage, Total: total, Aggregates: aggregates},\n")
+	} else {
+		b.WriteString("\t\t\tMeta: &" + metaType + "{Page: page, PerPage: perPage, Total: total},\n")
+	}
 	b.WriteString("\t\t},\n")
 	b.WriteString("\t}, nil\n}\n\n")
 

--- a/resourcegen/listquery_test.go
+++ b/resourcegen/listquery_test.go
@@ -152,7 +152,7 @@ func TestRenderHandlerNoListQuery(t *testing.T) {
 	if !strings.Contains(src, `q.Order("id").Offset(`) {
 		t.Fatalf("handler without sort must keep fixed Order(\"id\"):\n%s", src)
 	}
-	for _, unwanted := range []string{`query:"search"`, `query:"ordering"`, `database.Ordering`, `database.Search`, `database.FilterEq`} {
+	for _, unwanted := range []string{`query:"search"`, `query:"ordering"`, `query:"aggregate"`, `database.Ordering`, `database.Search`, `database.FilterEq`, `database.Aggregate`, `contract.ListMeta`} {
 		if strings.Contains(src, unwanted) {
 			t.Fatalf("handler without modifiers must not contain %q:\n%s", unwanted, src)
 		}

--- a/resourcegen/names.go
+++ b/resourcegen/names.go
@@ -28,13 +28,14 @@ var reservedFields = map[string]struct{}{
 }
 
 // reservedQueryFields are the query keys the generated list handler owns for its
-// declared list-query surface (#260): pagination plus the admin-aligned search /
-// ordering params. A resource field claiming one of these would be emitted as a
-// second list-input struct field with a duplicate `query` tag (e.g. a
-// filterable `page`), so the name is rejected at parse time — the same upfront
-// treatment reservedFields gives gorm.Model columns.
+// declared list-query surface: pagination plus the admin-aligned search /
+// ordering params (#260) and the aggregate param (#272). A resource field
+// claiming one of these would be emitted as a second list-input struct field
+// with a duplicate `query` tag (e.g. a filterable `page`), so the name is
+// rejected at parse time — the same upfront treatment reservedFields gives
+// gorm.Model columns.
 var reservedQueryFields = map[string]struct{}{
-	"page": {}, "per_page": {}, "search": {}, "ordering": {},
+	"page": {}, "per_page": {}, "search": {}, "ordering": {}, "aggregate": {},
 }
 
 // ResourceName is the derived identifiers for one generated feature-package.


### PR DESCRIPTION
## Summary

Adds an opt-in **numeric aggregate** surface to the generated resource list handler, in the same spirit as #260's declared `filterable`/`sortable`/`searchable`. A numeric field marked `aggregatable` can be reduced server-side with `SUM`/`AVG`/`MIN`/`MAX` over the collection, respecting the list's filters/search and computed before pagination — the contract Gombit Forge's dashboard numeric-aggregate cards consume (gombit-forge #54).

- **Modifier:** `aggregatable`, valid only on `int`/`int64`/`uint`/`decimal`, validated per type at parse time.
- **Request:** `GET /invoices?aggregate=sum:total,avg:total` (comma-separated `<func>:<field>`; funcs `sum`/`avg`/`min`/`max`).
- **Response:** values in `meta.aggregates`, keyed `"<func>:<field>"`, as canonical decimal strings (`types.Decimal`). **Precision is per driver:** exact for integer aggregates everywhere and for decimal `SUM` on Postgres/MySQL; SQLite computes `AVG` and fractional decimal `SUM` in IEEE float, and `AVG` is an approximation on any driver — see docs/contract.md. Omitted when no `?aggregate=` is requested, so the envelope stays byte-identical to a `PageMeta` response.
- **Scope:** computed over the same filtered/searched query as the list, before pagination (like the COUNT). Empty match set → `0`. Unknown func / undeclared field / malformed pair → D10 `validation_error` (422) on `aggregate`.
- **Shared primitives** live in the `database` package (`ParseAggregates`, `Aggregate`) alongside `FilterEq`/`Search`/`Ordering`; the meta type is the new `contract.ListMeta` (PageMeta + optional `aggregates`). The generator emits the wiring only when a field opts in, so a resource with no aggregatable field is unchanged (regression-guarded).

> Builds on #260's shared list-query primitives (`FilterEq`/`Search`/`Ordering`), now merged to `main`; rebased onto `main`.

Closes #272

## Acceptance criteria

- [x] Field modifier `aggregatable` opts a numeric field (`int`, `int64`, `uint`, `decimal`) into aggregation, validated per type (non-numeric types rejected at parse time).
- [x] Request one or more aggregates on the collection endpoint — `?aggregate=sum:total,avg:total` — returning computed values in a stable envelope (`meta.aggregates`, keyed `"<func>:<field>"`).
- [x] Aggregates respect the same filters/search as the list, computed server-side before/independent of pagination.
- [x] Shared primitives in the `database` package (`ParseAggregates`, `Aggregate`), mirroring where #260 put `FilterEq`/`Search`/`Ordering`.

## Scope notes

- **Admin data plane** is intentionally not wired for aggregates: it uses its own query helpers (`applyFilters`/`applySearch`/`applyOrdering`), and the named consumer (Forge, gombit-forge #54) drives the generated resource handlers, not admin — matching #260's boundary. Can follow separately if admin cards are ever needed.
- Only `sum`/`avg`/`min`/`max`; grouping / per-bucket aggregates are out of scope.

## Validation

- [x] `go test ./...` (database, contract, resourcegen, goldentest, admin, client, framework green; SQLite unit + PG/MySQL integration wrappers for the aggregate helpers)
- [x] `go build ./...`, `go vet`, `gofmt -l` clean on changed files
- [ ] `golangci-lint` (not run locally)
- [ ] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix (SQLite unit + `TestAggregateHelpers{Postgres,MySQL}` integration wrappers)
- [x] Stable features ship docs and appear in an example app — docs in `docs/contract.md` + tutorial; a goldentest end-to-end **compile fixture** exercises a generated app (parity with #260, which documented rather than adding the modifier to a committed example app)
- [x] Extraction preserves contracts — additive; a resource with no `aggregatable` field generates byte-identical output (regression-guarded)
- [x] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files
- [x] API changes regenerate the OpenAPI doc + TS client in this PR — N/A: the framework's sample app doesn't use the modifier, so `client.SampleApp()` and its generated spec/client are unchanged (verified: client/openapi suites pass, no drift)
- [x] No secrets in generated frontend source; `VITE_*` is treated as public — N/A (no frontend changes)
- [x] Scope stays inside this issue's milestone — no M6 battery creep
- [x] This PR links its issue and states which acceptance criteria it satisfies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

