### PR TITLE
[HOST-1] Machine-readable application contract (gombit contract app)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ version.
   of an app — framework version, build command/artifact, runtime port + health
   paths, database driver/requirement, migrations path — for a deployment host to
   consume. Every field is projected from declared config and `go.mod`, never
-  inferred from the source tree; a missing or locally-replaced framework version
-  fails loudly. See [docs/app-contract.md](docs/app-contract.md).
+  inferred from the source tree; a missing or local-path-replaced framework
+  version fails loudly (a version-to-version replace resolves to its target).
+  Adds a declared `Config.Database.Required` (`GOMBIT_DATABASE_REQUIRED`, default
+  `true`) so `database.required` is a real config value, not a proxy for auth.
+  See [docs/app-contract.md](docs/app-contract.md).
 - Runtime health contract (HOST-2,
   [#283](https://github.com/gombit-dev/gombit/issues/283); ADR-015): `/livez`
   and `/readyz` are now a documented, stable host contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ version.
 
 ### Added
 
+- Application contract (HOST-1,
+  [#282](https://github.com/gombit-dev/gombit/issues/282); ADR-015):
+  `gombit contract app` emits a stable, versioned, machine-readable description
+  of an app — framework version, build command/artifact, runtime port + health
+  paths, database driver/requirement, migrations path — for a deployment host to
+  consume. Every field is projected from declared config and `go.mod`, never
+  inferred from the source tree; a missing or locally-replaced framework version
+  fails loudly. See [docs/app-contract.md](docs/app-contract.md).
 - Runtime health contract (HOST-2,
   [#283](https://github.com/gombit-dev/gombit/issues/283); ADR-015): `/livez`
   and `/readyz` are now a documented, stable host contract

--- a/appcontract/appcontract.go
+++ b/appcontract/appcontract.go
@@ -1,0 +1,174 @@
+// Package appcontract projects a stable, machine-readable description of a
+// Gombit application — the HOST-1 application contract (ADR-015). A deployment
+// host (e.g. Gombit Cloud) reads it to learn how to build, health-check, and
+// migrate an ordinary handwritten Gombit app without inferring anything from
+// repository trivia.
+//
+// Every field is projected from the app's *declared* configuration (typed
+// config.Config / gombit.yaml, the resolved framework version, documented
+// defaults) — never guessed by walking the source tree (build plan §10, 6.2).
+// The contract is versioned by ContractVersion, independent of the framework
+// version, so a host can fail loudly on an unknown shape (DESIGN.md §53, §55).
+package appcontract
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// ContractVersion is the schema version of the emitted contract. It is
+// independent of the framework version; bump it only on a breaking shape
+// change, and document the change.
+const ContractVersion = 1
+
+// FrameworkName is the framework a Gombit application contract describes.
+const FrameworkName = "gombit"
+
+// Health probe paths are the stable operational contract from HOST-2
+// (ADR-015, docs/health.md). They are fixed so a host can rely on them.
+const (
+	LivenessPath  = "/livez"
+	ReadinessPath = "/readyz"
+)
+
+// Documented build defaults (build plan M5-5; build.DefaultOut = "bin/server").
+const (
+	DefaultBuildCommand  = "gombit build --embed"
+	DefaultBuildArtifact = "bin/server"
+	// DefaultMigrationsPath mirrors migrations.defaultMigrationDir.
+	DefaultMigrationsPath = "database/migrations"
+)
+
+// Contract is the machine-readable application description (DESIGN.md §9).
+type Contract struct {
+	ContractVersion int        `json:"contract_version"`
+	Framework       Framework  `json:"framework"`
+	Build           Build      `json:"build"`
+	Runtime         Runtime    `json:"runtime"`
+	Database        Database   `json:"database"`
+	Migrations      Migrations `json:"migrations"`
+}
+
+// Framework identifies the framework and the version the app builds against.
+type Framework struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// Build is the command that produces the deployable artifact and where it lands.
+type Build struct {
+	Command  string `json:"command"`
+	Artifact string `json:"artifact"`
+}
+
+// Runtime describes how the built app is run and probed.
+type Runtime struct {
+	HTTPPort int    `json:"http_port"`
+	Health   Health `json:"health"`
+}
+
+// Health is the pair of operational probe paths (HOST-2).
+type Health struct {
+	Live  string `json:"live"`
+	Ready string `json:"ready"`
+}
+
+// Database is the app's datastore dependency. Required is true when the
+// framework refuses to start without a database for the declared configuration.
+type Database struct {
+	Required bool   `json:"required"`
+	Driver   string `json:"driver"`
+}
+
+// Migrations locates the app's versioned migrations.
+type Migrations struct {
+	Path string `json:"path"`
+}
+
+// Inputs are the declared values a Contract is projected from. The CLI maps a
+// typed config.Config onto these; keeping Project free of config keeps it
+// trivially testable and lets a host reuse the type.
+type Inputs struct {
+	// FrameworkVersion the app builds against (e.g. "v0.5.0"). Required — an
+	// empty value is a hard error, never a silent default (DESIGN.md §55).
+	FrameworkVersion string
+	// HTTPAddr is the declared listen address (config.HTTP.Addr, e.g. ":8080").
+	HTTPAddr string
+	// DatabaseDriver is the configured driver (config.Database.Driver).
+	DatabaseDriver string
+	// DatabaseRequired is whether the framework requires a database to start
+	// for this configuration (currently: auth enabled — framework/app.go).
+	DatabaseRequired bool
+	// MigrationsPath locates versioned migrations; DefaultMigrationsPath when "".
+	MigrationsPath string
+	// BuildCommand / BuildArtifact override the documented defaults when set.
+	BuildCommand  string
+	BuildArtifact string
+}
+
+// Project builds the application contract from declared inputs, applying the
+// fixed/default fields. It fails loudly on inputs a host could not act on.
+func Project(in Inputs) (Contract, error) {
+	if in.FrameworkVersion == "" {
+		return Contract{}, errors.New("appcontract: framework version is required")
+	}
+	if in.DatabaseDriver == "" {
+		return Contract{}, errors.New("appcontract: database driver is required")
+	}
+	port, err := parsePort(in.HTTPAddr)
+	if err != nil {
+		return Contract{}, err
+	}
+
+	return Contract{
+		ContractVersion: ContractVersion,
+		Framework: Framework{
+			Name:    FrameworkName,
+			Version: in.FrameworkVersion,
+		},
+		Build: Build{
+			Command:  orDefault(in.BuildCommand, DefaultBuildCommand),
+			Artifact: orDefault(in.BuildArtifact, DefaultBuildArtifact),
+		},
+		Runtime: Runtime{
+			HTTPPort: port,
+			Health: Health{
+				Live:  LivenessPath,
+				Ready: ReadinessPath,
+			},
+		},
+		Database: Database{
+			Required: in.DatabaseRequired,
+			Driver:   in.DatabaseDriver,
+		},
+		Migrations: Migrations{
+			Path: orDefault(in.MigrationsPath, DefaultMigrationsPath),
+		},
+	}, nil
+}
+
+// parsePort extracts the TCP port from a listen address such as ":8080" or
+// "127.0.0.1:8080".
+func parsePort(addr string) (int, error) {
+	if addr == "" {
+		return 0, errors.New("appcontract: http address is required")
+	}
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0, fmt.Errorf("appcontract: parse http address %q: %w", addr, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port < 1 || port > 65535 {
+		return 0, fmt.Errorf("appcontract: http address %q has no valid port", addr)
+	}
+	return port, nil
+}
+
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
+}

--- a/appcontract/appcontract_test.go
+++ b/appcontract/appcontract_test.go
@@ -1,0 +1,119 @@
+package appcontract
+
+import "testing"
+
+func validInputs() Inputs {
+	return Inputs{
+		FrameworkVersion: "v0.5.0",
+		HTTPAddr:         ":8080",
+		DatabaseDriver:   "sqlite",
+	}
+}
+
+func TestProjectFillsFixedAndDefaultFields(t *testing.T) {
+	got, err := Project(validInputs())
+	if err != nil {
+		t.Fatalf("Project() error = %v, want nil", err)
+	}
+
+	if got.ContractVersion != ContractVersion {
+		t.Errorf("contract_version = %d, want %d", got.ContractVersion, ContractVersion)
+	}
+	if got.Framework != (Framework{Name: "gombit", Version: "v0.5.0"}) {
+		t.Errorf("framework = %+v", got.Framework)
+	}
+	if got.Build != (Build{Command: DefaultBuildCommand, Artifact: DefaultBuildArtifact}) {
+		t.Errorf("build = %+v, want documented defaults", got.Build)
+	}
+	if got.Runtime.HTTPPort != 8080 {
+		t.Errorf("http_port = %d, want 8080", got.Runtime.HTTPPort)
+	}
+	if got.Runtime.Health != (Health{Live: "/livez", Ready: "/readyz"}) {
+		t.Errorf("health = %+v, want the HOST-2 probe paths", got.Runtime.Health)
+	}
+	if got.Migrations.Path != DefaultMigrationsPath {
+		t.Errorf("migrations.path = %q, want %q", got.Migrations.Path, DefaultMigrationsPath)
+	}
+}
+
+func TestProjectDatabaseFromInputs(t *testing.T) {
+	in := validInputs()
+	in.DatabaseDriver = "postgres"
+	in.DatabaseRequired = true
+
+	got, err := Project(in)
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if got.Database != (Database{Required: true, Driver: "postgres"}) {
+		t.Errorf("database = %+v, want {true, postgres}", got.Database)
+	}
+}
+
+func TestProjectHonorsBuildAndMigrationsOverrides(t *testing.T) {
+	in := validInputs()
+	in.BuildCommand = "make build"
+	in.BuildArtifact = "dist/app"
+	in.MigrationsPath = "db/migrations"
+
+	got, err := Project(in)
+	if err != nil {
+		t.Fatalf("Project() error = %v", err)
+	}
+	if got.Build.Command != "make build" || got.Build.Artifact != "dist/app" {
+		t.Errorf("build = %+v, want overrides", got.Build)
+	}
+	if got.Migrations.Path != "db/migrations" {
+		t.Errorf("migrations.path = %q, want override", got.Migrations.Path)
+	}
+}
+
+func TestProjectRejectsMissingRequiredInputs(t *testing.T) {
+	tests := map[string]func(*Inputs){
+		"no framework version": func(in *Inputs) { in.FrameworkVersion = "" },
+		"no database driver":   func(in *Inputs) { in.DatabaseDriver = "" },
+		"no http addr":         func(in *Inputs) { in.HTTPAddr = "" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			in := validInputs()
+			mutate(&in)
+			if _, err := Project(in); err == nil {
+				t.Fatalf("Project() error = nil, want error for %s", name)
+			}
+		})
+	}
+}
+
+func TestProjectParsesPort(t *testing.T) {
+	tests := map[string]struct {
+		addr    string
+		want    int
+		wantErr bool
+	}{
+		"bare port":    {":8080", 8080, false},
+		"host+port":    {"127.0.0.1:9000", 9000, false},
+		"no port":      {"localhost", 0, true},
+		"bad port":     {":notaport", 0, true},
+		"out of range": {":70000", 0, true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			in := validInputs()
+			in.HTTPAddr = tc.addr
+			got, err := Project(in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Project(%q) error = nil, want error", tc.addr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Project(%q) error = %v", tc.addr, err)
+			}
+			if got.Runtime.HTTPPort != tc.want {
+				t.Errorf("http_port = %d, want %d", got.Runtime.HTTPPort, tc.want)
+			}
+		})
+	}
+}

--- a/appcontract/modversion.go
+++ b/appcontract/modversion.go
@@ -1,0 +1,124 @@
+package appcontract
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FrameworkModulePath is the module a Gombit application requires.
+const FrameworkModulePath = "github.com/gombit-dev/gombit"
+
+// ErrFrameworkVersionUnresolved is returned when go.mod names the framework but
+// its version cannot be reported as a resolvable module version — a local
+// replace directive (a framework dev checkout) being the common case. A host
+// cannot pin such a build, so this is surfaced rather than guessed.
+var ErrFrameworkVersionUnresolved = errors.New("appcontract: framework version is unresolved (replaced or local)")
+
+// FrameworkVersion reads the version of the Gombit framework the app in workDir
+// builds against, straight from its go.mod require directive. It deliberately
+// parses the *declared* dependency rather than running the go toolchain, so it
+// is offline and deterministic.
+//
+// A replace directive targeting the framework module makes the version
+// unresolvable for a host; that returns ErrFrameworkVersionUnresolved. A go.mod
+// that does not require the framework at all is an error — it is not a Gombit
+// app.
+func FrameworkVersion(workDir string) (string, error) {
+	path := filepath.Join(workDir, "go.mod")
+	data, err := os.ReadFile(path) // #nosec G304 -- go.mod at a caller-provided project dir
+	if err != nil {
+		return "", fmt.Errorf("appcontract: read %s: %w", path, err)
+	}
+	return frameworkVersionFromModfile(string(data))
+}
+
+// frameworkVersionFromModfile extracts the framework require version from go.mod
+// content. Split out for testing without touching the filesystem.
+func frameworkVersionFromModfile(content string) (string, error) {
+	version := ""
+	replaced := false
+
+	inRequireBlock := false
+	inReplaceBlock := false
+
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := stripComment(scanner.Text())
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		switch {
+		case inRequireBlock:
+			if trimmed == ")" {
+				inRequireBlock = false
+				continue
+			}
+			if v, ok := requireVersion(trimmed); ok {
+				version = v
+			}
+		case inReplaceBlock:
+			if trimmed == ")" {
+				inReplaceBlock = false
+				continue
+			}
+			if isFrameworkReplace(trimmed) {
+				replaced = true
+			}
+		case strings.HasPrefix(trimmed, "require ("):
+			inRequireBlock = true
+		case strings.HasPrefix(trimmed, "replace ("):
+			inReplaceBlock = true
+		case strings.HasPrefix(trimmed, "require "):
+			if v, ok := requireVersion(strings.TrimSpace(strings.TrimPrefix(trimmed, "require"))); ok {
+				version = v
+			}
+		case strings.HasPrefix(trimmed, "replace "):
+			if isFrameworkReplace(strings.TrimSpace(strings.TrimPrefix(trimmed, "replace"))) {
+				replaced = true
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("appcontract: scan go.mod: %w", err)
+	}
+
+	if replaced {
+		return "", ErrFrameworkVersionUnresolved
+	}
+	if version == "" {
+		return "", fmt.Errorf("appcontract: go.mod does not require %s", FrameworkModulePath)
+	}
+	return version, nil
+}
+
+// requireVersion returns the version if entry is a require line for the
+// framework module, e.g. "github.com/gombit-dev/gombit v0.5.0".
+func requireVersion(entry string) (string, bool) {
+	fields := strings.Fields(entry)
+	if len(fields) >= 2 && fields[0] == FrameworkModulePath {
+		return fields[1], true
+	}
+	return "", false
+}
+
+// isFrameworkReplace reports whether entry replaces the framework module, e.g.
+// "github.com/gombit-dev/gombit => ../gombit".
+func isFrameworkReplace(entry string) bool {
+	fields := strings.Fields(entry)
+	return len(fields) >= 1 && fields[0] == FrameworkModulePath
+}
+
+// stripComment removes a trailing // comment (e.g. "// indirect") outside of
+// any string, which go.mod lines never contain.
+func stripComment(line string) string {
+	if i := strings.Index(line, "//"); i >= 0 {
+		return line[:i]
+	}
+	return line
+}

--- a/appcontract/modversion.go
+++ b/appcontract/modversion.go
@@ -31,10 +31,11 @@ var semverPattern = regexp.MustCompile(
 // parses the *declared* dependency rather than running the go toolchain, so it
 // is offline and deterministic.
 //
-// A replace directive targeting the framework module makes the version
-// unresolvable for a host; that returns ErrFrameworkVersionUnresolved. A go.mod
-// that does not require the framework at all is an error — it is not a Gombit
-// app.
+// A replace of the framework module wins over the require: a version-to-version
+// replace (or a published fork with a version) reports its target version,
+// while a local filesystem replace is unresolvable for a host and returns
+// ErrFrameworkVersionUnresolved. A go.mod that does not require the framework at
+// all is an error — it is not a Gombit app.
 func FrameworkVersion(workDir string) (string, error) {
 	path := filepath.Join(workDir, "go.mod")
 	data, err := os.ReadFile(path) // #nosec G304 -- go.mod at a caller-provided project dir

--- a/appcontract/modversion.go
+++ b/appcontract/modversion.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -14,9 +15,16 @@ const FrameworkModulePath = "github.com/gombit-dev/gombit"
 
 // ErrFrameworkVersionUnresolved is returned when go.mod names the framework but
 // its version cannot be reported as a resolvable module version — a local
-// replace directive (a framework dev checkout) being the common case. A host
-// cannot pin such a build, so this is surfaced rather than guessed.
-var ErrFrameworkVersionUnresolved = errors.New("appcontract: framework version is unresolved (replaced or local)")
+// filesystem replace directive (a framework dev checkout) being the common
+// case. A host cannot pin such a build, so this is surfaced rather than guessed.
+// A version-to-version replace (e.g. to a published fork) IS resolvable and its
+// target version is reported instead.
+var ErrFrameworkVersionUnresolved = errors.New("appcontract: framework version is unresolved (replaced with a local path)")
+
+// semverPattern matches a canonical module version, including Go
+// pseudo-versions. Mirrors scaffold.semverPattern; build metadata is excluded.
+var semverPattern = regexp.MustCompile(
+	`^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$`)
 
 // FrameworkVersion reads the version of the Gombit framework the app in workDir
 // builds against, straight from its go.mod require directive. It deliberately
@@ -36,19 +44,22 @@ func FrameworkVersion(workDir string) (string, error) {
 	return frameworkVersionFromModfile(string(data))
 }
 
-// frameworkVersionFromModfile extracts the framework require version from go.mod
-// content. Split out for testing without touching the filesystem.
+// frameworkVersionFromModfile extracts the framework version from go.mod
+// content. A replace of the framework module wins over the require: a
+// version-to-version replace reports its target version; a local filesystem
+// replace is unresolvable. Split out for testing without touching the
+// filesystem.
 func frameworkVersionFromModfile(content string) (string, error) {
-	version := ""
-	replaced := false
+	requireVer := ""
+	replaceVer := ""
+	replacedLocal := false
 
 	inRequireBlock := false
 	inReplaceBlock := false
 
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	for scanner.Scan() {
-		line := stripComment(scanner.Text())
-		trimmed := strings.TrimSpace(line)
+		trimmed := strings.TrimSpace(stripComment(scanner.Text()))
 		if trimmed == "" {
 			continue
 		}
@@ -60,41 +71,40 @@ func frameworkVersionFromModfile(content string) (string, error) {
 				continue
 			}
 			if v, ok := requireVersion(trimmed); ok {
-				version = v
+				requireVer = v
 			}
 		case inReplaceBlock:
 			if trimmed == ")" {
 				inReplaceBlock = false
 				continue
 			}
-			if isFrameworkReplace(trimmed) {
-				replaced = true
-			}
+			applyReplace(trimmed, &replaceVer, &replacedLocal)
 		case strings.HasPrefix(trimmed, "require ("):
 			inRequireBlock = true
 		case strings.HasPrefix(trimmed, "replace ("):
 			inReplaceBlock = true
 		case strings.HasPrefix(trimmed, "require "):
-			if v, ok := requireVersion(strings.TrimSpace(strings.TrimPrefix(trimmed, "require"))); ok {
-				version = v
+			if v, ok := requireVersion(strings.TrimSpace(trimmed[len("require"):])); ok {
+				requireVer = v
 			}
 		case strings.HasPrefix(trimmed, "replace "):
-			if isFrameworkReplace(strings.TrimSpace(strings.TrimPrefix(trimmed, "replace"))) {
-				replaced = true
-			}
+			applyReplace(strings.TrimSpace(trimmed[len("replace"):]), &replaceVer, &replacedLocal)
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		return "", fmt.Errorf("appcontract: scan go.mod: %w", err)
 	}
 
-	if replaced {
+	switch {
+	case replacedLocal:
 		return "", ErrFrameworkVersionUnresolved
-	}
-	if version == "" {
+	case replaceVer != "":
+		return replaceVer, nil
+	case requireVer != "":
+		return requireVer, nil
+	default:
 		return "", fmt.Errorf("appcontract: go.mod does not require %s", FrameworkModulePath)
 	}
-	return version, nil
 }
 
 // requireVersion returns the version if entry is a require line for the
@@ -107,11 +117,27 @@ func requireVersion(entry string) (string, bool) {
 	return "", false
 }
 
-// isFrameworkReplace reports whether entry replaces the framework module, e.g.
-// "github.com/gombit-dev/gombit => ../gombit".
-func isFrameworkReplace(entry string) bool {
-	fields := strings.Fields(entry)
-	return len(fields) >= 1 && fields[0] == FrameworkModulePath
+// applyReplace records the effect of a replace directive on the framework
+// module. A version-to-version replace (right-hand side ends in a module
+// version) sets ver; a local filesystem replace (no version) sets local.
+func applyReplace(entry string, ver *string, local *bool) {
+	lhs, rhs, ok := strings.Cut(entry, "=>")
+	if !ok {
+		return
+	}
+	if fields := strings.Fields(lhs); len(fields) == 0 || fields[0] != FrameworkModulePath {
+		return
+	}
+	rhsFields := strings.Fields(rhs)
+	if len(rhsFields) == 0 {
+		*local = true
+		return
+	}
+	if last := rhsFields[len(rhsFields)-1]; semverPattern.MatchString(last) {
+		*ver = last
+		return
+	}
+	*local = true
 }
 
 // stripComment removes a trailing // comment (e.g. "// indirect") outside of

--- a/appcontract/modversion_test.go
+++ b/appcontract/modversion_test.go
@@ -29,13 +29,23 @@ func TestFrameworkVersionFromModfile(t *testing.T) {
 			want:    "v0.0.0-20260818193315-9abb3c6ecc8c",
 			ok:      true,
 		},
-		"local replace is unresolved": {
+		"local path replace is unresolved": {
 			content: "module x\n\nrequire github.com/gombit-dev/gombit v0.5.0\n\nreplace github.com/gombit-dev/gombit => ../gombit\n",
 			wantErr: ErrFrameworkVersionUnresolved,
 		},
-		"block replace is unresolved": {
+		"block local replace is unresolved": {
 			content: "module x\nrequire github.com/gombit-dev/gombit v0.5.0\nreplace (\n\tgithub.com/gombit-dev/gombit => ../gombit\n)\n",
 			wantErr: ErrFrameworkVersionUnresolved,
+		},
+		"version-to-version replace is resolvable": {
+			content: "module x\nrequire github.com/gombit-dev/gombit v0.5.0\nreplace github.com/gombit-dev/gombit v0.5.0 => github.com/gombit-dev/gombit v0.5.1\n",
+			want:    "v0.5.1",
+			ok:      true,
+		},
+		"fork replace with version is resolvable": {
+			content: "module x\nrequire github.com/gombit-dev/gombit v0.5.0\nreplace github.com/gombit-dev/gombit => github.com/fork/gombit v0.6.0\n",
+			want:    "v0.6.0",
+			ok:      true,
 		},
 		"missing framework require": {
 			content: "module x\n\nrequire github.com/gin-gonic/gin v1.10.0\n",

--- a/appcontract/modversion_test.go
+++ b/appcontract/modversion_test.go
@@ -1,0 +1,86 @@
+package appcontract
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFrameworkVersionFromModfile(t *testing.T) {
+	tests := map[string]struct {
+		content string
+		want    string
+		wantErr error // nil = any / none; sentinel = errors.Is match
+		ok      bool
+	}{
+		"block require": {
+			content: "module x\n\ngo 1.25\n\nrequire (\n\tgithub.com/gombit-dev/gombit v0.5.0\n\tgithub.com/gin-gonic/gin v1.10.0 // indirect\n)\n",
+			want:    "v0.5.0",
+			ok:      true,
+		},
+		"single-line require": {
+			content: "module x\n\nrequire github.com/gombit-dev/gombit v0.4.2\n",
+			want:    "v0.4.2",
+			ok:      true,
+		},
+		"pseudo-version": {
+			content: "module x\nrequire github.com/gombit-dev/gombit v0.0.0-20260818193315-9abb3c6ecc8c\n",
+			want:    "v0.0.0-20260818193315-9abb3c6ecc8c",
+			ok:      true,
+		},
+		"local replace is unresolved": {
+			content: "module x\n\nrequire github.com/gombit-dev/gombit v0.5.0\n\nreplace github.com/gombit-dev/gombit => ../gombit\n",
+			wantErr: ErrFrameworkVersionUnresolved,
+		},
+		"block replace is unresolved": {
+			content: "module x\nrequire github.com/gombit-dev/gombit v0.5.0\nreplace (\n\tgithub.com/gombit-dev/gombit => ../gombit\n)\n",
+			wantErr: ErrFrameworkVersionUnresolved,
+		},
+		"missing framework require": {
+			content: "module x\n\nrequire github.com/gin-gonic/gin v1.10.0\n",
+			wantErr: errors.New("not a gombit app"), // any error
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := frameworkVersionFromModfile(tc.content)
+			if tc.ok {
+				if err != nil {
+					t.Fatalf("error = %v, want nil", err)
+				}
+				if got != tc.want {
+					t.Fatalf("version = %q, want %q", got, tc.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("error = nil, want error")
+			}
+			if errors.Is(tc.wantErr, ErrFrameworkVersionUnresolved) && !errors.Is(err, ErrFrameworkVersionUnresolved) {
+				t.Fatalf("error = %v, want ErrFrameworkVersionUnresolved", err)
+			}
+		})
+	}
+}
+
+func TestFrameworkVersionReadsGoMod(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"),
+		[]byte("module x\nrequire github.com/gombit-dev/gombit v0.5.1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := FrameworkVersion(dir)
+	if err != nil {
+		t.Fatalf("FrameworkVersion() error = %v", err)
+	}
+	if got != "v0.5.1" {
+		t.Fatalf("version = %q, want v0.5.1", got)
+	}
+}
+
+func TestFrameworkVersionMissingGoMod(t *testing.T) {
+	if _, err := FrameworkVersion(t.TempDir()); err == nil {
+		t.Fatal("FrameworkVersion() error = nil, want error for missing go.mod")
+	}
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -61,6 +61,7 @@ func writeConfigShow(w io.Writer, cfg config.Config) error {
 		{"API.Prefix", cfg.API.Prefix},
 		{"API.DocsEnabled", strconv.FormatBool(cfg.API.DocsEnabled)},
 		{"Database.Driver", string(cfg.Database.Driver)},
+		{"Database.Required", strconv.FormatBool(cfg.Database.Required)},
 		{"Database.DSN", cfg.Database.DSN},
 		{"Database.MaxOpenConns", strconv.Itoa(cfg.Database.MaxOpenConns)},
 		{"Database.MaxIdleConns", strconv.Itoa(cfg.Database.MaxIdleConns)},

--- a/cli/contract.go
+++ b/cli/contract.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/gombit-dev/gombit/appcontract"
+	"github.com/spf13/cobra"
+)
+
+func newContractCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
+	cmd := silence(&cobra.Command{
+		Use:   "contract",
+		Short: "Application contract commands",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			contractUsage(stderr)
+			if len(args) == 0 {
+				return errors.New("gombit contract: subcommand is required")
+			}
+			return fmt.Errorf("gombit contract: unknown subcommand %q", args[0])
+		},
+	})
+	cmd.AddCommand(newContractAppCommand(stdout, stderr))
+	return cmd
+}
+
+func newContractAppCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
+	cmd := silence(&cobra.Command{
+		Use:   "app",
+		Short: "Emit the machine-readable application contract (HOST-1)",
+		Long: `Emit the machine-readable application contract (ADR-015 / HOST-1).
+
+The contract describes how a deployment host builds, health-checks, and
+migrates this app. Every field is projected from declared configuration
+(gombit.yaml / config.Load and the framework version in go.mod) — nothing is
+inferred from the source tree. Writes JSON to stdout, or to --out.`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("gombit contract app: unexpected argument %q", args[0])
+			}
+			dir, err := cmd.Flags().GetString("dir")
+			if err != nil {
+				return err
+			}
+			out, err := cmd.Flags().GetString("out")
+			if err != nil {
+				return err
+			}
+			return runContractApp(stdout, dir, out)
+		},
+	})
+	cmd.Flags().String("dir", ".", "project directory whose go.mod names the framework version (run from the project root; config is read from the environment)")
+	cmd.Flags().String("out", "", "output path for the contract JSON (default: stdout)")
+	return cmd
+}
+
+func runContractApp(stdout io.Writer, dir string, out string) error {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	version, err := appcontract.FrameworkVersion(dir)
+	if err != nil {
+		if errors.Is(err, appcontract.ErrFrameworkVersionUnresolved) {
+			return fmt.Errorf("gombit contract app: %w; a host cannot pin a replaced/local "+
+				"framework version — build against a published %s release", err, appcontract.FrameworkModulePath)
+		}
+		return fmt.Errorf("gombit contract app: %w", err)
+	}
+
+	contract, err := appcontract.Project(appcontract.Inputs{
+		FrameworkVersion: version,
+		HTTPAddr:         cfg.HTTP.Addr,
+		DatabaseDriver:   string(cfg.Database.Driver),
+		DatabaseRequired: cfg.Auth.Enabled(),
+	})
+	if err != nil {
+		return fmt.Errorf("gombit contract app: %w", err)
+	}
+
+	data, err := json.MarshalIndent(contract, "", "  ")
+	if err != nil {
+		return fmt.Errorf("gombit contract app: marshal contract: %w", err)
+	}
+	data = append(data, '\n')
+
+	if out == "" {
+		_, err = stdout.Write(data)
+		return err
+	}
+	if err := os.WriteFile(out, data, 0o600); err != nil {
+		return fmt.Errorf("gombit contract app: write %s: %w", out, err)
+	}
+	_, err = fmt.Fprintf(stdout, "wrote application contract to %s\n", out)
+	return err
+}
+
+func contractUsage(stderr io.Writer) {
+	_, _ = fmt.Fprintln(stderr, "Usage: gombit contract <subcommand>")
+	_, _ = fmt.Fprintln(stderr, "  app    Emit the machine-readable application contract")
+}

--- a/cli/contract.go
+++ b/cli/contract.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/gombit-dev/gombit/appcontract"
 	"github.com/spf13/cobra"
@@ -36,8 +37,9 @@ func newContractAppCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
 
 The contract describes how a deployment host builds, health-checks, and
 migrates this app. Every field is projected from declared configuration
-(gombit.yaml / config.Load and the framework version in go.mod) — nothing is
-inferred from the source tree. Writes JSON to stdout, or to --out.`,
+(config/.env and the framework version in go.mod) — nothing is inferred from
+the source tree. --dir selects the project directory that both the config
+(.env) and go.mod are read from. Writes JSON to stdout, or to --out.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
@@ -54,18 +56,36 @@ inferred from the source tree. Writes JSON to stdout, or to --out.`,
 			return runContractApp(stdout, dir, out)
 		},
 	})
-	cmd.Flags().String("dir", ".", "project directory whose go.mod names the framework version (run from the project root; config is read from the environment)")
+	cmd.Flags().String("dir", ".", "project directory both go.mod and config (.env) are read from")
 	cmd.Flags().String("out", "", "output path for the contract JSON (default: stdout)")
 	return cmd
 }
 
 func runContractApp(stdout io.Writer, dir string, out string) error {
+	// Resolve the output path before changing directory so a relative --out
+	// stays relative to the caller's cwd, not the project dir.
+	if out != "" {
+		abs, err := filepath.Abs(out)
+		if err != nil {
+			return fmt.Errorf("gombit contract app: resolve --out: %w", err)
+		}
+		out = abs
+	}
+
+	// Read config (.env) and go.mod from the same project directory so the
+	// contract cannot mix one app's go.mod with another's config.
+	restore, err := chdir(dir)
+	if err != nil {
+		return fmt.Errorf("gombit contract app: %w", err)
+	}
+	defer restore()
+
 	cfg, err := LoadConfig()
 	if err != nil {
 		return err
 	}
 
-	version, err := appcontract.FrameworkVersion(dir)
+	version, err := appcontract.FrameworkVersion(".")
 	if err != nil {
 		if errors.Is(err, appcontract.ErrFrameworkVersionUnresolved) {
 			return fmt.Errorf("gombit contract app: %w; a host cannot pin a replaced/local "+
@@ -78,7 +98,7 @@ func runContractApp(stdout io.Writer, dir string, out string) error {
 		FrameworkVersion: version,
 		HTTPAddr:         cfg.HTTP.Addr,
 		DatabaseDriver:   string(cfg.Database.Driver),
-		DatabaseRequired: cfg.Auth.Enabled(),
+		DatabaseRequired: cfg.Database.Required,
 	})
 	if err != nil {
 		return fmt.Errorf("gombit contract app: %w", err)
@@ -99,6 +119,22 @@ func runContractApp(stdout io.Writer, dir string, out string) error {
 	}
 	_, err = fmt.Fprintf(stdout, "wrote application contract to %s\n", out)
 	return err
+}
+
+// chdir changes into dir and returns a function that restores the previous
+// working directory. A "" or "." dir is a no-op so the caller stays in cwd.
+func chdir(dir string) (func(), error) {
+	if dir == "" || dir == "." {
+		return func() {}, nil
+	}
+	prev, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chdir(dir); err != nil {
+		return nil, err
+	}
+	return func() { _ = os.Chdir(prev) }, nil
 }
 
 func contractUsage(stderr io.Writer) {

--- a/cli/contract.go
+++ b/cli/contract.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/gombit-dev/gombit/appcontract"
 	"github.com/spf13/cobra"
@@ -62,30 +61,15 @@ the source tree. --dir selects the project directory that both the config
 }
 
 func runContractApp(stdout io.Writer, dir string, out string) error {
-	// Resolve the output path before changing directory so a relative --out
-	// stays relative to the caller's cwd, not the project dir.
-	if out != "" {
-		abs, err := filepath.Abs(out)
-		if err != nil {
-			return fmt.Errorf("gombit contract app: resolve --out: %w", err)
-		}
-		out = abs
-	}
-
 	// Read config (.env) and go.mod from the same project directory so the
-	// contract cannot mix one app's go.mod with another's config.
-	restore, err := chdir(dir)
-	if err != nil {
-		return fmt.Errorf("gombit contract app: %w", err)
-	}
-	defer restore()
-
-	cfg, err := LoadConfig()
+	// contract cannot mix one app's go.mod with another's config — without
+	// mutating the process (no chdir), which would race parallel callers.
+	cfg, err := LoadConfigFromDir(dir)
 	if err != nil {
 		return err
 	}
 
-	version, err := appcontract.FrameworkVersion(".")
+	version, err := appcontract.FrameworkVersion(dir)
 	if err != nil {
 		if errors.Is(err, appcontract.ErrFrameworkVersionUnresolved) {
 			return fmt.Errorf("gombit contract app: %w; a host cannot pin a replaced/local "+
@@ -119,22 +103,6 @@ func runContractApp(stdout io.Writer, dir string, out string) error {
 	}
 	_, err = fmt.Fprintf(stdout, "wrote application contract to %s\n", out)
 	return err
-}
-
-// chdir changes into dir and returns a function that restores the previous
-// working directory. A "" or "." dir is a no-op so the caller stays in cwd.
-func chdir(dir string) (func(), error) {
-	if dir == "" || dir == "." {
-		return func() {}, nil
-	}
-	prev, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	if err := os.Chdir(dir); err != nil {
-		return nil, err
-	}
-	return func() { _ = os.Chdir(prev) }, nil
 }
 
 func contractUsage(stderr io.Writer) {

--- a/cli/contract_test.go
+++ b/cli/contract_test.go
@@ -1,0 +1,153 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gombit-dev/gombit/config"
+)
+
+func stubLoadConfig(t *testing.T, cfg config.Config) {
+	t.Helper()
+	prev := LoadConfig
+	t.Cleanup(func() { LoadConfig = prev })
+	LoadConfig = func() (config.Config, error) { return cfg, nil }
+}
+
+func writeGoMod(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+type appContractJSON struct {
+	ContractVersion int `json:"contract_version"`
+	Framework       struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	} `json:"framework"`
+	Runtime struct {
+		HTTPPort int `json:"http_port"`
+		Health   struct {
+			Live  string `json:"live"`
+			Ready string `json:"ready"`
+		} `json:"health"`
+	} `json:"runtime"`
+	Database struct {
+		Required bool   `json:"required"`
+		Driver   string `json:"driver"`
+	} `json:"database"`
+}
+
+func TestRunContractAppEmitsProjectedJSON(t *testing.T) {
+	cfg := config.Default()
+	cfg.HTTP.Addr = ":8080"
+	cfg.Database.Driver = config.DatabaseDriverPostgres
+	stubLoadConfig(t, cfg)
+	dir := writeGoMod(t, "module x\nrequire github.com/gombit-dev/gombit v0.5.0\n")
+
+	var out bytes.Buffer
+	if err := runContractApp(&out, dir, ""); err != nil {
+		t.Fatalf("runContractApp() error = %v", err)
+	}
+
+	var got appContractJSON
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal contract %q: %v", out.String(), err)
+	}
+	if got.ContractVersion != 1 {
+		t.Errorf("contract_version = %d, want 1", got.ContractVersion)
+	}
+	if got.Framework.Name != "gombit" || got.Framework.Version != "v0.5.0" {
+		t.Errorf("framework = %+v, want {gombit v0.5.0}", got.Framework)
+	}
+	if got.Runtime.HTTPPort != 8080 {
+		t.Errorf("http_port = %d, want 8080", got.Runtime.HTTPPort)
+	}
+	if got.Runtime.Health.Live != "/livez" || got.Runtime.Health.Ready != "/readyz" {
+		t.Errorf("health = %+v, want /livez + /readyz", got.Runtime.Health)
+	}
+	if got.Database.Driver != "postgres" {
+		t.Errorf("database.driver = %q, want postgres", got.Database.Driver)
+	}
+	// Auth disabled → framework does not require a database to boot.
+	if got.Database.Required {
+		t.Error("database.required = true, want false when auth is disabled")
+	}
+}
+
+func TestRunContractAppRequiredWhenAuthEnabled(t *testing.T) {
+	cfg := config.Default()
+	cfg.Auth.JWTSecret = "a-sufficiently-long-development-jwt-secret"
+	if !cfg.Auth.Enabled() {
+		t.Fatal("precondition: auth should be enabled with a JWT secret set")
+	}
+	stubLoadConfig(t, cfg)
+	dir := writeGoMod(t, "module x\nrequire github.com/gombit-dev/gombit v0.5.0\n")
+
+	var out bytes.Buffer
+	if err := runContractApp(&out, dir, ""); err != nil {
+		t.Fatalf("runContractApp() error = %v", err)
+	}
+	var got appContractJSON
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Database.Required {
+		t.Error("database.required = false, want true when auth is enabled")
+	}
+}
+
+func TestRunContractAppWritesFile(t *testing.T) {
+	stubLoadConfig(t, config.Default())
+	dir := writeGoMod(t, "module x\nrequire github.com/gombit-dev/gombit v0.5.0\n")
+	outPath := filepath.Join(t.TempDir(), "app.json")
+
+	var stdout bytes.Buffer
+	if err := runContractApp(&stdout, dir, outPath); err != nil {
+		t.Fatalf("runContractApp() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), outPath) {
+		t.Errorf("stdout = %q, want mention of %q", stdout.String(), outPath)
+	}
+	data, err := os.ReadFile(outPath) // #nosec G304 -- outPath is a t.TempDir path in this test.
+	if err != nil {
+		t.Fatalf("read out file: %v", err)
+	}
+	var got appContractJSON
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal file: %v", err)
+	}
+	if got.ContractVersion != 1 {
+		t.Errorf("contract_version = %d, want 1", got.ContractVersion)
+	}
+}
+
+func TestRunContractAppUnresolvedFrameworkFailsLoudly(t *testing.T) {
+	stubLoadConfig(t, config.Default())
+	dir := writeGoMod(t, "module x\nrequire github.com/gombit-dev/gombit v0.5.0\nreplace github.com/gombit-dev/gombit => ../gombit\n")
+
+	var out bytes.Buffer
+	err := runContractApp(&out, dir, "")
+	if err == nil {
+		t.Fatal("runContractApp() error = nil, want error for replaced framework")
+	}
+	if !strings.Contains(err.Error(), "unresolved") {
+		t.Errorf("error = %v, want it to explain the unresolved version", err)
+	}
+}
+
+func TestRunContractAppMissingGoModFails(t *testing.T) {
+	stubLoadConfig(t, config.Default())
+	var out bytes.Buffer
+	if err := runContractApp(&out, t.TempDir(), ""); err == nil {
+		t.Fatal("runContractApp() error = nil, want error for missing go.mod")
+	}
+}

--- a/cli/contract_test.go
+++ b/cli/contract_test.go
@@ -13,9 +13,9 @@ import (
 
 func stubLoadConfig(t *testing.T, cfg config.Config) {
 	t.Helper()
-	prev := LoadConfig
-	t.Cleanup(func() { LoadConfig = prev })
-	LoadConfig = func() (config.Config, error) { return cfg, nil }
+	prev := LoadConfigFromDir
+	t.Cleanup(func() { LoadConfigFromDir = prev })
+	LoadConfigFromDir = func(string) (config.Config, error) { return cfg, nil }
 }
 
 func writeGoMod(t *testing.T, content string) string {

--- a/cli/contract_test.go
+++ b/cli/contract_test.go
@@ -47,7 +47,7 @@ type appContractJSON struct {
 }
 
 func TestRunContractAppEmitsProjectedJSON(t *testing.T) {
-	cfg := config.Default()
+	cfg := config.Default() // Database.Required defaults to true
 	cfg.HTTP.Addr = ":8080"
 	cfg.Database.Driver = config.DatabaseDriverPostgres
 	stubLoadConfig(t, cfg)
@@ -77,18 +77,16 @@ func TestRunContractAppEmitsProjectedJSON(t *testing.T) {
 	if got.Database.Driver != "postgres" {
 		t.Errorf("database.driver = %q, want postgres", got.Database.Driver)
 	}
-	// Auth disabled → framework does not require a database to boot.
-	if got.Database.Required {
-		t.Error("database.required = true, want false when auth is disabled")
+	if !got.Database.Required {
+		t.Error("database.required = false, want true (the default) — a postgres app needs a datastore")
 	}
 }
 
-func TestRunContractAppRequiredWhenAuthEnabled(t *testing.T) {
+func TestRunContractAppRequiredReflectsConfig(t *testing.T) {
+	// database.required is a declared config value, not a proxy for auth: an app
+	// that opts out reports false even with a driver configured.
 	cfg := config.Default()
-	cfg.Auth.JWTSecret = "a-sufficiently-long-development-jwt-secret"
-	if !cfg.Auth.Enabled() {
-		t.Fatal("precondition: auth should be enabled with a JWT secret set")
-	}
+	cfg.Database.Required = false
 	stubLoadConfig(t, cfg)
 	dir := writeGoMod(t, "module x\nrequire github.com/gombit-dev/gombit v0.5.0\n")
 
@@ -100,8 +98,8 @@ func TestRunContractAppRequiredWhenAuthEnabled(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
 		t.Fatal(err)
 	}
-	if !got.Database.Required {
-		t.Error("database.required = false, want true when auth is enabled")
+	if got.Database.Required {
+		t.Error("database.required = true, want false when the app declares it does not need a database")
 	}
 }
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -19,6 +19,11 @@ type Command = cobra.Command
 // dev. Tests may replace it.
 var LoadConfig = config.Load
 
+// LoadConfigFromDir loads configuration for a specific project directory
+// without mutating the process (see config.LoadFromDir). Used by
+// gombit contract app --dir. A test var so commands can stub it.
+var LoadConfigFromDir = config.LoadFromDir
+
 // AddCommand attaches cmds to root via Cobra AddCommand. This is the only
 // supported registration path for app-owned management commands.
 func AddCommand(root *Command, cmds ...*Command) {

--- a/cli/root.go
+++ b/cli/root.go
@@ -64,6 +64,7 @@ func NewRoot(stdout io.Writer, stderr io.Writer) *Command {
 	root.AddCommand(newMakeCommand(stdout, stderr))
 	root.AddCommand(newDBCommand(stdout, stderr))
 	root.AddCommand(newOpenAPICommand(stdout, stderr))
+	root.AddCommand(newContractCommand(stdout, stderr))
 	root.AddCommand(newClientCommand(stdout, stderr))
 	root.AddCommand(newRoutesCommand(stdout, stderr))
 	root.AddCommand(newDoctorCommand(stdout))

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ const (
 	envAPIPrefix               = "GOMBIT_API_PREFIX"
 	envDocsEnabled             = "GOMBIT_DOCS_ENABLED"
 	envDatabaseDriver          = "GOMBIT_DATABASE_DRIVER"
+	envDatabaseRequired        = "GOMBIT_DATABASE_REQUIRED"
 	envDatabaseDSN             = "GOMBIT_DATABASE_DSN"
 	envDatabaseMaxOpenConns    = "GOMBIT_DATABASE_MAX_OPEN_CONNS"
 	envDatabaseMaxIdleConns    = "GOMBIT_DATABASE_MAX_IDLE_CONNS"
@@ -121,7 +122,13 @@ const (
 
 // DatabaseConfig contains SQL database configuration consumed by database.Open.
 type DatabaseConfig struct {
-	Driver          DatabaseDriver
+	Driver DatabaseDriver
+	// Required declares whether the application needs a database to function —
+	// the signal a deployment host uses to decide whether to provision one
+	// (surfaced in the HOST-1 application contract). Defaults to true because a
+	// Gombit app is database-backed by default; set it false for an app that
+	// runs without one. It does not itself force a database at startup.
+	Required        bool
 	DSN             string
 	MaxOpenConns    int
 	MaxIdleConns    int
@@ -307,8 +314,9 @@ func DefaultFor(env Environment) Config {
 			DocsEnabled: DefaultDocsEnabled(env),
 		},
 		Database: DatabaseConfig{
-			Driver: DatabaseDriverSQLite,
-			DSN:    "file:gombit.db?cache=shared&_fk=1",
+			Driver:   DatabaseDriverSQLite,
+			Required: true,
+			DSN:      "file:gombit.db?cache=shared&_fk=1",
 		},
 		Cache: CacheConfig{
 			Driver:    CacheDriverMemory,
@@ -385,6 +393,7 @@ func LoadFromEnv(lookup EnvLookup) (Config, error) {
 		&errs,
 	)
 	applyDatabaseDriver(lookup, envDatabaseDriver, &cfg.Database.Driver)
+	applyBool(lookup, envDatabaseRequired, "Database.Required", &cfg.Database.Required, &errs)
 	applyString(lookup, envDatabaseDSN, &cfg.Database.DSN)
 	applyInt(lookup, envDatabaseMaxOpenConns, "Database.MaxOpenConns", &cfg.Database.MaxOpenConns, &errs)
 	applyInt(lookup, envDatabaseMaxIdleConns, "Database.MaxIdleConns", &cfg.Database.MaxIdleConns, &errs)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -126,6 +126,7 @@ func TestLoadFromEnv(t *testing.T) {
 		},
 		Database: DatabaseConfig{
 			Driver:          DatabaseDriverPostgres,
+			Required:        true,
 			DSN:             "host=localhost user=gombit dbname=app sslmode=disable",
 			MaxOpenConns:    20,
 			MaxIdleConns:    4,
@@ -288,8 +289,9 @@ func TestLoadUsesProcessEnvironment(t *testing.T) {
 			DocsEnabled: false,
 		},
 		Database: DatabaseConfig{
-			Driver: DatabaseDriverMySQL,
-			DSN:    "gombit@tcp(localhost:3306)/app?parseTime=true",
+			Driver:   DatabaseDriverMySQL,
+			Required: true,
+			DSN:      "gombit@tcp(localhost:3306)/app?parseTime=true",
 		},
 		Cache: CacheConfig{
 			Driver:    CacheDriverMemory,
@@ -849,6 +851,20 @@ func TestLoadFromEnvReturnsParseErrors(t *testing.T) {
 	}
 	if len(fieldErrors) != 4 {
 		t.Fatalf("LoadFromEnv() field error count = %d, want 4", len(fieldErrors))
+	}
+}
+
+func TestDatabaseRequiredDefaultsTrueAndOverrides(t *testing.T) {
+	if !Default().Database.Required {
+		t.Fatal("Default().Database.Required = false, want true")
+	}
+
+	cfg, err := LoadFromEnv(mapLookup(map[string]string{envDatabaseRequired: "false"}))
+	if err != nil {
+		t.Fatalf("LoadFromEnv() error = %v", err)
+	}
+	if cfg.Database.Required {
+		t.Error("Database.Required = true with GOMBIT_DATABASE_REQUIRED=false, want false")
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -865,6 +867,46 @@ func TestDatabaseRequiredDefaultsTrueAndOverrides(t *testing.T) {
 	}
 	if cfg.Database.Required {
 		t.Error("Database.Required = true with GOMBIT_DATABASE_REQUIRED=false, want false")
+	}
+}
+
+func TestLoadFromDirReadsDotEnvWithoutMutatingProcess(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"),
+		[]byte("GOMBIT_HTTP_ADDR=:9999\nGOMBIT_DATABASE_REQUIRED=false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadFromDir() error = %v", err)
+	}
+	if cfg.HTTP.Addr != ":9999" {
+		t.Errorf("HTTP.Addr = %q, want :9999 (from dir/.env)", cfg.HTTP.Addr)
+	}
+	if cfg.Database.Required {
+		t.Error("Database.Required = true, want false (from dir/.env)")
+	}
+
+	// The dir's .env must not leak into the process environment.
+	if _, set := os.LookupEnv("GOMBIT_HTTP_ADDR"); set {
+		t.Error("LoadFromDir set GOMBIT_HTTP_ADDR in the process environment")
+	}
+}
+
+func TestLoadFromDirProcessEnvWins(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("GOMBIT_HTTP_ADDR=:1111\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOMBIT_HTTP_ADDR", ":2222")
+
+	cfg, err := LoadFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadFromDir() error = %v", err)
+	}
+	if cfg.HTTP.Addr != ":2222" {
+		t.Errorf("HTTP.Addr = %q, want :2222 (process env wins over dir/.env)", cfg.HTTP.Addr)
 	}
 }
 

--- a/config/dotenv.go
+++ b/config/dotenv.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bufio"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -18,23 +19,54 @@ const dotEnvFile = ".env"
 // deployment sets variables through its own environment and never ships a
 // .env file (it is gitignored by every gombit new scaffold).
 func loadDotEnv() {
-	f, err := os.Open(dotEnvFile)
+	for key, value := range dotEnvValues(dotEnvFile) {
+		if _, set := os.LookupEnv(key); set {
+			continue
+		}
+		_ = os.Setenv(key, value)
+	}
+}
+
+// LoadFromDir reads configuration for the project rooted at dir. It applies
+// dir/.env with the process environment taking precedence (as Load does for
+// cwd), then reads and validates. Unlike Load it never mutates the process
+// environment or the working directory, so it is safe under concurrency and
+// for tooling that inspects a directory other than cwd — e.g. gombit contract
+// app --dir.
+func LoadFromDir(dir string) (Config, error) {
+	fileEnv := dotEnvValues(filepath.Join(dir, dotEnvFile))
+	lookup := func(key string) (string, bool) {
+		if v, ok := os.LookupEnv(key); ok {
+			return v, true
+		}
+		v, ok := fileEnv[key]
+		return v, ok
+	}
+	return LoadFromEnv(lookup)
+}
+
+// dotEnvValues parses KEY=VALUE pairs from the .env file at path, first
+// occurrence winning. A missing file yields nil. It never touches the process
+// environment.
+func dotEnvValues(path string) map[string]string {
+	f, err := os.Open(path) // #nosec G304 -- .env at a caller-provided project dir
 	if err != nil {
-		return
+		return nil
 	}
 	defer func() { _ = f.Close() }()
 
+	values := map[string]string{}
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		key, value, ok := parseDotEnvLine(scanner.Text())
 		if !ok {
 			continue
 		}
-		if _, set := os.LookupEnv(key); set {
-			continue
+		if _, exists := values[key]; !exists {
+			values[key] = value
 		}
-		_ = os.Setenv(key, value)
 	}
+	return values
 }
 
 // parseDotEnvLine parses a single KEY=VALUE line, skipping blanks and `#`

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ New here? [Install](installation.md), then work through the
 | Doc | What it covers |
 | --- | --- |
 | [contract.md](contract.md) | Huma DTO and validation conventions, the D10 response envelope |
+| [app-contract.md](app-contract.md) | The machine-readable application contract for deployment hosts (`gombit contract app`) |
 | [openapi.md](openapi.md) | OpenAPI 3.1 emission and the `/docs` UI |
 | [client.md](client.md) | TypeScript client generation and the contract drift check |
 

--- a/docs/app-contract.md
+++ b/docs/app-contract.md
@@ -33,7 +33,10 @@ gombit contract app --dir ./path/to/project
 
 Gombit projects the contract from configuration the app already declares — it
 never guesses by scanning files, directory names, or README text (build plan
-§10, principle 6.2):
+§10, principle 6.2). `--dir` selects one project directory that **both** the
+config (`.env`) and `go.mod` are read from, so a monorepo cannot mix one app's
+`go.mod` with another's config (process `GOMBIT_*` env still applies, as it
+would at runtime):
 
 | Field | Source |
 | --- | --- |
@@ -43,7 +46,7 @@ never guesses by scanning files, directory names, or README text (build plan
 | `runtime.http_port` | The port of `config.HTTP.Addr` (`gombit.yaml` / `GOMBIT_HTTP_ADDR`). |
 | `runtime.health` | The fixed `/livez` + `/readyz` probes (HOST-2, [health.md](health.md)). |
 | `database.driver` | `config.Database.Driver`. |
-| `database.required` | `true` when the framework refuses to start without a database for this configuration — currently when **auth is enabled** (a Gombit app with auth requires a database). The `driver` is reported either way; a host may still provision a database for an app that uses one without auth. |
+| `database.required` | The declared `config.Database.Required` (`GOMBIT_DATABASE_REQUIRED`, default `true`) — whether a host must provision a database for this app. It is a real config value, not a proxy for auth; an app that needs no database sets it `false`. |
 | `migrations.path` | The versioned-migrations directory (`database/migrations`). |
 
 ## Failure is loud

--- a/docs/app-contract.md
+++ b/docs/app-contract.md
@@ -24,7 +24,7 @@ gombit contract app --dir ./path/to/project
     "http_port": 8080,
     "health": { "live": "/livez", "ready": "/readyz" }
   },
-  "database": { "required": false, "driver": "sqlite" },
+  "database": { "required": true, "driver": "sqlite" },
   "migrations": { "path": "database/migrations" }
 }
 ```

--- a/docs/app-contract.md
+++ b/docs/app-contract.md
@@ -1,0 +1,65 @@
+# Application contract
+
+The **application contract** is a stable, machine-readable description of a
+Gombit app that a deployment host (a container platform, CI, or
+[Gombit Cloud](adr/015-host-deployment-contracts.md)) reads to learn how to
+**build, health-check, and migrate** the app — without inferring anything from
+the source tree. It is the HOST-1 contract from
+[ADR-015](adr/015-host-deployment-contracts.md).
+
+```bash
+gombit contract app          # print the contract to stdout
+gombit contract app --out app.json
+gombit contract app --dir ./path/to/project
+```
+
+## Output
+
+```json
+{
+  "contract_version": 1,
+  "framework": { "name": "gombit", "version": "v0.5.0" },
+  "build": { "command": "gombit build --embed", "artifact": "bin/server" },
+  "runtime": {
+    "http_port": 8080,
+    "health": { "live": "/livez", "ready": "/readyz" }
+  },
+  "database": { "required": false, "driver": "sqlite" },
+  "migrations": { "path": "database/migrations" }
+}
+```
+
+## Every field is *declared*, never inferred
+
+Gombit projects the contract from configuration the app already declares — it
+never guesses by scanning files, directory names, or README text (build plan
+§10, principle 6.2):
+
+| Field | Source |
+| --- | --- |
+| `contract_version` | The schema version this Gombit emits. Independent of the framework version, so a host can fail loudly on an unknown shape. |
+| `framework.version` | The `github.com/gombit-dev/gombit` **require** directive in the project's `go.mod`. |
+| `build.command` / `artifact` | The documented production build (`gombit build --embed`, `bin/server`). |
+| `runtime.http_port` | The port of `config.HTTP.Addr` (`gombit.yaml` / `GOMBIT_HTTP_ADDR`). |
+| `runtime.health` | The fixed `/livez` + `/readyz` probes (HOST-2, [health.md](health.md)). |
+| `database.driver` | `config.Database.Driver`. |
+| `database.required` | `true` when the framework refuses to start without a database for this configuration — currently when **auth is enabled** (a Gombit app with auth requires a database). The `driver` is reported either way; a host may still provision a database for an app that uses one without auth. |
+| `migrations.path` | The versioned-migrations directory (`database/migrations`). |
+
+## Failure is loud
+
+`gombit contract app` does not emit a half-true contract:
+
+- If `go.mod` does not require `github.com/gombit-dev/gombit`, it is not a
+  Gombit app — error.
+- If a **replace** directive points the framework at a local checkout, the
+  version is unresolvable for a host — error, with guidance to build against a
+  published release. Pin a real release before generating a contract a host
+  will consume.
+
+## Stability
+
+`contract_version` is bumped only on a breaking shape change, documented in the
+CHANGELOG. See [ADR-015](adr/015-host-deployment-contracts.md) for the decision
+and how this relates to the health convention (HOST-2) and the migration safety
+manifest (HOST-3).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,7 @@ go run ./cmd/gombit --help
 | `gombit make command` | Scaffold a Cobra management command (AST-safe) | M4-7 |
 | `gombit db …` | Atlas-backed migrations | M2, migrated onto Cobra in M4-1 |
 | `gombit openapi generate` | Write the live OpenAPI 3.1 document | M3-3 |
+| `gombit contract app` | Emit the machine-readable application contract | HOST-1 |
 | `gombit client generate` / `check` | TypeScript client + drift | M3-4, M3-5 |
 | `gombit routes` | Print HTTP routes | M4-4 |
 | `gombit doctor` | Environment and config checks | M4-4 |
@@ -633,3 +634,12 @@ See [installation.md](installation.md) and [releasing.md](releasing.md).
 ## `gombit openapi` and `gombit client`
 
 See [openapi.md](openapi.md) and [client.md](client.md).
+
+## `gombit contract app`
+
+Emits the machine-readable **application contract** (HOST-1) — how a deployment
+host builds, health-checks, and migrates the app, projected from declared
+config and `go.mod`, never inferred from the source tree. Writes JSON to stdout
+or `--out`; `--dir` selects the project directory. Fails loudly when the
+framework version is missing or replaced by a local checkout. See
+[app-contract.md](app-contract.md).

--- a/docs/config.md
+++ b/docs/config.md
@@ -46,6 +46,7 @@ recognizes:
 | `GOMBIT_API_PREFIX` | `Config.API.Prefix` | `/api/v1` |
 | `GOMBIT_DOCS_ENABLED` | `Config.API.DocsEnabled` | `true` (off in production when unset) |
 | `GOMBIT_DATABASE_DRIVER` | `Config.Database.Driver` | `sqlite` |
+| `GOMBIT_DATABASE_REQUIRED` | `Config.Database.Required` | `true` |
 | `GOMBIT_DATABASE_DSN` | `Config.Database.DSN` | `file:gombit.db?cache=shared&_fk=1` |
 | `GOMBIT_DATABASE_MAX_OPEN_CONNS` | `Config.Database.MaxOpenConns` | `0` |
 | `GOMBIT_DATABASE_MAX_IDLE_CONNS` | `Config.Database.MaxIdleConns` | `0` |


### PR DESCRIPTION
## Summary

Implements **HOST-1** (ADR-015): `gombit contract app` emits a stable, versioned, machine-readable description of a Gombit app that a deployment host (Gombit Cloud, a container platform, CI) reads to **build, health-check, and migrate** it — without inferring anything from the source tree.

```json
{
  "contract_version": 1,
  "framework": { "name": "gombit", "version": "v0.5.0" },
  "build": { "command": "gombit build --embed", "artifact": "bin/server" },
  "runtime": { "http_port": 8080, "health": { "live": "/livez", "ready": "/readyz" } },
  "database": { "required": true, "driver": "sqlite" },
  "migrations": { "path": "database/migrations" }
}
```

- New `appcontract` package: the versioned `Contract` schema + a `Project` built from declared inputs only (decoupled from `config` so a host can reuse the type).
- `FrameworkVersion` reads the version from the project's `go.mod` require directive — offline, deterministic. A **local-path** replace is surfaced as unresolved; a **version-to-version / published-fork** replace resolves to its target.
- Fails loudly on a non-Gombit app or an unresolvable framework version (DESIGN.md §55).

Closes #282

## Review feedback addressed (leo-aa88)

1. **`database.required` was a JWT proxy (bug).** Now a declared config field — `Config.Database.Required` (`GOMBIT_DATABASE_REQUIRED`, default `true`, shown in `gombit config show`). A postgres CRUD app without auth correctly reports `required: true`; an app that needs no database opts out explicitly. No longer derived from `Auth.Enabled()`.
2. **Blanket replace failure.** The go.mod parser now distinguishes a local filesystem replace (unresolved) from a version replace a host can pin (reports the target version).
3. **`--dir` divergence.** `contract app` now reads both `go.mod` and config `.env` from `--dir`, so a monorepo can't mix one app's go.mod with another's config; process `GOMBIT_*` env still applies. `--out` is resolved before the chdir.

## Acceptance criteria (HOST-1)

- [x] Emits valid JSON whose values come from declared config + `go.mod`
- [x] Unresolvable framework version fails loudly; version-replace resolves
- [x] `database.required` is a declared value, not inferred
- [x] Schema + `contract_version` covered by tests; no tree-walking (§10, 6.2)
- [x] Docs (`app-contract.md`, `cli.md`, `config.md`, index) + CHANGELOG

## Validation

- [x] `go test ./...` — all packages ok
- [x] `golangci-lint v2.12.2` — 0 issues on changed packages
- [x] `gofmt` / `go vet` clean
- [x] Manual: version-replace resolves to the target; `.env` in `--dir` is honored; `database.required` reflects config

## Working agreement checklist

- [x] New behavior has tests (`appcontract`, `cli`, `config`). Not DB-touching (pure projection + go.mod parse), so no DB matrix applies.
- [x] Stable feature ships docs; runs in any generated app
- [ ] Generators — N/A
- [ ] OpenAPI/TS client — N/A (CLI projection, not an HTTP route)
- [x] No secrets in frontend — N/A
- [x] Scope stays in `post-v0.1`; no M6 battery
- [x] Links its issue and lists satisfied AC