### PR TITLE
fix: eliminate flaky Go module downloads in CI, pin Atlas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,20 @@ on:
 permissions:
   contents: read
 
+# GOTOOLCHAIN=local: never let `go` reach out for a different toolchain than
+# actions/setup-go already installed. GOPROXY with `|` (not `,`) falls back to
+# `direct` on ANY proxy/network failure, not just 404/410 — proxy.golang.org
+# intermittently drops connections mid-fetch (issue #208) and the default
+# `,`-joined GOPROXY doesn't fail over for that. ATLAS_VERSION pins the Atlas
+# CLI in one place: scripts/ci-install-atlas.sh reads it (atlasgo.sh takes the
+# version from the environment) and then asserts the installed binary really is
+# that version, so CI can't silently pick up a canary build — the unpinned
+# installer defaults to "latest", which has resolved to a canary here before.
+env:
+  GOTOOLCHAIN: local
+  GOPROXY: https://proxy.golang.org|direct
+  ATLAS_VERSION: "v1.3.0"
+
 # Pipeline: lint → build → test → (database ∥ migrations ∥ conformance ∥ contract-drift ∥ benchmark-report-drift)
 jobs:
   lint:
@@ -51,6 +65,34 @@ jobs:
       - name: Build examples
         run: go build ./examples/...
 
+  ci-scripts:
+    name: CI script tests
+    # Mirrors the benchmark-scripts job below: hermetic bash tests (stubs
+    # `go`/`sleep`/`curl`, no real network or waiting) for the scripts/ helpers
+    # the test and migration/conformance jobs rely on. It runs alongside `test`
+    # rather than gating it — a broken helper fails `test` anyway, and gating
+    # would only delay the matrix — so its value is the failure message: "the
+    # retry/backoff logic regressed" or "the Atlas pin is unenforced", instead
+    # of an opaque GOPROXY=off error surfacing from inside somebody's test.
+    # Kept out of `build` so the two script-test surfaces (top-level scripts/,
+    # benchmarks/scripts/) stay in one place each.
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run CI script tests
+        run: |
+          bash scripts/ci-prefetch-go-modules_test.sh
+          bash scripts/ci-install-atlas_test.sh
+
   test:
     name: Test
     needs: build
@@ -79,7 +121,19 @@ jobs:
       - name: Warm npx openapi-typescript cache
         run: npx --yes openapi-typescript@7.13.0 --help >/dev/null
 
+      # `go test ./...` resolves modules two ways that must both be warmed
+      # before GOPROXY goes off (issue #208): ./migrations does a real `go run`
+      # of the generated Atlas GORM loader, needing
+      # ariga.io/atlas-provider-gorm's full graph; and ./cmd/gombit +
+      # ./goldentest run `go mod tidy` inside a freshly scaffolded app, whose
+      # own graph selects versions this module never does — hence
+      # --with-scaffold.
+      - name: Pre-fetch Go modules
+        run: bash scripts/ci-prefetch-go-modules.sh --with-scaffold
+
       - name: Run tests
+        env:
+          GOPROXY: "off"
         run: go test ./...
 
   contract-drift:
@@ -279,7 +333,7 @@ jobs:
             -c 'CREATE DATABASE gombit_bench_gombit;'
 
       - name: Install Atlas CLI
-        run: curl -sSf https://atlasgo.sh | sh -s -- --community
+        run: bash scripts/ci-install-atlas.sh
 
       - name: Apply gombit benchmark app migration
         working-directory: benchmarks/apps/gombit
@@ -466,11 +520,19 @@ jobs:
           cache: true
 
       - name: Install Atlas Community Edition
-        run: curl -sSf https://atlasgo.sh | sh -s -- --community
+        run: bash scripts/ci-install-atlas.sh
+
+      # `go test ./migrations` includes the same generated-loader path as the
+      # `test` job's TestMakeMigrationsGeneratedLoaderUsesRealGormschema, and
+      # ./cmd/gombit runs `go mod tidy` in a scaffolded app — hence
+      # --with-scaffold here too.
+      - name: Pre-fetch Go modules
+        run: bash scripts/ci-prefetch-go-modules.sh --with-scaffold
 
       - name: Run migration unit and Atlas smoke tests
         env:
           ATLAS_BINARY: atlas
+          GOPROXY: "off"
         run: go test ./migrations ./cmd/gombit
 
   migrations-postgres:
@@ -501,7 +563,12 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Pre-fetch Go modules
+        run: bash scripts/ci-prefetch-go-modules.sh
+
       - name: Run Postgres migration integration tests
+        env:
+          GOPROXY: "off"
         run: >-
           go test -tags integration ./migrations
           -migrations.postgres-dsn
@@ -536,7 +603,12 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Pre-fetch Go modules
+        run: bash scripts/ci-prefetch-go-modules.sh
+
       - name: Run MySQL migration integration tests
+        env:
+          GOPROXY: "off"
         run: >-
           go test -tags integration ./migrations
           -migrations.mysql-dsn
@@ -557,11 +629,17 @@ jobs:
           cache: true
 
       - name: Install Atlas Community Edition
-        run: curl -sSf https://atlasgo.sh | sh -s -- --community
+        run: bash scripts/ci-install-atlas.sh
+
+      # harness.prepareSchema() runs the same generated-loader path as the
+      # `test` job's TestMakeMigrationsGeneratedLoaderUsesRealGormschema.
+      - name: Pre-fetch Go modules
+        run: bash scripts/ci-prefetch-go-modules.sh
 
       - name: Run SQLite conformance suite
         env:
           ATLAS_BINARY: atlas
+          GOPROXY: "off"
         run: >-
           go test -tags conformance ./database/conformance
           -conformance.driver sqlite
@@ -596,11 +674,15 @@ jobs:
           cache: true
 
       - name: Install Atlas Community Edition
-        run: curl -sSf https://atlasgo.sh | sh -s -- --community
+        run: bash scripts/ci-install-atlas.sh
+
+      - name: Pre-fetch Go modules
+        run: bash scripts/ci-prefetch-go-modules.sh
 
       - name: Run Postgres conformance suite
         env:
           ATLAS_BINARY: atlas
+          GOPROXY: "off"
         run: >-
           go test -tags conformance ./database/conformance
           -conformance.driver postgres
@@ -638,11 +720,15 @@ jobs:
           cache: true
 
       - name: Install Atlas Community Edition
-        run: curl -sSf https://atlasgo.sh | sh -s -- --community
+        run: bash scripts/ci-install-atlas.sh
+
+      - name: Pre-fetch Go modules
+        run: bash scripts/ci-prefetch-go-modules.sh
 
       - name: Run MySQL conformance suite
         env:
           ATLAS_BINARY: atlas
+          GOPROXY: "off"
         run: >-
           go test -tags conformance ./database/conformance
           -conformance.driver mysql

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,21 @@ change reviewed, and the bar a change has to clear.
 | Go | 1.25+ (`go.mod` is authoritative) | everything |
 | A C toolchain | gcc/clang, or Xcode CLT on macOS | SQLite (`mattn/go-sqlite3` is cgo-only) |
 | Node.js | 22+ | frontend, admin UI, TypeScript client generation |
-| Atlas | Community Edition | `gombit db makemigrations` / `migrate` and the migration tests |
+| Atlas | Community Edition, pinned by CI | `gombit db makemigrations` / `migrate` and the migration tests |
 | Docker | any recent | PostgreSQL and MySQL test matrices |
 
 ```bash
+curl -sSf https://atlasgo.sh | sh -s -- --community
+```
+
+That installs whatever `latest` resolves to, which has been a canary build
+before now. CI pins Atlas through the `ATLAS_VERSION` variable at the top of
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml), and the installer reads
+that same variable — so to match CI when reproducing a migration or conformance
+failure, export the pinned version first:
+
+```bash
+export ATLAS_VERSION=<the version pinned in ci.yml>
 curl -sSf https://atlasgo.sh | sh -s -- --community
 ```
 

--- a/scripts/ci-install-atlas.sh
+++ b/scripts/ci-install-atlas.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Installs the pinned Atlas Community Edition CLI for CI.
+#
+# The pin works because atlasgo.sh reads ATLAS_VERSION from the environment
+# (`ATLAS_VERSION="${ATLAS_VERSION:-latest}"`) and builds the artifact name
+# from it. That coupling is invisible at the call site, and its failure mode is
+# silent: rename or drop the variable and CI goes back to installing
+# `atlas-community-linux-amd64-latest`, which has resolved to a canary build
+# before (issue #208). So this script refuses to run without ATLAS_VERSION and
+# verifies afterwards that the binary on PATH really is that version — a
+# canary or a newer release fails the job loudly instead of quietly becoming
+# the version every migration and conformance job runs against.
+#
+#   ATLAS_VERSION=v1.3.0 bash scripts/ci-install-atlas.sh
+set -euo pipefail
+
+if [ -z "${ATLAS_VERSION:-}" ]; then
+  echo "ci-install-atlas: ATLAS_VERSION is not set; refusing to install an unpinned Atlas" >&2
+  exit 1
+fi
+
+# CI=true suppresses the installer's interactive confirmation prompt.
+export ATLAS_VERSION CI=true
+curl -sSf https://atlasgo.sh | sh -s -- --community
+
+# `atlas version` prints e.g. "atlas community version v1.3.0" on its first
+# line, followed by a release URL and an install hint. Take the first line by
+# trimming the captured output rather than piping into `head`: under
+# `pipefail`, `head` exiting after one line kills `atlas` with SIGPIPE and the
+# pipeline reports 141, which would fail this step at random.
+#
+# Matching the trailing version rather than the whole line tolerates a reworded
+# prefix while still rejecting a canary suffix like "v1.3.1-9a6bc60-canary".
+reported="$(atlas version)"
+installed="${reported%%$'\n'*}"
+case "$installed" in
+*" $ATLAS_VERSION") ;;
+*)
+  echo "ci-install-atlas: installed Atlas is \"$installed\", want version $ATLAS_VERSION" >&2
+  exit 1
+  ;;
+esac
+echo "$installed"

--- a/scripts/ci-install-atlas_test.sh
+++ b/scripts/ci-install-atlas_test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Tests for ci-install-atlas.sh. Stubs `curl` on PATH with a fake installer so
+# the pin contract is exercised hermetically (no network, no real Atlas): the
+# script must refuse to run unpinned, must hand the pinned version to the
+# installer through the environment (atlasgo.sh reads ATLAS_VERSION from
+# there), and must fail the job when the binary that actually landed is a
+# different version — the canary case from issue #208.
+#
+#   bash scripts/ci-install-atlas_test.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+fail=0
+note() { echo "FAIL: $*" >&2; fail=1; }
+
+SCRIPT="scripts/ci-install-atlas.sh"
+
+fakebin="$(mktemp -d)"
+trap 'rm -rf "$fakebin"' EXIT
+
+# Stands in for `curl -sSf https://atlasgo.sh`, printing an installer that the
+# real `sh` in the script's pipeline then executes. It records the URL asked
+# for and the ATLAS_VERSION it saw in its environment, and installs a fake
+# atlas reporting $INSTALLED_VERSION — which the tests set independently of
+# ATLAS_VERSION to simulate the installer handing back something else.
+cat > "$fakebin/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >> "$CURL_LOG"
+echo "$ATLAS_VERSION" > "$INSTALLER_SAW_VERSION"
+cat <<INSTALLER
+#!/bin/sh
+cat > "$FAKE_BIN/atlas" <<'ATLASBIN'
+#!/usr/bin/env bash
+echo "atlas community version $INSTALLED_VERSION"
+echo "https://github.com/ariga/atlas/releases/tag/$INSTALLED_VERSION"
+echo "To download an official version, visit: https://atlasgo.io/getting-started#installation"
+# Real 'atlas version' prints more than one line, and a reader that stops
+# after the first one kills it with SIGPIPE. Under 'set -o pipefail' that
+# surfaces as exit 141 and fails the step at random, so make the tail long
+# enough that any such reader hits it on every run instead of sometimes.
+# (Escaped: this text is produced by the unquoted INSTALLER heredoc below.)
+for i in \$(seq 1 5000); do echo "filler line \$i"; done
+ATLASBIN
+chmod +x "$FAKE_BIN/atlas"
+INSTALLER
+EOF
+chmod +x "$fakebin/curl"
+
+# Runs the script under test with the fakes on PATH, setting $rc and the log
+# globals. $1 is the pinned version to request (empty means "unset"); $2 the
+# version the installer actually delivers.
+run_install() {
+  local want="$1" got="$2"
+  curl_log="$(mktemp)"; installer_saw="$(mktemp)"; out="$(mktemp)"; errout="$(mktemp)"
+  rm -f "$fakebin/atlas"
+  rc=0
+  if [ -n "$want" ]; then
+    PATH="$fakebin:$PATH" ATLAS_VERSION="$want" \
+      CURL_LOG="$curl_log" INSTALLER_SAW_VERSION="$installer_saw" \
+      FAKE_BIN="$fakebin" INSTALLED_VERSION="$got" \
+      bash "$SCRIPT" >"$out" 2>"$errout" || rc=$?
+  else
+    # `env -u`, not merely omitting the assignment: CI sets ATLAS_VERSION at the
+    # workflow level, so the variable is already in this test's own environment
+    # and would be inherited by the script under test, making the "unpinned"
+    # case silently untestable there.
+    env -u ATLAS_VERSION \
+      PATH="$fakebin:$PATH" \
+      CURL_LOG="$curl_log" INSTALLER_SAW_VERSION="$installer_saw" \
+      FAKE_BIN="$fakebin" INSTALLED_VERSION="$got" \
+      bash "$SCRIPT" >"$out" 2>"$errout" || rc=$?
+  fi
+}
+
+# ---- 1. an unset ATLAS_VERSION is refused before anything is downloaded ----
+# Falling through to the installer here is exactly how CI silently went back
+# to "latest"; the script must not do the install at all.
+run_install "" v1.3.0
+[ "$rc" -eq 1 ]           || note "unpinned: exit=$rc, want 1"
+[ ! -s "$curl_log" ]      || note "unpinned: ran the installer anyway ($(cat "$curl_log"))"
+grep -qF "ATLAS_VERSION is not set" "$errout" \
+  || note "unpinned: stderr did not explain that ATLAS_VERSION is unset"
+
+# ---- 2. the pinned version reaches the installer through the environment ----
+run_install v1.3.0 v1.3.0
+[ "$rc" -eq 0 ]                              || note "pinned: exit=$rc, want 0"
+grep -qF "https://atlasgo.sh" "$curl_log"    || note "pinned: did not fetch the installer"
+[ "$(cat "$installer_saw")" = "v1.3.0" ] \
+  || note "pinned: installer saw ATLAS_VERSION=$(cat "$installer_saw"), want v1.3.0"
+grep -qF "atlas community version v1.3.0" "$out" \
+  || note "pinned: did not report the installed version"
+# Guards the SIGPIPE trap above specifically: 141 means the script read the
+# version through something that closed the pipe early.
+[ "$rc" -ne 141 ] || note "pinned: exit 141 — the version check died of SIGPIPE under pipefail"
+
+# ---- 3. a canary (or any other version) landing instead fails the job ----
+# This is the guard that makes the pin enforced rather than merely requested.
+run_install v1.3.0 v1.3.1-9a6bc60-canary
+[ "$rc" -eq 1 ]  || note "canary: exit=$rc, want 1"
+grep -qF "want version v1.3.0" "$errout" \
+  || note "canary: stderr did not report the version mismatch"
+
+# ---- 4. the workflow's pin and the script agree ----
+# A pin nothing references is the defect this replaced; keep them coupled.
+workflow_version="$(sed -n 's/^  ATLAS_VERSION: "\(.*\)"$/\1/p' .github/workflows/ci.yml)"
+[ -n "$workflow_version" ] \
+  || note "ci.yml no longer sets a workflow-level ATLAS_VERSION"
+grep -qF "bash scripts/ci-install-atlas.sh" .github/workflows/ci.yml \
+  || note "ci.yml does not install Atlas through $SCRIPT"
+if grep -vE '^\s*#' .github/workflows/ci.yml | grep -qF "atlasgo.sh"; then
+  note "ci.yml still installs Atlas inline; every install must go through $SCRIPT"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "ci-install-atlas_test: FAILED" >&2
+  exit 1
+fi
+echo "ci-install-atlas_test: unpinned refusal, environment pin, canary rejection, and workflow wiring all pass"

--- a/scripts/ci-prefetch-go-modules.sh
+++ b/scripts/ci-prefetch-go-modules.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Prefetches Go module dependencies with bounded retries so a transient
+# module-proxy failure (e.g. "stream error: INTERNAL_ERROR" from
+# proxy.golang.org/sum.golang.org) doesn't fail CI jobs that would otherwise
+# resolve modules in the middle of a test (see issue #208). Only dependency
+# acquisition is retried here — never `go test` — so a genuine test failure
+# still fails immediately, with no retry hiding it.
+#
+# `go mod download all` warms the versions *this* module's build list selects.
+# That is enough for the generated Atlas GORM loader, which `go run`s inside
+# this module. It is not enough for the tests in ./cmd/gombit and ./goldentest:
+# those scaffold an app and run `go mod tidy` in it, and a fresh module both
+# resolves its own graph and needs the test dependencies of the packages it
+# imports. Those land on versions this module never selects — huma pins
+# go-spew v1.1.1 / go-difflib v1.0.0 for its own tests while gombit's graph
+# selects newer ones — so --with-scaffold additionally warms that closure by
+# doing the same thing those tests do.
+#
+#   bash scripts/ci-prefetch-go-modules.sh [--with-scaffold]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+with_scaffold=false
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --with-scaffold) with_scaffold=true ;;
+  *)
+    echo "usage: ${BASH_SOURCE[0]} [--with-scaffold]" >&2
+    exit 2
+    ;;
+  esac
+  shift
+done
+
+# `go mod download all` records checksums for the *entire* module graph, not
+# just what this module builds, so it rewrites go.sum with hundreds of lines
+# that `go mod tidy` immediately removes again. Only the populated module cache
+# is wanted here, so go.sum is put back afterwards — otherwise every run of
+# this script leaves a tracked file dirty, which is how that churn got
+# committed once already.
+gosum_backup="$(mktemp)"
+cp go.sum "$gosum_backup"
+trap 'cp "$gosum_backup" go.sum; rm -f "$gosum_backup"' EXIT
+
+attempts=3
+
+# retry runs "$@" up to $attempts times with an attempt*5s backoff, naming
+# $what in the exhausted-attempts message. It only ever wraps dependency
+# acquisition — never a test command.
+retry() {
+  local what="$1"
+  shift
+  local attempt
+  for attempt in $(seq 1 "$attempts"); do
+    if "$@"; then
+      return 0
+    fi
+
+    if [ "$attempt" -eq "$attempts" ]; then
+      echo "failed to $what after ${attempts} attempts" >&2
+      return 1
+    fi
+
+    sleep $((attempt * 5))
+  done
+}
+
+# warm_scaffold resolves the module graph of a throwaway generated app exactly
+# the way ./cmd/gombit and ./goldentest do at test time: scaffold it, point its
+# framework requirement at this checkout, then tidy. --skip-tidy keeps the
+# scaffold itself offline-neutral so the tidy below is the only resolution
+# step, and the local replace is what the tests append too — without it this
+# would warm the graph of a published gombit release instead of the one under
+# test.
+#
+# One scaffold covers every variant ./goldentest exercises (cookie auth, MUI,
+# make resource, make command) because they all generate code into the same
+# module and import the same packages — verified by running the whole suite
+# offline. That is an assumption, not a guarantee: if a variant ever pulls in a
+# Go dependency the default app doesn't, the offline test step fails naming
+# that module, and the fix is to warm that variant here too.
+warm_scaffold() {
+  local tmp rc=0
+  tmp="$(mktemp -d)" || return 1
+  (
+    set -e
+    go build -o "$tmp/gombit" ./cmd/gombit
+    cd "$tmp"
+    ./gombit new demo --module github.com/example/demo --skip-tidy >/dev/null
+    printf '\nreplace github.com/gombit-dev/gombit => %s\n' "$ROOT" >>demo/go.mod
+    cd demo
+    go mod tidy
+  ) || rc=$?
+  rm -rf "$tmp"
+  return "$rc"
+}
+
+retry "download Go dependencies" go mod download all
+
+if [ "$with_scaffold" = true ]; then
+  retry "warm the generated-app module closure" warm_scaffold
+fi

--- a/scripts/ci-prefetch-go-modules_test.sh
+++ b/scripts/ci-prefetch-go-modules_test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Tests for ci-prefetch-go-modules.sh. Stubs `go` and `sleep` on PATH so the
+# retry/backoff control flow and the scaffold warm-up are exercised
+# hermetically (no network, no real waiting, no real toolchain) and asserts
+# exactly what CI issue #208 requires: bounded retries only around dependency
+# acquisition, the documented attempt*5s backoff, a failure message when all
+# attempts are exhausted, and — under --with-scaffold — that the warm-up tidies
+# a generated app pointed at *this* checkout. `go test` is never invoked by the
+# script under test: a real test failure must stay visible, never silently
+# retried.
+#
+#   bash scripts/ci-prefetch-go-modules_test.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+fail=0
+note() { echo "FAIL: $*" >&2; fail=1; }
+
+SCRIPT="scripts/ci-prefetch-go-modules.sh"
+
+# ---- static: the prefetch script never wraps `go test` in its own retry ----
+# Only dependency acquisition may be retried; a genuine test failure must
+# fail immediately and visibly. Comment-only mentions (e.g. this file's own
+# explanatory header) don't count — only an actual invocation does.
+if [ -f "$SCRIPT" ] && grep -vE '^\s*#' "$SCRIPT" | grep -qE 'go test'; then
+  note "$SCRIPT invokes 'go test' — only dependency acquisition may be retried"
+fi
+
+# ---- fake `go` + `sleep` on PATH, driven by env, for hermetic retry tests ----
+fakebin="$(mktemp -d)"
+# The fake `go mod download all` below deliberately dirties go.sum, the way the
+# real one does. Snapshot it so a broken restore in the script under test fails
+# the assertion instead of leaving the checkout modified.
+gosum_snapshot="$(mktemp)"
+cp go.sum "$gosum_snapshot"
+trap 'cp "$gosum_snapshot" go.sum; rm -rf "$fakebin" "$gosum_snapshot"' EXIT
+
+# The fake `go` covers the three subcommands the script drives: the module
+# download it retries, the build that produces the scaffolding binary (stubbed
+# out as a script that writes the generated go.mod), and the tidy inside the
+# generated app — which snapshots that go.mod so the assertions below can see
+# it after the script has cleaned up its temp dir.
+cat > "$fakebin/go" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >> "$CALL_LOG"
+case "$1 ${2:-}" in
+"mod download")
+  # `go mod download all` really does rewrite go.sum; the script is expected
+  # to put it back, so give it something unmistakable to put back.
+  echo "$GOSUM_MARKER" >> go.sum
+  count=$(( $(cat "$COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
+  echo "$count" > "$COUNT_FILE"
+  if [ "$count" -ge "$SUCCEED_ON_ATTEMPT" ]; then
+    exit 0
+  fi
+  echo "go: mod download all: fake network failure" >&2
+  exit 1
+  ;;
+"mod tidy")
+  cp go.mod "$TIDY_GOMOD"
+  count=$(( $(cat "$TIDY_COUNT_FILE" 2>/dev/null || echo 0) + 1 ))
+  echo "$count" > "$TIDY_COUNT_FILE"
+  if [ "$count" -ge "$TIDY_SUCCEED_ON_ATTEMPT" ]; then
+    exit 0
+  fi
+  echo "go: mod tidy: fake network failure" >&2
+  exit 1
+  ;;
+"build -o")
+  cat > "$3" <<'GOMBIT'
+#!/usr/bin/env bash
+echo "$*" >> "$GOMBIT_LOG"
+mkdir -p demo
+printf 'module github.com/example/demo\n\ngo 1.25.7\n\nrequire github.com/gombit-dev/gombit v0.0.0\n' > demo/go.mod
+GOMBIT
+  chmod +x "$3"
+  exit 0
+  ;;
+esac
+exit 0
+EOF
+chmod +x "$fakebin/go"
+
+cat > "$fakebin/sleep" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >> "$SLEEP_LOG"
+exit 0
+EOF
+chmod +x "$fakebin/sleep"
+
+# Runs the script under test and sets $rc plus the count_file/call_log/
+# sleep_log globals below — NOT via $(...), so those assignments survive in
+# this shell instead of vanishing with a subshell. $1 is the download attempt
+# that succeeds; $2 the tidy attempt that succeeds; the rest are the script's
+# own flags.
+run_prefetch() {
+  local succeed_on="$1" tidy_succeed_on="$2"
+  shift 2
+  gosum_marker="# fake-prefetch-marker-$RANDOM"
+  count_file="$(mktemp)"; call_log="$(mktemp)"; sleep_log="$(mktemp)"
+  tidy_count_file="$(mktemp)"; tidy_gomod="$(mktemp)"; gombit_log="$(mktemp)"
+  rm -f "$count_file" "$call_log" "$sleep_log" "$tidy_count_file" "$tidy_gomod" "$gombit_log"
+  rc=0
+  PATH="$fakebin:$PATH" \
+    COUNT_FILE="$count_file" CALL_LOG="$call_log" SLEEP_LOG="$sleep_log" \
+    TIDY_COUNT_FILE="$tidy_count_file" TIDY_GOMOD="$tidy_gomod" \
+    GOMBIT_LOG="$gombit_log" GOSUM_MARKER="$gosum_marker" \
+    SUCCEED_ON_ATTEMPT="$succeed_on" TIDY_SUCCEED_ON_ATTEMPT="$tidy_succeed_on" \
+    bash "$SCRIPT" "$@" >"$call_log.stdout" 2>"$call_log.stderr" || rc=$?
+}
+
+count_of() { [ -f "$count_file" ] && cat "$count_file" || echo 0; }
+tidy_count_of() { [ -f "$tidy_count_file" ] && cat "$tidy_count_file" || echo 0; }
+sleep_calls() { [ -f "$sleep_log" ] && cat "$sleep_log" || true; }
+
+# ---- 1. immediate success: no retry, no sleep ----
+run_prefetch 1 1
+[ "$rc" -eq 0 ]              || note "immediate success: exit=$rc, want 0"
+[ "$(count_of)" = "1" ]      || note "immediate success: go invoked $(count_of)x, want 1"
+[ -z "$(sleep_calls)" ]      || note "immediate success: slept ($(sleep_calls | tr '\n' ',')), want no retries"
+
+# ---- 2. fails twice, succeeds on the 3rd: retried with attempt*5s backoff ----
+run_prefetch 3 1
+[ "$rc" -eq 0 ]                                || note "eventual success: exit=$rc, want 0"
+[ "$(count_of)" = "3" ]                        || note "eventual success: go invoked $(count_of)x, want 3"
+[ "$(sleep_calls)" = "$(printf '5\n10')" ]      || note "eventual success: slept ($(sleep_calls | tr '\n' ',')), want 5,10"
+
+# ---- 3. fails all 3 attempts: exits 1, never a 4th try, no sleep after the last ----
+run_prefetch 99 1
+[ "$rc" -eq 1 ]                                || note "exhausted retries: exit=$rc, want 1"
+[ "$(count_of)" = "3" ]                        || note "exhausted retries: go invoked $(count_of)x, want exactly 3 (no 4th attempt)"
+[ "$(sleep_calls)" = "$(printf '5\n10')" ]      || note "exhausted retries: slept ($(sleep_calls | tr '\n' ',')), want 5,10 (no sleep after the final failure)"
+grep -qF "failed to download Go dependencies after 3 attempts" "$call_log.stderr" \
+  || note "exhausted retries: stderr did not report the exhausted-attempts message"
+
+# ---- 4. without --with-scaffold the warm-up does not run at all ----
+# The jobs that never build a generated app (conformance, the Postgres/MySQL
+# migration suites) must not pay for it.
+run_prefetch 1 1
+[ "$rc" -eq 0 ]                         || note "no scaffold: exit=$rc, want 0"
+[ "$(tidy_count_of)" = "0" ]            || note "no scaffold: ran 'go mod tidy' $(tidy_count_of)x, want 0"
+if grep -q 'build -o' "$call_log"; then
+  note "no scaffold: built the gombit binary, want no scaffold work"
+fi
+
+# ---- 5. --with-scaffold tidies a generated app pinned to this checkout ----
+# The local replace is the point: without it the warm-up would resolve a
+# published gombit release and cache the wrong module graph.
+run_prefetch 1 1 --with-scaffold
+[ "$rc" -eq 0 ]                                 || note "scaffold: exit=$rc, want 0"
+[ "$(count_of)" = "1" ]                         || note "scaffold: 'go mod download all' ran $(count_of)x, want 1"
+[ "$(tidy_count_of)" = "1" ]                    || note "scaffold: 'go mod tidy' ran $(tidy_count_of)x, want 1"
+grep -q 'build -o' "$call_log"                  || note "scaffold: never built the gombit binary"
+grep -qF 'new demo --module github.com/example/demo --skip-tidy' "$gombit_log" \
+  || note "scaffold: gombit was not asked to scaffold with --skip-tidy (got: $(cat "$gombit_log" 2>/dev/null))"
+grep -qF "replace github.com/gombit-dev/gombit => $ROOT" "$tidy_gomod" \
+  || note "scaffold: tidied go.mod does not replace the framework with this checkout"
+
+# ---- 6. a flaky warm-up is retried on the same bounded schedule ----
+run_prefetch 1 3 --with-scaffold
+[ "$rc" -eq 0 ]                                || note "flaky scaffold: exit=$rc, want 0"
+[ "$(tidy_count_of)" = "3" ]                   || note "flaky scaffold: 'go mod tidy' ran $(tidy_count_of)x, want 3"
+[ "$(sleep_calls)" = "$(printf '5\n10')" ]      || note "flaky scaffold: slept ($(sleep_calls | tr '\n' ',')), want 5,10"
+
+# ---- 7. an exhausted warm-up fails the job, named distinctly from the download ----
+run_prefetch 1 99 --with-scaffold
+[ "$rc" -eq 1 ]                                || note "scaffold exhausted: exit=$rc, want 1"
+[ "$(tidy_count_of)" = "3" ]                   || note "scaffold exhausted: 'go mod tidy' ran $(tidy_count_of)x, want exactly 3"
+grep -qF "failed to warm the generated-app module closure after 3 attempts" "$call_log.stderr" \
+  || note "scaffold exhausted: stderr did not name the warm-up as what failed"
+
+# ---- 8. an unknown flag is rejected rather than silently ignored ----
+# A typo'd flag must not quietly skip the warm-up and leave the job to fail
+# later inside a test with an opaque GOPROXY=off error.
+run_prefetch 1 1 --with-scafold
+[ "$rc" -eq 2 ]                 || note "unknown flag: exit=$rc, want 2"
+[ "$(count_of)" = "0" ]         || note "unknown flag: downloaded anyway ($(count_of)x), want no work"
+
+# ---- 9. the prefetch leaves go.sum exactly as it found it ----
+# The checksums `go mod download all` records for the whole module graph are
+# noise `go mod tidy` deletes again; committing them once already produced a
+# 473-line unrelated diff. Only the module cache should survive this script.
+run_prefetch 1 1
+[ "$rc" -eq 0 ]                     || note "go.sum restore: exit=$rc, want 0"
+if grep -qF "$gosum_marker" go.sum; then
+  note "go.sum restore: the prefetch left go.sum modified"
+fi
+
+# ...including when it gives up, so a failed bootstrap doesn't leave a dirty
+# tree behind either.
+run_prefetch 99 1
+[ "$rc" -eq 1 ]                     || note "go.sum restore on failure: exit=$rc, want 1"
+if grep -qF "$gosum_marker" go.sum; then
+  note "go.sum restore on failure: the prefetch left go.sum modified"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "ci-prefetch-go-modules_test: FAILED" >&2
+  exit 1
+fi
+echo "ci-prefetch-go-modules_test: retry/backoff, exhausted retries, scaffold warm-up, flag handling, and go.sum restore all pass"


### PR DESCRIPTION
## Summary

Migration/conformance CI jobs intermittently failed on transient network errors
(`stream error: INTERNAL_ERROR`) while the generated Atlas GORM loader resolved
`ariga.io/atlas-provider-gorm`'s full module graph — including Spanner — against
`proxy.golang.org`/`sum.golang.org`.

- **Proxy fallback.** `GOPROXY` is now `https://proxy.golang.org|direct` (pipe,
  not comma) at the workflow level, so any proxy/network failure falls back to
  `direct`, not just 404/410. `GOTOOLCHAIN=local` keeps `go` from fetching a
  different toolchain.
- **Explicit bootstrap.** `scripts/ci-prefetch-go-modules.sh` downloads modules
  with 3 bounded retries (5s/10s backoff) before each affected job's test step.
  Only dependency acquisition is retried — never `go test`. It restores `go.sum`
  afterwards, because `go mod download all` records checksums for the whole
  module graph that `go mod tidy` deletes again.
- **`--with-scaffold`.** `go mod download all` warms the versions *this* module's
  build list selects. That covers the generated Atlas loader, which `go run`s
  inside this module. It does not cover `./cmd/gombit` and `./goldentest`, which
  run `go mod tidy` inside a freshly scaffolded app: a fresh module resolves its
  own graph and also needs the test dependencies of the packages it imports.
  Those land on versions this module never selects — huma pins `go-spew v1.1.1` /
  `go-difflib v1.0.0` for its own tests while gombit's graph selects
  `v1.1.2-0.20180830191138` / `v1.0.1-0.20181226105442`. So `--with-scaffold`
  warms that closure by doing exactly what those tests do (build the CLI,
  `gombit new --skip-tidy`, append the local `replace`, `go mod tidy`), in a temp
  dir it deletes. The `test` and `migrations-sqlite` jobs use it.
- **Offline test steps.** Every affected job runs the prefetch, then sets
  `GOPROXY=off` for its actual test step, so a genuine module-graph gap fails
  loudly and immediately instead of silently reaching the network mid-test.
- **Atlas pin, enforced.** `scripts/ci-install-atlas.sh` replaces five inline
  unpinned installs. `atlasgo.sh` takes its version from `ATLAS_VERSION` in the
  environment — a coupling that is invisible at the call site and whose failure
  mode is silent (drop the variable and CI is back on `latest`, which has
  resolved to a canary). The script refuses to run without `ATLAS_VERSION` and
  then asserts the installed binary really is that version. `--community` is
  retained: ADR-012 requires Atlas Community Edition, not the MSA-licensed
  standard CLI.
- Both scripts have hermetic bash tests (stubbing `go`/`sleep`/`curl`, no real
  network or waiting) run by a new `ci-scripts` job.

Closes #208

## Acceptance criteria

- [x] CI no longer relies on `GOPROXY=https://proxy.golang.org,direct` for affected jobs
- [x] Proxy failures can fall back to direct module retrieval
- [x] Go dependency acquisition is explicit and happens before affected test suites
- [x] Network dependency operations use bounded retries
- [x] `go test` commands themselves are not automatically retried
- [x] Generated GORM loader dependencies are included in the dependency bootstrap
- [x] `Migrations (sqlite)` does not unexpectedly fetch Go modules during the actual test step
- [x] `Conformance (sqlite)` does not unexpectedly fetch Go modules during the actual test step
- [x] `Conformance (mysql)` does not unexpectedly fetch Go modules during the actual test step
- [x] Equivalent Postgres paths are covered as well
- [x] Atlas Community Edition is pinned to an explicit stable version (`v1.3.0`)
- [x] CI no longer installs `atlas-community-*-latest`
- [x] CI cannot silently switch to an Atlas canary build — the install asserts the version
- [x] Where feasible, affected test execution succeeds with `GOPROXY=off` after dependency bootstrap — verified for the whole suite, not just the listed jobs
- [x] A genuine test failure still fails immediately and is not hidden by generic retries
- [x] Existing migration, database, conformance, benchmark, and contract-drift coverage remains unchanged

Non-goals honoured: no blanket job retries, no retried `go test`, no `GOSUMDB=off`,
no disabled checksum verification, no vendoring, no removed coverage. The diff
contains no `GOSUMDB`/`GOFLAGS`/`GOPRIVATE` setting at all.

## Scope notes

Two deliberate omissions, both inside the issue's stated criteria:

- The prefetch uses `go mod download all` (~50s/job). The narrower `go mod
  download` (build list only, does not rewrite `go.sum`) was **not** evaluated —
  `all` is proven to make the Atlas loader path work offline, and the narrower
  form may exclude it since `tools.go` blank-imports `gormschema` behind a build
  tag.
- The `database-*` jobs get the workflow-level `|direct` fallback but no
  prefetch/`GOPROXY=off`. They run no nested `go` invocation, so they are not
  exposed to the failure class this issue describes.

## Validation

Reproduced and fixed against a **cold module cache** (`GOMODCACHE` pointed at an
empty dir), so the fix is demonstrably what changed the outcome:

- Before, prefetch without `--with-scaffold`: `GOPROXY=off go test ./cmd/gombit`
  fails with the exact CI error —
  `github.com/davecgh/go-spew/spew: module lookup disabled by GOPROXY=off`.
- After, prefetch with `--with-scaffold`: the same test passes, and the full
  `GOPROXY=off go test ./...` passes — **46 packages ok, 0 failures**, including
  `goldentest` (cookie-auth, MUI, `make resource`, `make command` variants) and
  `cmd/gombit`.
- Build-tagged packages compile offline too: `go vet -tags integration
  ./migrations`, `-tags conformance ./database/conformance`, and `-tags
  integration ./database ./auth ./admin ./framework`.

- [x] `go test ./...` (and `GOPROXY=off go test ./...` against the warmed cache)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run` — 0 issues
- [x] `go build ./... && go build ./examples/...`
- [x] `go mod tidy -diff` clean — the previous revision of this branch left
      `go.sum` with 473 extra lines that `tidy` removes again; that churn is
      reverted, and the prefetch script no longer produces it
- [x] `bash scripts/ci-prefetch-go-modules_test.sh` (9 cases)
- [x] `bash scripts/ci-install-atlas_test.sh` (4 cases)
- [x] Project `code-review` skill run against this diff

The review pass caught a real defect in the new code: `atlas version | head -n 1`
under `set -o pipefail` kills `atlas` with SIGPIPE and reports exit 141 at
random — a fresh source of CI non-determinism inside the change meant to remove
it. Fixed by capturing the output and trimming the first line without a pipe,
and the test now forces the condition on every run (the fake `atlas` emits a long
tail); reverting the fix fails the test 3/3.

## Working agreement checklist

- [ ] New behavior has tests; DB-touching changes pass the SQLite + PostgreSQL + MySQL matrix — the new behavior (both scripts) has hermetic tests. No database behavior changes; the nine matrix jobs are unmodified apart from the prefetch step and `GOPROXY=off`, and their real validation is this PR's CI run
- [ ] Stable features ship docs and appear in an example app — N/A, CI plumbing, not a user-facing framework feature. `CONTRIBUTING.md` documents how to install the pinned Atlas locally
- [ ] Extraction preserves contracts — N/A, no extraction from the template in this PR
- [ ] Generators are idempotent/additive, AST-safe, and never overwrite user-owned files — N/A, no generator changed. The prefetch *invokes* `gombit new` but only into a `mktemp -d` it deletes; it writes nothing into the checkout
- [ ] API changes regenerate the OpenAPI doc + TS client in this PR — N/A, no API change
- [ ] No secrets in generated frontend source; `VITE_*` is treated as public — N/A, no frontend change
- [x] Scope stays inside this issue's milestone — no M6 "battery" creep
- [x] This PR links its issue and states which acceptance criteria it satisfies

Conformance re-checked against build plan §1–§3/§5 and ADRs 011–015: no locked
decision reopened (zero Go source changed), ADR-012's Community Edition boundary
preserved and the pinned v1.3.0 binary verified to provide `migrate diff`/`apply`/
`status`, D12's nine-job matrix intact and unrenamed (the only job added is
`ci-scripts`), and ADR-015's newly landed `appcontract`/`manifest` code is
`GOPROXY=off`-safe because it parses `go.mod` offline rather than shelling out.