### PR TITLE
perf: fast-path the JSON content-type check in the XSS sanitizer (#269)

### DIFF
--- a/framework/xss.go
+++ b/framework/xss.go
@@ -185,15 +185,64 @@ func sanitizeJSONBody(c *gin.Context) {
 	c.Request.Header.Set("Content-Length", strconv.FormatInt(int64(len(cleaned)), 10))
 }
 
+// jsonMediaType is the only media type the sanitizer decodes. Its length
+// doubles as the fast-path prefix window below.
+const jsonMediaType = "application/json"
+
+// isJSONContentType reports whether contentType names the JSON media type.
+//
+// mime.ParseMediaType is not free: it allocates its parameter map
+// unconditionally on the success path (mime/mediatype.go), so even the exact
+// string "application/json" costs one alloc on every POST/PUT/PATCH carrying a
+// body. The fast path below skips that parse for the two shapes that carry
+// essentially all real traffic (issue #269).
+//
+// The fast path never returns false, and it returns true only where the media
+// type is unambiguously "application/json": the whole string, or everything
+// before the ';' that ends the subtype. Everything else is delegated to
+// isJSONContentTypeSlow, which stays the only place a content type is actually
+// decided — a longer subtype ("application/jsonx"), a structured suffix
+// ("application/vnd.api+json"), a cased spelling with no parameters
+// ("Application/JSON", accepted there via ToLower), leading whitespace, a tab
+// delimiter, an unparseable tail ("application/json bogus"), and the empty
+// string. FuzzIsJSONContentType asserts that the two never disagree.
 func isJSONContentType(contentType string) bool {
+	if contentType == jsonMediaType {
+		return true
+	}
+	// Only ';' is accepted as the delimiter. It is the one byte that ends the
+	// subtype under RFC 2045 grammar, so "application/json" before it is the
+	// media type no matter how the parameters that follow are spelled — even
+	// malformed ones, which the slow path still accepts. A space does not carry
+	// that guarantee: "application/json bogus" fails the media-type parse
+	// outright and survives only through the prefix fallback below, so
+	// accelerating it would make this path depend on that fallback's exact
+	// looseness. It is left to the slow path deliberately.
+	if len(contentType) > len(jsonMediaType) &&
+		contentType[len(jsonMediaType)] == ';' &&
+		strings.EqualFold(contentType[:len(jsonMediaType)], jsonMediaType) {
+		return true
+	}
+	return isJSONContentTypeSlow(contentType)
+}
+
+// isJSONContentTypeSlow is the full-parse decision, unchanged from before the
+// fast path landed: it stays the single place a content type is actually
+// decided.
+func isJSONContentTypeSlow(contentType string) bool {
 	if contentType == "" {
 		return false
 	}
 	mediaType, _, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		return strings.HasPrefix(strings.ToLower(strings.TrimSpace(contentType)), "application/json")
+		// A malformed parameter ("application/json; charset", no "=") fails the
+		// parse even though the media type itself is fine, so fall back to a
+		// prefix match and still sanitize those bodies. Deliberately fail-safe:
+		// an over-eager yes only costs a decode, and an undecodable body is
+		// handed to the handler untouched (sanitizeJSONBody above).
+		return strings.HasPrefix(strings.ToLower(strings.TrimSpace(contentType)), jsonMediaType)
 	}
-	return strings.EqualFold(mediaType, "application/json")
+	return strings.EqualFold(mediaType, jsonMediaType)
 }
 
 // sanitizeJSONValue strips HTML from every string in value in place and reports

--- a/framework/xss_test.go
+++ b/framework/xss_test.go
@@ -71,6 +71,92 @@ func TestSanitizeJSONValueNestedArray(t *testing.T) {
 	}
 }
 
+func TestIsJSONContentType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "exact", in: "application/json", want: true},
+		{name: "charset parameter", in: "application/json; charset=utf-8", want: true},
+		{name: "charset parameter without space", in: "application/json;charset=utf-8", want: true},
+		{name: "space before parameters", in: "application/json ; charset=utf-8", want: true},
+		{name: "uppercase", in: "Application/JSON", want: true},
+		{name: "uppercase with parameter", in: "APPLICATION/JSON; charset=utf-8", want: true},
+		{name: "leading space", in: " application/json", want: true},
+		{name: "trailing tab", in: "application/json\t", want: true},
+		// Fails checkMediaTypeDisposition outright and is accepted only by the
+		// prefix fallback. Pinned because that is precisely why the fast path
+		// does not accelerate a space delimiter: this case must keep being
+		// decided by isJSONContentTypeSlow alone.
+		{name: "unparseable tail after subtype", in: "application/json bogus", want: true},
+		{name: "longer subtype", in: "application/jsonx", want: false},
+		{name: "structured suffix", in: "application/vnd.api+json", want: false},
+		{name: "not json", in: "text/plain", want: false},
+		{name: "form encoded", in: "application/x-www-form-urlencoded", want: false},
+		{name: "empty", in: "", want: false},
+		// A parameter with no "=" fails mime.ParseMediaType, so the fallback
+		// prefix-matches the raw header and still sanitizes the body.
+		{name: "malformed parameter on json", in: "application/json; charset", want: true},
+		// Characterization, not a guarantee: the same fallback also accepts a
+		// subtype the exact-parse path rejects ("application/jsonx" alone is
+		// false above). Fail-safe, per isJSONContentTypeSlow. Pinned here so
+		// the issue #269 fast path cannot shift it by accident — not because
+		// the asymmetry is desirable.
+		{name: "malformed parameter widens the match", in: "application/jsonx; charset", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isJSONContentType(tt.in)
+			if got != tt.want {
+				t.Fatalf("isJSONContentType(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			// Issue #269's contract: the fast path only short-circuits, it never
+			// decides a case differently from the full parse behind it.
+			if slow := isJSONContentTypeSlow(tt.in); got != slow {
+				t.Fatalf("isJSONContentType(%q) = %v but isJSONContentTypeSlow = %v: fast path diverged", tt.in, got, slow)
+			}
+		})
+	}
+}
+
+// FuzzIsJSONContentType is the machine-checked form of issue #269's acceptance
+// criterion. That criterion is a universal claim — the fast path must return
+// what the full parse would return for *any* header value — and a finite table
+// is evidence, not proof. Keeping isJSONContentTypeSlow as a callable function
+// is what makes the differential property expressible at all; the seed corpus
+// alone runs under a plain `go test`.
+func FuzzIsJSONContentType(f *testing.F) {
+	seeds := []string{
+		"application/json",
+		"application/json; charset=utf-8",
+		"APPLICATION/JSON;charset=utf-8",
+		"application/json ; charset=utf-8",
+		"application/json bogus",
+		"application/json; charset",
+		"application/jsonx",
+		"application/jsonx; charset",
+		"application/vnd.api+json",
+		" application/json",
+		"application/json\t",
+		"application/json;",
+		"application/json; a=b; a=c",
+		"text/plain",
+		"",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, contentType string) {
+		if fast, slow := isJSONContentType(contentType), isJSONContentTypeSlow(contentType); fast != slow {
+			t.Fatalf("isJSONContentType(%q) = %v, isJSONContentTypeSlow(%q) = %v: fast path diverged", contentType, fast, contentType, slow)
+		}
+	})
+}
+
 func TestSanitizeJSONBodyInvalidJSONPassthrough(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`isJSONContentType` ran `mime.ParseMediaType` on every `POST`/`PUT`/`PATCH`
carrying a body. That parse allocates its parameter map unconditionally on the
success path (`mime/mediatype.go:151`), so the exact string `application/json`
cost one alloc per request and `application/json; charset=utf-8` cost two —
purely to answer a question a string comparison answers.

This adds a fast path for the two shapes that carry essentially all real
traffic (the exact media type, and the media type followed by the `;` that ends
the subtype) and preserves the full-parse decision verbatim as
`isJSONContentTypeSlow`, which stays the only place a content type is actually
decided.

Measured with `testing.AllocsPerRun`:

| Content-Type | before | after |
| --- | ---: | ---: |
| `application/json` | 1 | **0** |
| `application/json; charset=utf-8` | 2 | **0** |
| `Application/JSON` | 2 | 2 (delegated) |
| `application/jsonx` | 1 | 1 (delegated, still `false`) |

The safety property: **the fast path never returns `false`** — it either
short-circuits a `true` or delegates — so no request body can lose
sanitization through it, and the accepted set is identical by construction
rather than by enumeration.

Only `;` is accelerated. A space delimiter was prototyped and dropped: it would
have been correct only via the prefix fallback in the slow path
(`application/json bogus` fails the media-type parse outright and survives only
there), which would have coupled the fast path to that fallback's exact
looseness. It also bought nothing — that input allocates zero either way,
because `checkMediaTypeDisposition` rejects it before the parameter map is made.

Closes #269

## Acceptance criteria

- [x] Table test covering `application/json`, `application/json; charset=utf-8`,
      `Application/JSON`, `application/jsonx`, `application/vnd.api+json` (still
      `false`), and malformed input, asserting identical results to the previous
      implementation. `TestIsJSONContentType` covers those five plus leading
      whitespace, a tab delimiter, an unparseable tail, form-encoded, and the
      empty string — 16 cases, each additionally asserted against
      `isJSONContentTypeSlow`. `FuzzIsJSONContentType` turns "identical results"
      into a machine-checked differential property (223k local executions, no
      divergence).
- [x] `mime.ParseMediaType` no longer appears in the valid-POST alloc profile.
      The micro harness posts exactly `application/json`
      (`benchmarks/micro/scenario/benchmark.go:78`), which returns on the
      exact-match branch before `ParseMediaType` is reached.

## Scope notes

`isJSONContentTypeSlow` carries a pre-existing asymmetry, **unchanged by this
PR**: when `mime.ParseMediaType` fails on a malformed parameter, the fallback
matches by *prefix*, so `application/jsonx; charset` returns `true` while
`application/jsonx` alone returns `false`.

It is fail-safe — an over-eager yes only costs a decode, and an undecodable body
is handed to the handler untouched — so it is not a correctness or security
problem today. It is pinned in `TestIsJSONContentType` as a **characterization
test** (documenting the behavior that exists, not endorsing it) so this PR's
fast path cannot shift it by accident.

Worth a separate decision, not taken here: `mime.ParseMediaType` already returns
the correctly parsed `mediatype` alongside `ErrInvalidMediaParameter`, and the
current code discards it — the information needed for an exact answer is already
available at that call site. Flagged for the maintainer rather than fixed as
unrequested scope; #271 (PERF-13) may also change this surface wholesale.

No new issue was opened for it, per AGENTS.md ("don't create issues beyond §4
backlog entries without asking first").

## Validation

- [x] `go build ./...`
- [x] `go test ./...` — 44 packages ok, 0 failures
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — 0 issues
- [x] `go test ./framework/ -fuzz FuzzIsJSONContentType -fuzztime 25s` — 223,538 executions, no divergence (no `testdata/` corpus produced, nothing to commit)
- [x] Project `code-review` skill run against this diff — two rounds. The first
      returned REQUEST CHANGES (misleading invariant comment; the space branch
      depending on the slow path's prefix fallback with no test pinning
      `application/json bogus`; universal-equivalence claim proven only over a
      finite table). All three were addressed — the space branch was removed
      rather than tested around — and the second round returned APPROVE with no
      findings.

Not run (not applicable): the SQLite + PostgreSQL + MySQL matrix — this change
does not touch the database.

## Working agreement checklist

- [x] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — tests added; no DB surface touched, so the matrix does not apply
- [ ] Stable features ship docs and appear in an example app — N/A: no observable behavior change, so there is nothing to document. `docs/router.md`'s XSS notes remain accurate as written
- [x] Extraction preserves contracts — refactor and move, don't rewrite code that already passes its tests — the full-parse decision is preserved verbatim as `isJSONContentTypeSlow`; only the string literals became a named constant
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — N/A: runtime-only change, no generator touched
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A: internal middleware gate, the HTTP contract is unchanged
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public — N/A: no frontend surface touched
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep — two files, `framework/` only; no benchmark snapshot, README, docs, or DB changes
- [x] This PR links its issue and states which acceptance criteria it satisfies
