### PR TITLE
[HOST-3] Migration safety manifest + verifier (gombit db verify)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ version.
 
 ### Added
 
+- Migration safety manifest + verifier (HOST-3,
+  [#284](https://github.com/gombit-dev/gombit/issues/284); ADR-015):
+  `gombit db verify` classifies each migration's SQL into a closed operation set,
+  flags data-loss operations (drop column/table, destructive alter,
+  delete/truncate) as `requires_confirmation`, and (`--write`) emits a
+  `<version>_<name>.manifest.json` bound to the SQL by `sql_sha256`. Verifying an
+  existing manifest fails on a hash mismatch (SQL changed after review) or a
+  mis-declared safety — a host re-derives the classification and never trusts the
+  declared field (§31). Gombit classifies and verifies; the approval gate is the
+  host's policy. New importable `manifest` package. See
+  [docs/migration-safety.md](docs/migration-safety.md).
 - Application contract (HOST-1,
   [#282](https://github.com/gombit-dev/gombit/issues/282); ADR-015):
   `gombit contract app` emits a stable, versioned, machine-readable description

--- a/cli/db.go
+++ b/cli/db.go
@@ -27,6 +27,7 @@ func newDBCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
 	cmd.AddCommand(newMigrateCommand(stdout, stderr))
 	cmd.AddCommand(newRollbackCommand(stdout, stderr))
 	cmd.AddCommand(newStatusCommand(stdout, stderr))
+	cmd.AddCommand(newVerifyCommand(stdout, stderr))
 	cmd.AddCommand(newSeedCommand(stdout, stderr))
 	cmd.AddCommand(newResetCommand(stdout, stderr))
 	return cmd

--- a/cli/db_verify.go
+++ b/cli/db_verify.go
@@ -26,35 +26,50 @@ delete/truncate) and therefore require confirmation before a host applies them.
   --json   print the classification of every migration as JSON (for a host)
 
 Without --write, an existing manifest is verified against its SQL: a hash
-mismatch (SQL changed after review) or a mis-declared safety fails. Gombit
-classifies and verifies; the approval gate itself is the host's policy.`,
+mismatch (SQL changed after review) or a mis-declared safety fails. --strict
+additionally exits non-zero when any migration requires confirmation, so a host
+or CI can gate on the exit code. Gombit classifies and verifies; the approval
+gate itself is the host's policy.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				return fmt.Errorf("gombit db verify: unexpected argument %q", args[0])
 			}
-			dir, err := cmd.Flags().GetString("dir")
-			if err != nil {
+			opts := verifyOptions{}
+			var err error
+			if opts.dir, err = cmd.Flags().GetString("dir"); err != nil {
 				return err
 			}
-			write, err := cmd.Flags().GetBool("write")
-			if err != nil {
+			if opts.write, err = cmd.Flags().GetBool("write"); err != nil {
 				return err
 			}
-			asJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
+			if opts.asJSON, err = cmd.Flags().GetBool("json"); err != nil {
 				return err
 			}
-			return runVerify(stdout, stderr, dir, write, asJSON)
+			if opts.strict, err = cmd.Flags().GetBool("strict"); err != nil {
+				return err
+			}
+			return runVerify(stdout, stderr, opts)
 		},
 	})
 	cmd.Flags().String("dir", "database/migrations", "migration directory")
 	cmd.Flags().Bool("write", false, "generate/overwrite a manifest beside each migration")
 	cmd.Flags().Bool("json", false, "print each migration's classification as JSON")
+	cmd.Flags().Bool("strict", false, "exit non-zero if any migration requires confirmation (for host/CI gating)")
 	return cmd
 }
 
-func runVerify(stdout io.Writer, stderr io.Writer, dir string, write bool, asJSON bool) error {
+type verifyOptions struct {
+	dir    string
+	write  bool
+	asJSON bool
+	strict bool
+}
+
+func runVerify(stdout io.Writer, stderr io.Writer, opts verifyOptions) error {
+	dir := opts.dir
+	write := opts.write
+	asJSON := opts.asJSON
 	files, err := migrations.ListMigrationFiles(dir)
 	if err != nil {
 		return fmt.Errorf("gombit db verify: %w", err)
@@ -109,6 +124,21 @@ func runVerify(stdout io.Writer, stderr io.Writer, dir string, write bool, asJSO
 			_, _ = fmt.Fprintf(stderr, "verification failed: %s\n", f)
 		}
 		return fmt.Errorf("gombit db verify: %d migration(s) failed verification", len(failures))
+	}
+
+	if opts.strict {
+		var needConfirm []string
+		for _, m := range results {
+			if m.RequiresConfirmation {
+				needConfirm = append(needConfirm, m.Migration.Version+"_"+m.Migration.Name)
+			}
+		}
+		if len(needConfirm) > 0 {
+			for _, n := range needConfirm {
+				_, _ = fmt.Fprintf(stderr, "requires confirmation (data loss): %s\n", n)
+			}
+			return fmt.Errorf("gombit db verify: %d migration(s) require confirmation", len(needConfirm))
+		}
 	}
 	return nil
 }

--- a/cli/db_verify.go
+++ b/cli/db_verify.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gombit-dev/gombit/manifest"
+	"github.com/gombit-dev/gombit/migrations"
+	"github.com/spf13/cobra"
+)
+
+func newVerifyCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
+	cmd := silence(&cobra.Command{
+		Use:   "verify",
+		Short: "Classify and verify migration safety manifests (HOST-3)",
+		Long: `Classify each migration's SQL and verify its safety manifest (ADR-015 / HOST-3).
+
+Reports which migrations lose data (drop column/table, destructive alter,
+delete/truncate) and therefore require confirmation before a host applies them.
+
+  --write  (re)generate a <version>_<name>.manifest.json beside each migration
+  --json   print the classification of every migration as JSON (for a host)
+
+Without --write, an existing manifest is verified against its SQL: a hash
+mismatch (SQL changed after review) or a mis-declared safety fails. Gombit
+classifies and verifies; the approval gate itself is the host's policy.`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("gombit db verify: unexpected argument %q", args[0])
+			}
+			dir, err := cmd.Flags().GetString("dir")
+			if err != nil {
+				return err
+			}
+			write, err := cmd.Flags().GetBool("write")
+			if err != nil {
+				return err
+			}
+			asJSON, err := cmd.Flags().GetBool("json")
+			if err != nil {
+				return err
+			}
+			return runVerify(stdout, stderr, dir, write, asJSON)
+		},
+	})
+	cmd.Flags().String("dir", "database/migrations", "migration directory")
+	cmd.Flags().Bool("write", false, "generate/overwrite a manifest beside each migration")
+	cmd.Flags().Bool("json", false, "print each migration's classification as JSON")
+	return cmd
+}
+
+func runVerify(stdout io.Writer, stderr io.Writer, dir string, write bool, asJSON bool) error {
+	files, err := migrations.ListMigrationFiles(dir)
+	if err != nil {
+		return fmt.Errorf("gombit db verify: %w", err)
+	}
+
+	results := make([]manifest.SafetyManifest, 0, len(files))
+	var failures []string
+
+	for _, f := range files {
+		sql, err := os.ReadFile(f.UpPath) // #nosec G304 -- migration path from the enumerated migrations dir
+		if err != nil {
+			return fmt.Errorf("gombit db verify: read %s: %w", f.UpPath, err)
+		}
+		gen := manifest.Generate(manifest.Migration{Version: f.Version, Name: f.Name}, string(sql))
+		results = append(results, gen)
+
+		mpath := manifestPath(f.UpPath)
+		if write {
+			if err := writeManifest(mpath, gen); err != nil {
+				return fmt.Errorf("gombit db verify: %w", err)
+			}
+			_, _ = fmt.Fprintf(stdout, "wrote %s\n", mpath)
+			continue
+		}
+		if declared, ok, err := readManifest(mpath); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", f.Name, err))
+		} else if ok {
+			if err := manifest.Verify(declared, string(sql)); err != nil {
+				failures = append(failures, fmt.Sprintf("%s: %v", f.Name, err))
+			}
+		}
+	}
+
+	if write {
+		return nil
+	}
+
+	if asJSON {
+		data, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			return fmt.Errorf("gombit db verify: marshal: %w", err)
+		}
+		if _, err := stdout.Write(append(data, '\n')); err != nil {
+			return err
+		}
+	} else {
+		writeVerifyTable(stdout, results)
+	}
+
+	if len(failures) > 0 {
+		for _, f := range failures {
+			_, _ = fmt.Fprintf(stderr, "verification failed: %s\n", f)
+		}
+		return fmt.Errorf("gombit db verify: %d migration(s) failed verification", len(failures))
+	}
+	return nil
+}
+
+func writeVerifyTable(stdout io.Writer, results []manifest.SafetyManifest) {
+	if len(results) == 0 {
+		_, _ = fmt.Fprintln(stdout, "no migrations found")
+		return
+	}
+	dataLoss := 0
+	for _, m := range results {
+		status := "safe"
+		if m.RequiresConfirmation {
+			status = "REQUIRES CONFIRMATION (data loss)"
+			dataLoss++
+		}
+		_, _ = fmt.Fprintf(stdout, "%s_%s: %s\n", m.Migration.Version, m.Migration.Name, status)
+	}
+	_, _ = fmt.Fprintf(stdout, "\n%d migration(s), %d require confirmation\n", len(results), dataLoss)
+}
+
+// manifestPath is the manifest file beside a migration's up SQL:
+// 0001_name.sql -> 0001_name.manifest.json.
+func manifestPath(upPath string) string {
+	return strings.TrimSuffix(upPath, ".sql") + ".manifest.json"
+}
+
+func writeManifest(path string, m manifest.SafetyManifest) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	// #nosec G703 G304 -- path is derived from the enumerated migrations dir.
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// readManifest reads and decodes a manifest. ok is false when the file does not
+// exist (no manifest yet, not an error).
+func readManifest(path string) (m manifest.SafetyManifest, ok bool, err error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- manifest path derived from the enumerated migrations dir
+	if errors.Is(err, os.ErrNotExist) {
+		return manifest.SafetyManifest{}, false, nil
+	}
+	if err != nil {
+		return manifest.SafetyManifest{}, false, err
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return manifest.SafetyManifest{}, false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return m, true, nil
+}

--- a/cli/db_verify_test.go
+++ b/cli/db_verify_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gombit-dev/gombit/manifest"
+)
+
+func migrationsDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, sql := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(sql), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestRunVerifyClassifiesDataLoss(t *testing.T) {
+	dir := migrationsDir(t, map[string]string{
+		"0001_create_users.sql": `CREATE TABLE "users" ("id" bigserial NOT NULL);`,
+		"0002_drop_legacy.sql":  `ALTER TABLE "users" DROP COLUMN "legacy";`,
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runVerify(&out, &errOut, dir, false, false); err != nil {
+		t.Fatalf("runVerify() error = %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "0002_drop_legacy: REQUIRES CONFIRMATION") {
+		t.Errorf("output missing data-loss flag:\n%s", got)
+	}
+	if !strings.Contains(got, "0001_create_users: safe") {
+		t.Errorf("output missing safe classification:\n%s", got)
+	}
+}
+
+func TestRunVerifyWriteThenVerifyPasses(t *testing.T) {
+	dir := migrationsDir(t, map[string]string{
+		"0001_drop_legacy.sql": `ALTER TABLE "users" DROP COLUMN "legacy";`,
+	})
+
+	var out, errOut bytes.Buffer
+	if err := runVerify(&out, &errOut, dir, true, false); err != nil {
+		t.Fatalf("runVerify(--write) error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "0001_drop_legacy.manifest.json")); err != nil {
+		t.Fatalf("manifest not written: %v", err)
+	}
+	out.Reset()
+	errOut.Reset()
+	if err := runVerify(&out, &errOut, dir, false, false); err != nil {
+		t.Fatalf("runVerify() after --write error = %v; stderr=%s", err, errOut.String())
+	}
+}
+
+func TestRunVerifyFailsOnTamperedSQL(t *testing.T) {
+	dir := migrationsDir(t, map[string]string{
+		"0001_add_note.sql": `ALTER TABLE "users" ADD COLUMN "note" text;`,
+	})
+	var out, errOut bytes.Buffer
+	if err := runVerify(&out, &errOut, dir, true, false); err != nil {
+		t.Fatalf("runVerify(--write) error = %v", err)
+	}
+	// Change the SQL after the manifest was written.
+	if err := os.WriteFile(filepath.Join(dir, "0001_add_note.sql"),
+		[]byte(`ALTER TABLE "users" DROP COLUMN "note";`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out.Reset()
+	errOut.Reset()
+	err := runVerify(&out, &errOut, dir, false, false)
+	if err == nil {
+		t.Fatal("runVerify() error = nil, want failure for tampered SQL")
+	}
+	if !strings.Contains(errOut.String(), "hash mismatch") {
+		t.Errorf("stderr = %q, want hash mismatch", errOut.String())
+	}
+}
+
+func TestRunVerifyFailsOnForgedManifest(t *testing.T) {
+	dir := migrationsDir(t, map[string]string{
+		"0001_drop_legacy.sql": `ALTER TABLE "users" DROP COLUMN "legacy";`,
+	})
+	// A manifest with the correct hash but a lie about the classification.
+	sql := `ALTER TABLE "users" DROP COLUMN "legacy";`
+	forged := manifest.SafetyManifest{
+		ManifestVersion:      manifest.ManifestVersion,
+		Migration:            manifest.Migration{Version: "0001", Name: "drop_legacy"},
+		SQLSHA256:            manifest.HashSQL(sql),
+		RequiresConfirmation: false,
+		Operations:           []manifest.Operation{{Kind: manifest.OpOther, Resource: "users", Safety: manifest.SafetyNonDestructive}},
+	}
+	data, _ := json.MarshalIndent(forged, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "0001_drop_legacy.manifest.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	err := runVerify(&out, &errOut, dir, false, false)
+	if err == nil {
+		t.Fatal("runVerify() error = nil, want failure for forged manifest")
+	}
+	if !strings.Contains(errOut.String(), "classification mismatch") {
+		t.Errorf("stderr = %q, want classification mismatch", errOut.String())
+	}
+}
+
+func TestRunVerifyJSON(t *testing.T) {
+	dir := migrationsDir(t, map[string]string{
+		"0001_drop_legacy.sql": `ALTER TABLE "users" DROP COLUMN "legacy";`,
+	})
+	var out, errOut bytes.Buffer
+	if err := runVerify(&out, &errOut, dir, false, true); err != nil {
+		t.Fatalf("runVerify(--json) error = %v", err)
+	}
+	var manifests []manifest.SafetyManifest
+	if err := json.Unmarshal(out.Bytes(), &manifests); err != nil {
+		t.Fatalf("unmarshal json: %v\n%s", err, out.String())
+	}
+	if len(manifests) != 1 || !manifests[0].RequiresConfirmation {
+		t.Fatalf("manifests = %+v, want 1 requiring confirmation", manifests)
+	}
+}

--- a/cli/db_verify_test.go
+++ b/cli/db_verify_test.go
@@ -29,7 +29,7 @@ func TestRunVerifyClassifiesDataLoss(t *testing.T) {
 	})
 
 	var out, errOut bytes.Buffer
-	if err := runVerify(&out, &errOut, dir, false, false); err != nil {
+	if err := runVerify(&out, &errOut, verifyOptions{dir: dir}); err != nil {
 		t.Fatalf("runVerify() error = %v", err)
 	}
 	got := out.String()
@@ -47,7 +47,7 @@ func TestRunVerifyWriteThenVerifyPasses(t *testing.T) {
 	})
 
 	var out, errOut bytes.Buffer
-	if err := runVerify(&out, &errOut, dir, true, false); err != nil {
+	if err := runVerify(&out, &errOut, verifyOptions{dir: dir, write: true}); err != nil {
 		t.Fatalf("runVerify(--write) error = %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "0001_drop_legacy.manifest.json")); err != nil {
@@ -55,7 +55,7 @@ func TestRunVerifyWriteThenVerifyPasses(t *testing.T) {
 	}
 	out.Reset()
 	errOut.Reset()
-	if err := runVerify(&out, &errOut, dir, false, false); err != nil {
+	if err := runVerify(&out, &errOut, verifyOptions{dir: dir}); err != nil {
 		t.Fatalf("runVerify() after --write error = %v; stderr=%s", err, errOut.String())
 	}
 }
@@ -65,7 +65,7 @@ func TestRunVerifyFailsOnTamperedSQL(t *testing.T) {
 		"0001_add_note.sql": `ALTER TABLE "users" ADD COLUMN "note" text;`,
 	})
 	var out, errOut bytes.Buffer
-	if err := runVerify(&out, &errOut, dir, true, false); err != nil {
+	if err := runVerify(&out, &errOut, verifyOptions{dir: dir, write: true}); err != nil {
 		t.Fatalf("runVerify(--write) error = %v", err)
 	}
 	// Change the SQL after the manifest was written.
@@ -76,7 +76,7 @@ func TestRunVerifyFailsOnTamperedSQL(t *testing.T) {
 
 	out.Reset()
 	errOut.Reset()
-	err := runVerify(&out, &errOut, dir, false, false)
+	err := runVerify(&out, &errOut, verifyOptions{dir: dir})
 	if err == nil {
 		t.Fatal("runVerify() error = nil, want failure for tampered SQL")
 	}
@@ -104,7 +104,7 @@ func TestRunVerifyFailsOnForgedManifest(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runVerify(&out, &errOut, dir, false, false)
+	err := runVerify(&out, &errOut, verifyOptions{dir: dir})
 	if err == nil {
 		t.Fatal("runVerify() error = nil, want failure for forged manifest")
 	}
@@ -113,12 +113,46 @@ func TestRunVerifyFailsOnForgedManifest(t *testing.T) {
 	}
 }
 
+func TestRunVerifyStrictFailsOnDataLoss(t *testing.T) {
+	dir := migrationsDir(t, map[string]string{
+		"0001_create_users.sql": `CREATE TABLE "users" ("id" bigserial NOT NULL);`,
+		"0002_drop_legacy.sql":  `ALTER TABLE "users" DROP COLUMN "legacy";`,
+	})
+
+	// Non-strict: a correctly classified data-loss migration is not a failure.
+	var out, errOut bytes.Buffer
+	if err := runVerify(&out, &errOut, verifyOptions{dir: dir}); err != nil {
+		t.Fatalf("runVerify() non-strict error = %v, want nil", err)
+	}
+
+	// Strict: the host-gating exit code trips on the data-loss migration.
+	out.Reset()
+	errOut.Reset()
+	err := runVerify(&out, &errOut, verifyOptions{dir: dir, strict: true})
+	if err == nil {
+		t.Fatal("runVerify(--strict) error = nil, want failure for data-loss migration")
+	}
+	if !strings.Contains(errOut.String(), "0002_drop_legacy") {
+		t.Errorf("stderr = %q, want the data-loss migration named", errOut.String())
+	}
+}
+
+func TestRunVerifyStrictPassesWhenAllSafe(t *testing.T) {
+	dir := migrationsDir(t, map[string]string{
+		"0001_create_users.sql": `CREATE TABLE "users" ("id" bigserial NOT NULL);`,
+	})
+	var out, errOut bytes.Buffer
+	if err := runVerify(&out, &errOut, verifyOptions{dir: dir, strict: true}); err != nil {
+		t.Fatalf("runVerify(--strict) error = %v, want nil for all-safe migrations", err)
+	}
+}
+
 func TestRunVerifyJSON(t *testing.T) {
 	dir := migrationsDir(t, map[string]string{
 		"0001_drop_legacy.sql": `ALTER TABLE "users" DROP COLUMN "legacy";`,
 	})
 	var out, errOut bytes.Buffer
-	if err := runVerify(&out, &errOut, dir, false, true); err != nil {
+	if err := runVerify(&out, &errOut, verifyOptions{dir: dir, asJSON: true}); err != nil {
 		t.Fatalf("runVerify(--json) error = %v", err)
 	}
 	var manifests []manifest.SafetyManifest

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ New here? [Install](installation.md), then work through the
 | --- | --- |
 | [database.md](database.md) | GORM setup and the SQLite / PostgreSQL / MySQL support matrix |
 | [migrations.md](migrations.md) | Atlas-backed `gombit db` migrations, revisions, rollback |
+| [migration-safety.md](migration-safety.md) | Migration safety manifests + the `gombit db verify` verifier for deployment hosts |
 | [validation.md](validation.md) | Model `Validate` hooks (API + admin), `app.Tx`, and optimistic locking |
 
 ## Contract

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,7 @@ go run ./cmd/gombit --help
 | `gombit make resource` | Generate a feature-package resource (AST-safe) | M4-3 |
 | `gombit make command` | Scaffold a Cobra management command (AST-safe) | M4-7 |
 | `gombit db …` | Atlas-backed migrations | M2, migrated onto Cobra in M4-1 |
+| `gombit db verify` | Classify + verify migration safety manifests | HOST-3 |
 | `gombit openapi generate` | Write the live OpenAPI 3.1 document | M3-3 |
 | `gombit contract app` | Emit the machine-readable application contract | HOST-1 |
 | `gombit client generate` / `check` | TypeScript client + drift | M3-4, M3-5 |
@@ -485,9 +486,13 @@ gombit db rollback
 gombit db status
 gombit db seed
 gombit db reset [--force]
+gombit db verify [--write] [--json]
 ```
 
-See [migrations.md](migrations.md) for Atlas behavior.
+See [migrations.md](migrations.md) for Atlas behavior and
+[migration-safety.md](migration-safety.md) for `gombit db verify` — the
+migration safety manifest and verifier a deployment host uses to gate
+destructive migrations (HOST-3).
 
 ## `gombit routes`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -486,7 +486,7 @@ gombit db rollback
 gombit db status
 gombit db seed
 gombit db reset [--force]
-gombit db verify [--write] [--json]
+gombit db verify [--write] [--json] [--strict]
 ```
 
 See [migrations.md](migrations.md) for Atlas behavior and

--- a/docs/migration-safety.md
+++ b/docs/migration-safety.md
@@ -11,6 +11,7 @@ the HOST-3 contract from [ADR-015](adr/015-host-deployment-contracts.md).
 gombit db verify            # classify each migration; verify existing manifests
 gombit db verify --write    # write a manifest beside each migration
 gombit db verify --json     # print each migration's classification (for a host)
+gombit db verify --strict   # also exit non-zero if any migration loses data
 ```
 
 ## What it classifies
@@ -25,12 +26,16 @@ that lose data:
 | `drop_column`, `drop_table`, `alter_column`, `DELETE` / `TRUNCATE` (as `other`) | **`data_loss`** |
 
 A migration with any `data_loss` operation sets `requires_confirmation: true`.
-`alter_column` is treated as data loss conservatively — a narrowing type change
-can truncate values, and the classifier cannot prove otherwise. It is a
-statement-level DDL classifier, not a full SQL parser, and it errs toward
-`data_loss` rather than declaring a statement safe. It handles the Postgres
-(`"`), MySQL (`` ` ``) and SQLite quoting Atlas emits; where SQLite rewrites a
-drop-column as a table rebuild, the old-table `DROP` still flags data loss.
+It is a statement-level DDL classifier, not a full SQL parser, and it is
+**fail-safe**: only statements it positively recognizes as additive or metadata
+(create table/index/view, add column, insert, grant, …) are `non_destructive`.
+Everything else — `UPDATE`, `TRUNCATE`, any `DELETE` (including MySQL
+multi-table `DELETE t FROM …`), `DROP SCHEMA`/`DROP DATABASE`, a narrowing
+`alter_column`, and any statement it cannot parse — classifies as `data_loss`
+so a host reviews it. It handles the Postgres (`"`), MySQL (`` ` ``) and SQLite
+quoting Atlas emits; where SQLite rewrites a drop-column as a table rebuild, the
+old-table `DROP` still flags data loss, and a multi-action `ALTER`
+(`ADD a, DROP b`) still surfaces the drop.
 
 ## The manifest
 
@@ -69,6 +74,15 @@ classification from the executable SQL and compares (DESIGN.md §31).
 Gombit **classifies and verifies**. It does **not** implement the approval
 workflow: blocking a `data_loss` migration until a human confirms it is the
 host's policy (DESIGN.md §32), and automation must never silently auto-confirm
-data loss (§33). `gombit db verify` gives a host the signal — a non-zero exit
-and `requires_confirmation` — to enforce that gate. See
+data loss (§33).
+
+Two exit behaviors give a host what it needs:
+
+- Plain `gombit db verify` exits non-zero only on a **verification failure**
+  (hash or classification mismatch) — a correctly classified, honestly declared
+  data-loss migration exits `0`.
+- `gombit db verify --strict` **additionally** exits non-zero when any migration
+  requires confirmation, so a host or CI can gate on the exit code alone.
+
+A host can equivalently read `requires_confirmation` from `--json`. See
 [ADR-015](adr/015-host-deployment-contracts.md).

--- a/docs/migration-safety.md
+++ b/docs/migration-safety.md
@@ -1,0 +1,74 @@
+# Migration safety manifest
+
+A **migration safety manifest** classifies whether a migration destroys data,
+and a **verifier** proves that classification matches the migration's actual
+SQL. A deployment host (a container platform, CI, or
+[Gombit Cloud](adr/015-host-deployment-contracts.md)) uses it to **gate
+destructive migrations** without blindly trusting a declared safety field. It is
+the HOST-3 contract from [ADR-015](adr/015-host-deployment-contracts.md).
+
+```bash
+gombit db verify            # classify each migration; verify existing manifests
+gombit db verify --write    # write a manifest beside each migration
+gombit db verify --json     # print each migration's classification (for a host)
+```
+
+## What it classifies
+
+`gombit db verify` reads each `database/migrations/*.sql` file, strips comments,
+and classifies every statement into a closed set of operations, flagging those
+that lose data:
+
+| Operation | Safety |
+| --- | --- |
+| `create_table`, `add_column`, `create_index`, `drop_index`, `rename_table`, `rename_column` | `non_destructive` |
+| `drop_column`, `drop_table`, `alter_column`, `DELETE` / `TRUNCATE` (as `other`) | **`data_loss`** |
+
+A migration with any `data_loss` operation sets `requires_confirmation: true`.
+`alter_column` is treated as data loss conservatively — a narrowing type change
+can truncate values, and the classifier cannot prove otherwise. It is a
+statement-level DDL classifier, not a full SQL parser, and it errs toward
+`data_loss` rather than declaring a statement safe. It handles the Postgres
+(`"`), MySQL (`` ` ``) and SQLite quoting Atlas emits; where SQLite rewrites a
+drop-column as a table rebuild, the old-table `DROP` still flags data loss.
+
+## The manifest
+
+`--write` emits `<version>_<name>.manifest.json` beside each migration:
+
+```json
+{
+  "manifest_version": 1,
+  "migration": { "version": "20260901120000", "name": "drop_legacy_code" },
+  "sql_sha256": "…",
+  "requires_confirmation": true,
+  "operations": [
+    { "kind": "drop_column", "resource": "customers", "column": "legacy_code", "safety": "data_loss" }
+  ]
+}
+```
+
+`sql_sha256` binds the manifest to the exact reviewed SQL. It is **anti-tamper**
+binding, not migration drift detection (build plan D4 keeps
+`framework_migrations` checksum-free); the manifest never touches that table.
+
+## Verify, don't trust
+
+Without `--write`, `gombit db verify` checks each migration that has a manifest
+against its SQL and **fails** (non-zero exit) when:
+
+- **the SQL changed after review** — `sql_sha256` no longer matches; or
+- **the manifest lies** — it declares `non_destructive` while the SQL drops a
+  column, or otherwise disagrees with what the SQL actually does.
+
+So a host never trusts a manifest's own `safety` field — it re-derives the
+classification from the executable SQL and compares (DESIGN.md §31).
+
+## Gombit classifies; the host gates
+
+Gombit **classifies and verifies**. It does **not** implement the approval
+workflow: blocking a `data_loss` migration until a human confirms it is the
+host's policy (DESIGN.md §32), and automation must never silently auto-confirm
+data loss (§33). `gombit db verify` gives a host the signal — a non-zero exit
+and `requires_confirmation` — to enforce that gate. See
+[ADR-015](adr/015-host-deployment-contracts.md).

--- a/manifest/classify.go
+++ b/manifest/classify.go
@@ -41,14 +41,20 @@ type Operation struct {
 var (
 	reCreateTable = regexp.MustCompile(`(?is)^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)`)
 	reCreateIndex = regexp.MustCompile(`(?is)^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)`)
-	reDropTable   = regexp.MustCompile(`(?is)^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(\S+)`)
-	reDropIndex   = regexp.MustCompile(`(?is)^\s*DROP\s+INDEX\s+(?:IF\s+EXISTS\s+)?(\S+)`)
-	reAlterTable  = regexp.MustCompile(`(?is)^\s*ALTER\s+TABLE\s+(\S+)\s+(.*)$`)
-	reDeleteData  = regexp.MustCompile(`(?is)^\s*(DELETE\s+FROM|TRUNCATE)\b`)
+	// Additive/replaceable object creations, and read-only or metadata
+	// statements, that add rather than destroy.
+	reCreateSafe = regexp.MustCompile(`(?is)^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?(VIEW|SEQUENCE|FUNCTION|PROCEDURE|TRIGGER|EXTENSION|SCHEMA|TYPE|DOMAIN|ROLE|AGGREGATE|OPERATOR)\b`)
+	reSafeStmt   = regexp.MustCompile(`(?is)^\s*(INSERT\s|SET\s|COMMENT\s+ON\b|GRANT\s|REVOKE\s|PRAGMA\s|BEGIN\b|COMMIT\b|SAVEPOINT\s|RELEASE\s|ANALYZE\b|VACUUM\b|REINDEX\b)`)
+
+	reDropTable  = regexp.MustCompile(`(?is)^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(\S+)`)
+	reDropIndex  = regexp.MustCompile(`(?is)^\s*DROP\s+INDEX\s+(?:IF\s+EXISTS\s+)?(\S+)`)
+	reDropAny    = regexp.MustCompile(`(?is)^\s*DROP\b`)
+	reAlterTable = regexp.MustCompile(`(?is)^\s*ALTER\s+TABLE\s+(\S+)\s+(.*)$`)
+	// Statements that change or remove row data.
+	reDataChange = regexp.MustCompile(`(?is)^\s*(UPDATE\s|DELETE\b|TRUNCATE\b|MERGE\s|REPLACE\s)`)
 
 	reDropColumn   = regexp.MustCompile(`(?is)\bDROP\s+COLUMN\s+(\S+)`)
 	reDropBare     = regexp.MustCompile(`(?is)\bDROP\s+(\S+)`)
-	reDropKeyword  = regexp.MustCompile(`(?is)\bDROP\s+(CONSTRAINT|INDEX|KEY|PRIMARY\s+KEY|FOREIGN\s+KEY)\b`)
 	reAddColumn    = regexp.MustCompile(`(?is)\bADD\s+(?:COLUMN\s+)?(\S+)`)
 	reAddKeyword   = regexp.MustCompile(`(?is)\bADD\s+(CONSTRAINT|INDEX|KEY|PRIMARY\s+KEY|FOREIGN\s+KEY|UNIQUE)\b`)
 	reRenameColumn = regexp.MustCompile(`(?is)\bRENAME\s+COLUMN\s+(\S+)`)
@@ -56,70 +62,106 @@ var (
 	reAlterColumn  = regexp.MustCompile(`(?is)\b(?:ALTER\s+COLUMN|MODIFY(?:\s+COLUMN)?|CHANGE(?:\s+COLUMN)?)\s+(\S+)`)
 )
 
+// dropKeywords are the tokens after a bare ALTER … DROP that are NOT a column,
+// so dropping them is a schema change, not row data loss. Anything else after a
+// bare DROP (including PARTITION, which carries data) is treated as a column
+// drop. COLUMN itself is handled by reDropColumn before the bare check.
+var dropKeywords = map[string]bool{
+	"CONSTRAINT": true, "INDEX": true, "KEY": true,
+	"PRIMARY": true, "FOREIGN": true, "UNIQUE": true, "CHECK": true,
+}
+
 // Classify parses migration SQL into a closed set of operations. It is a
 // statement-level DDL classifier (not a full SQL parser): it strips comments,
 // splits on ';', and matches each statement's leading DDL. It handles the
-// Postgres ("), MySQL (`) and SQLite quoting Atlas emits. Its purpose is safety
-// classification — flagging data loss — so when in doubt it errs toward
-// data_loss rather than declaring a statement safe.
+// Postgres ("), MySQL (`) and SQLite quoting Atlas emits.
+//
+// Its purpose is safety classification, so it is deliberately fail-safe: only
+// recognized additive/metadata statements are non_destructive; anything it does
+// not positively recognize as safe — including UPDATE, unrecognized DROPs, and
+// statements it cannot parse — classifies as data_loss so a host reviews it.
 func Classify(sql string) []Operation {
 	ops := []Operation{}
 	for _, stmt := range splitStatements(sql) {
-		if op, ok := classifyStatement(stmt); ok {
-			ops = append(ops, op)
-		}
+		ops = append(ops, classifyStatement(stmt))
 	}
 	return ops
 }
 
-func classifyStatement(stmt string) (Operation, bool) {
+func classifyStatement(stmt string) Operation {
 	switch {
 	case reCreateTable.MatchString(stmt):
-		return Operation{Kind: OpCreateTable, Resource: ident(reCreateTable, stmt), Safety: SafetyNonDestructive}, true
+		return Operation{Kind: OpCreateTable, Resource: ident(reCreateTable, stmt), Safety: SafetyNonDestructive}
 	case reCreateIndex.MatchString(stmt):
-		return Operation{Kind: OpCreateIndex, Resource: ident(reCreateIndex, stmt), Safety: SafetyNonDestructive}, true
+		return Operation{Kind: OpCreateIndex, Resource: ident(reCreateIndex, stmt), Safety: SafetyNonDestructive}
+	case reCreateSafe.MatchString(stmt):
+		return Operation{Kind: OpOther, Safety: SafetyNonDestructive}
 	case reDropTable.MatchString(stmt):
-		return Operation{Kind: OpDropTable, Resource: ident(reDropTable, stmt), Safety: SafetyDataLoss}, true
+		return Operation{Kind: OpDropTable, Resource: ident(reDropTable, stmt), Safety: SafetyDataLoss}
 	case reDropIndex.MatchString(stmt):
-		return Operation{Kind: OpDropIndex, Resource: ident(reDropIndex, stmt), Safety: SafetyNonDestructive}, true
+		return Operation{Kind: OpDropIndex, Resource: ident(reDropIndex, stmt), Safety: SafetyNonDestructive}
+	case reDropAny.MatchString(stmt):
+		// DROP SCHEMA / DATABASE / VIEW / SEQUENCE / … — destructive by default.
+		return Operation{Kind: OpOther, Safety: SafetyDataLoss}
 	case reAlterTable.MatchString(stmt):
-		return classifyAlter(stmt), true
-	case reDeleteData.MatchString(stmt):
-		return Operation{Kind: OpOther, Safety: SafetyDataLoss}, true
+		return classifyAlter(stmt)
+	case reDataChange.MatchString(stmt):
+		return Operation{Kind: OpOther, Safety: SafetyDataLoss}
+	case reSafeStmt.MatchString(stmt):
+		return Operation{Kind: OpOther, Safety: SafetyNonDestructive}
 	default:
-		return Operation{Kind: OpOther, Safety: SafetyNonDestructive}, true
+		// Fail-safe: an unrecognized statement is flagged for review, not
+		// silently stamped safe.
+		return Operation{Kind: OpOther, Safety: SafetyDataLoss}
 	}
 }
 
-// classifyAlter classifies the alteration in an ALTER TABLE statement. Atlas
-// emits one action per ALTER, so a single operation per statement is reported.
+// classifyAlter classifies an ALTER TABLE statement, scanning the whole body so
+// a destructive action is caught even in a multi-action ALTER
+// (e.g. ADD a, DROP b). Destructive actions win.
 func classifyAlter(stmt string) Operation {
 	m := reAlterTable.FindStringSubmatch(stmt)
 	table := clean(m[1])
 	body := m[2]
 
-	switch {
-	case reDropColumn.MatchString(body):
-		return Operation{Kind: OpDropColumn, Resource: table, Column: ident(reDropColumn, body), Safety: SafetyDataLoss}
-	case reAlterColumn.MatchString(body):
+	if col, ok := droppedColumn(body); ok {
+		return Operation{Kind: OpDropColumn, Resource: table, Column: col, Safety: SafetyDataLoss}
+	}
+	if reAlterColumn.MatchString(body) {
 		return Operation{Kind: OpAlterColumn, Resource: table, Column: ident(reAlterColumn, body), Safety: SafetyDataLoss}
-	case reRenameColumn.MatchString(body):
+	}
+	if reRenameColumn.MatchString(body) {
 		return Operation{Kind: OpRenameColumn, Resource: table, Column: ident(reRenameColumn, body), Safety: SafetyNonDestructive}
-	case reAddKeyword.MatchString(body):
-		return Operation{Kind: OpOther, Resource: table, Safety: SafetyNonDestructive}
-	case reAddColumn.MatchString(body):
-		return Operation{Kind: OpAddColumn, Resource: table, Column: ident(reAddColumn, body), Safety: SafetyNonDestructive}
-	case reDropKeyword.MatchString(body):
-		// DROP CONSTRAINT / INDEX / KEY — schema change, not row data loss.
-		return Operation{Kind: OpOther, Resource: table, Safety: SafetyNonDestructive}
-	case reDropBare.MatchString(body):
-		// A bare `DROP <ident>` that is not a known keyword drops a column.
-		return Operation{Kind: OpDropColumn, Resource: table, Column: ident(reDropBare, body), Safety: SafetyDataLoss}
-	case strings.Contains(strings.ToUpper(body), "RENAME"):
-		return Operation{Kind: OpRenameTable, Resource: table, Column: ident(reRenameTo, body), Safety: SafetyNonDestructive}
-	default:
+	}
+	if reAddKeyword.MatchString(body) {
 		return Operation{Kind: OpOther, Resource: table, Safety: SafetyNonDestructive}
 	}
+	if reAddColumn.MatchString(body) {
+		return Operation{Kind: OpAddColumn, Resource: table, Column: ident(reAddColumn, body), Safety: SafetyNonDestructive}
+	}
+	if strings.Contains(strings.ToUpper(body), "RENAME") {
+		return Operation{Kind: OpRenameTable, Resource: table, Column: ident(reRenameTo, body), Safety: SafetyNonDestructive}
+	}
+	// Remaining ALTER actions (ADD/DROP CONSTRAINT, SET/OWNER/ENABLE, …) are
+	// additive or metadata — non-destructive. The destructive ALTER actions are
+	// the finite set handled above.
+	return Operation{Kind: OpOther, Resource: table, Safety: SafetyNonDestructive}
+}
+
+// droppedColumn returns the name of a column dropped by the ALTER body, if any.
+// It recognizes DROP COLUMN and a bare DROP <ident> that is not a keyword
+// (CONSTRAINT / INDEX / KEY / …), and scans every DROP in the body.
+func droppedColumn(body string) (string, bool) {
+	if m := reDropColumn.FindStringSubmatch(body); m != nil {
+		return clean(m[1]), true
+	}
+	for _, m := range reDropBare.FindAllStringSubmatch(body, -1) {
+		if dropKeywords[strings.ToUpper(clean(m[1]))] {
+			continue
+		}
+		return clean(m[1]), true
+	}
+	return "", false
 }
 
 // splitStatements strips comments and splits SQL into trimmed, non-empty

--- a/manifest/classify.go
+++ b/manifest/classify.go
@@ -1,0 +1,166 @@
+package manifest
+
+import (
+	"regexp"
+	"strings"
+)
+
+// OpKind is a classified migration operation. The set is closed; unrecognized
+// statements classify as OpOther (HOST-3 / ADR-015).
+type OpKind string
+
+const (
+	OpCreateTable  OpKind = "create_table"
+	OpAddColumn    OpKind = "add_column"
+	OpCreateIndex  OpKind = "create_index"
+	OpDropColumn   OpKind = "drop_column"
+	OpDropTable    OpKind = "drop_table"
+	OpDropIndex    OpKind = "drop_index"
+	OpRenameTable  OpKind = "rename_table"
+	OpRenameColumn OpKind = "rename_column"
+	OpAlterColumn  OpKind = "alter_column"
+	OpOther        OpKind = "other"
+)
+
+// Safety classifies whether an operation can destroy data.
+type Safety string
+
+const (
+	SafetyNonDestructive Safety = "non_destructive"
+	SafetyDataLoss       Safety = "data_loss"
+)
+
+// Operation is one classified statement from a migration.
+type Operation struct {
+	Kind     OpKind `json:"kind"`
+	Resource string `json:"resource,omitempty"`
+	Column   string `json:"column,omitempty"`
+	Safety   Safety `json:"safety"`
+}
+
+var (
+	reCreateTable = regexp.MustCompile(`(?is)^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)`)
+	reCreateIndex = regexp.MustCompile(`(?is)^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?(\S+)`)
+	reDropTable   = regexp.MustCompile(`(?is)^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(\S+)`)
+	reDropIndex   = regexp.MustCompile(`(?is)^\s*DROP\s+INDEX\s+(?:IF\s+EXISTS\s+)?(\S+)`)
+	reAlterTable  = regexp.MustCompile(`(?is)^\s*ALTER\s+TABLE\s+(\S+)\s+(.*)$`)
+	reDeleteData  = regexp.MustCompile(`(?is)^\s*(DELETE\s+FROM|TRUNCATE)\b`)
+
+	reDropColumn   = regexp.MustCompile(`(?is)\bDROP\s+COLUMN\s+(\S+)`)
+	reDropBare     = regexp.MustCompile(`(?is)\bDROP\s+(\S+)`)
+	reDropKeyword  = regexp.MustCompile(`(?is)\bDROP\s+(CONSTRAINT|INDEX|KEY|PRIMARY\s+KEY|FOREIGN\s+KEY)\b`)
+	reAddColumn    = regexp.MustCompile(`(?is)\bADD\s+(?:COLUMN\s+)?(\S+)`)
+	reAddKeyword   = regexp.MustCompile(`(?is)\bADD\s+(CONSTRAINT|INDEX|KEY|PRIMARY\s+KEY|FOREIGN\s+KEY|UNIQUE)\b`)
+	reRenameColumn = regexp.MustCompile(`(?is)\bRENAME\s+COLUMN\s+(\S+)`)
+	reRenameTo     = regexp.MustCompile(`(?is)\bRENAME\s+(?:TO\s+)?(\S+)`)
+	reAlterColumn  = regexp.MustCompile(`(?is)\b(?:ALTER\s+COLUMN|MODIFY(?:\s+COLUMN)?|CHANGE(?:\s+COLUMN)?)\s+(\S+)`)
+)
+
+// Classify parses migration SQL into a closed set of operations. It is a
+// statement-level DDL classifier (not a full SQL parser): it strips comments,
+// splits on ';', and matches each statement's leading DDL. It handles the
+// Postgres ("), MySQL (`) and SQLite quoting Atlas emits. Its purpose is safety
+// classification — flagging data loss — so when in doubt it errs toward
+// data_loss rather than declaring a statement safe.
+func Classify(sql string) []Operation {
+	ops := []Operation{}
+	for _, stmt := range splitStatements(sql) {
+		if op, ok := classifyStatement(stmt); ok {
+			ops = append(ops, op)
+		}
+	}
+	return ops
+}
+
+func classifyStatement(stmt string) (Operation, bool) {
+	switch {
+	case reCreateTable.MatchString(stmt):
+		return Operation{Kind: OpCreateTable, Resource: ident(reCreateTable, stmt), Safety: SafetyNonDestructive}, true
+	case reCreateIndex.MatchString(stmt):
+		return Operation{Kind: OpCreateIndex, Resource: ident(reCreateIndex, stmt), Safety: SafetyNonDestructive}, true
+	case reDropTable.MatchString(stmt):
+		return Operation{Kind: OpDropTable, Resource: ident(reDropTable, stmt), Safety: SafetyDataLoss}, true
+	case reDropIndex.MatchString(stmt):
+		return Operation{Kind: OpDropIndex, Resource: ident(reDropIndex, stmt), Safety: SafetyNonDestructive}, true
+	case reAlterTable.MatchString(stmt):
+		return classifyAlter(stmt), true
+	case reDeleteData.MatchString(stmt):
+		return Operation{Kind: OpOther, Safety: SafetyDataLoss}, true
+	default:
+		return Operation{Kind: OpOther, Safety: SafetyNonDestructive}, true
+	}
+}
+
+// classifyAlter classifies the alteration in an ALTER TABLE statement. Atlas
+// emits one action per ALTER, so a single operation per statement is reported.
+func classifyAlter(stmt string) Operation {
+	m := reAlterTable.FindStringSubmatch(stmt)
+	table := clean(m[1])
+	body := m[2]
+
+	switch {
+	case reDropColumn.MatchString(body):
+		return Operation{Kind: OpDropColumn, Resource: table, Column: ident(reDropColumn, body), Safety: SafetyDataLoss}
+	case reAlterColumn.MatchString(body):
+		return Operation{Kind: OpAlterColumn, Resource: table, Column: ident(reAlterColumn, body), Safety: SafetyDataLoss}
+	case reRenameColumn.MatchString(body):
+		return Operation{Kind: OpRenameColumn, Resource: table, Column: ident(reRenameColumn, body), Safety: SafetyNonDestructive}
+	case reAddKeyword.MatchString(body):
+		return Operation{Kind: OpOther, Resource: table, Safety: SafetyNonDestructive}
+	case reAddColumn.MatchString(body):
+		return Operation{Kind: OpAddColumn, Resource: table, Column: ident(reAddColumn, body), Safety: SafetyNonDestructive}
+	case reDropKeyword.MatchString(body):
+		// DROP CONSTRAINT / INDEX / KEY — schema change, not row data loss.
+		return Operation{Kind: OpOther, Resource: table, Safety: SafetyNonDestructive}
+	case reDropBare.MatchString(body):
+		// A bare `DROP <ident>` that is not a known keyword drops a column.
+		return Operation{Kind: OpDropColumn, Resource: table, Column: ident(reDropBare, body), Safety: SafetyDataLoss}
+	case strings.Contains(strings.ToUpper(body), "RENAME"):
+		return Operation{Kind: OpRenameTable, Resource: table, Column: ident(reRenameTo, body), Safety: SafetyNonDestructive}
+	default:
+		return Operation{Kind: OpOther, Resource: table, Safety: SafetyNonDestructive}
+	}
+}
+
+// splitStatements strips comments and splits SQL into trimmed, non-empty
+// statements on ';'.
+func splitStatements(sql string) []string {
+	var b strings.Builder
+	for _, line := range strings.Split(sql, "\n") {
+		if i := strings.Index(line, "--"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	var out []string
+	for _, stmt := range strings.Split(b.String(), ";") {
+		if s := strings.TrimSpace(stmt); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// ident returns the cleaned first captured identifier of re against s.
+func ident(re *regexp.Regexp, s string) string {
+	m := re.FindStringSubmatch(s)
+	if len(m) < 2 {
+		return ""
+	}
+	return clean(m[1])
+}
+
+// clean strips quoting ("`[]), a trailing "(", and any schema prefix from an
+// identifier token.
+func clean(tok string) string {
+	tok = strings.TrimSpace(tok)
+	tok = strings.TrimSuffix(tok, "(")
+	if i := strings.LastIndexAny(tok, ".") + 1; i > 0 && i < len(tok) {
+		// keep the part after a schema/table qualifier only when it is not
+		// itself quoted away below
+		tok = tok[i:]
+	}
+	tok = strings.Trim(tok, "\"`[]")
+	return tok
+}

--- a/manifest/classify_test.go
+++ b/manifest/classify_test.go
@@ -63,9 +63,37 @@ func TestClassifySingleStatements(t *testing.T) {
 			`DELETE FROM "customers" WHERE "legacy" = true;`,
 			Operation{Kind: OpOther, Safety: SafetyDataLoss},
 		},
+		"mysql multi-table delete is data loss": {
+			"DELETE c FROM `customers` c JOIN `orders` o ON c.id = o.cid;",
+			Operation{Kind: OpOther, Safety: SafetyDataLoss},
+		},
+		"update is data loss (conservative)": {
+			`UPDATE "customers" SET "status" = 'x';`,
+			Operation{Kind: OpOther, Safety: SafetyDataLoss},
+		},
+		"truncate is data loss": {
+			`TRUNCATE "customers";`,
+			Operation{Kind: OpOther, Safety: SafetyDataLoss},
+		},
+		"drop schema cascade is data loss": {
+			`DROP SCHEMA "legacy" CASCADE;`,
+			Operation{Kind: OpOther, Safety: SafetyDataLoss},
+		},
+		"drop database is data loss": {
+			`DROP DATABASE "app";`,
+			Operation{Kind: OpOther, Safety: SafetyDataLoss},
+		},
 		"insert is safe other": {
 			`INSERT INTO "customers" ("name") VALUES ('a');`,
 			Operation{Kind: OpOther, Safety: SafetyNonDestructive},
+		},
+		"create view is safe other": {
+			`CREATE VIEW "active" AS SELECT * FROM "customers";`,
+			Operation{Kind: OpOther, Safety: SafetyNonDestructive},
+		},
+		"unrecognized statement is data loss (fail-safe)": {
+			`SOMETHING WEIRD HERE;`,
+			Operation{Kind: OpOther, Safety: SafetyDataLoss},
 		},
 	}
 	for name, tc := range tests {
@@ -111,18 +139,28 @@ ALTER TABLE ` + "`new_customers`" + ` RENAME TO ` + "`customers`" + `;`
 	}
 }
 
-func TestClassifyMixedAlterFlagsDataLoss(t *testing.T) {
-	// A migration that adds one column and drops another must surface the drop.
-	sql := `ALTER TABLE "customers" ADD COLUMN "note" text NOT NULL DEFAULT '';
-ALTER TABLE "customers" DROP COLUMN "legacy_code";`
-	ops := Classify(sql)
-	var sawDrop bool
-	for _, op := range ops {
-		if op.Kind == OpDropColumn && op.Safety == SafetyDataLoss {
-			sawDrop = true
-		}
+func TestClassifyMultiActionAlterInOneStatementFlagsDrop(t *testing.T) {
+	// A single ALTER that adds one column and drops another must surface the
+	// drop, even though the ADD comes first.
+	ops := Classify(`ALTER TABLE "customers" ADD COLUMN "note" text, DROP COLUMN "legacy_code";`)
+	if len(ops) != 1 {
+		t.Fatalf("Classify() = %d ops, want 1: %+v", len(ops), ops)
 	}
-	if !sawDrop {
-		t.Fatalf("Classify() did not flag the drop_column: %+v", ops)
+	if ops[0].Kind != OpDropColumn || ops[0].Safety != SafetyDataLoss {
+		t.Fatalf("Classify() = %+v, want drop_column/data_loss", ops[0])
+	}
+}
+
+func TestClassifyMysqlMultiActionAlterBareDrop(t *testing.T) {
+	ops := Classify("ALTER TABLE `customers` ADD `note` text, DROP `legacy_code`;")
+	if len(ops) != 1 || ops[0].Kind != OpDropColumn || ops[0].Safety != SafetyDataLoss {
+		t.Fatalf("Classify() = %+v, want drop_column/data_loss", ops)
+	}
+}
+
+func TestClassifyAlterDropConstraintIsNotDataLoss(t *testing.T) {
+	ops := Classify(`ALTER TABLE "customers" DROP CONSTRAINT "fk_owner";`)
+	if len(ops) != 1 || ops[0].Safety != SafetyNonDestructive {
+		t.Fatalf("Classify() = %+v, want non_destructive", ops)
 	}
 }

--- a/manifest/classify_test.go
+++ b/manifest/classify_test.go
@@ -1,0 +1,128 @@
+package manifest
+
+import "testing"
+
+func TestClassifySingleStatements(t *testing.T) {
+	tests := map[string]struct {
+		sql  string
+		want Operation
+	}{
+		"postgres create table": {
+			`CREATE TABLE "users" ("id" bigserial NOT NULL, PRIMARY KEY ("id"));`,
+			Operation{Kind: OpCreateTable, Resource: "users", Safety: SafetyNonDestructive},
+		},
+		"mysql create table backticks": {
+			"CREATE TABLE `users` (`id` bigint NOT NULL);",
+			Operation{Kind: OpCreateTable, Resource: "users", Safety: SafetyNonDestructive},
+		},
+		"create unique index": {
+			`CREATE UNIQUE INDEX "idx_users_email" ON "users" ("email");`,
+			Operation{Kind: OpCreateIndex, Resource: "idx_users_email", Safety: SafetyNonDestructive},
+		},
+		"drop table is data loss": {
+			`DROP TABLE "customers";`,
+			Operation{Kind: OpDropTable, Resource: "customers", Safety: SafetyDataLoss},
+		},
+		"drop index is not data loss": {
+			`DROP INDEX "idx_users_email";`,
+			Operation{Kind: OpDropIndex, Resource: "idx_users_email", Safety: SafetyNonDestructive},
+		},
+		"postgres drop column is data loss": {
+			`ALTER TABLE "customers" DROP COLUMN "legacy_code";`,
+			Operation{Kind: OpDropColumn, Resource: "customers", Column: "legacy_code", Safety: SafetyDataLoss},
+		},
+		"mysql drop column backticks": {
+			"ALTER TABLE `customers` DROP COLUMN `legacy_code`;",
+			Operation{Kind: OpDropColumn, Resource: "customers", Column: "legacy_code", Safety: SafetyDataLoss},
+		},
+		"mysql bare drop column": {
+			"ALTER TABLE `customers` DROP `legacy_code`;",
+			Operation{Kind: OpDropColumn, Resource: "customers", Column: "legacy_code", Safety: SafetyDataLoss},
+		},
+		"add column is safe": {
+			`ALTER TABLE "customers" ADD COLUMN "note" text NOT NULL DEFAULT '';`,
+			Operation{Kind: OpAddColumn, Resource: "customers", Column: "note", Safety: SafetyNonDestructive},
+		},
+		"alter column is data loss (conservative)": {
+			`ALTER TABLE "customers" ALTER COLUMN "code" TYPE integer;`,
+			Operation{Kind: OpAlterColumn, Resource: "customers", Column: "code", Safety: SafetyDataLoss},
+		},
+		"mysql modify column is data loss": {
+			"ALTER TABLE `customers` MODIFY COLUMN `code` int;",
+			Operation{Kind: OpAlterColumn, Resource: "customers", Column: "code", Safety: SafetyDataLoss},
+		},
+		"rename column is safe": {
+			`ALTER TABLE "customers" RENAME COLUMN "code" TO "ref";`,
+			Operation{Kind: OpRenameColumn, Resource: "customers", Column: "code", Safety: SafetyNonDestructive},
+		},
+		"drop constraint is not row data loss": {
+			`ALTER TABLE "customers" DROP CONSTRAINT "fk_customers_owner";`,
+			Operation{Kind: OpOther, Resource: "customers", Safety: SafetyNonDestructive},
+		},
+		"delete from is data loss": {
+			`DELETE FROM "customers" WHERE "legacy" = true;`,
+			Operation{Kind: OpOther, Safety: SafetyDataLoss},
+		},
+		"insert is safe other": {
+			`INSERT INTO "customers" ("name") VALUES ('a');`,
+			Operation{Kind: OpOther, Safety: SafetyNonDestructive},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ops := Classify(tc.sql)
+			if len(ops) != 1 {
+				t.Fatalf("Classify() = %d ops, want 1: %+v", len(ops), ops)
+			}
+			if ops[0] != tc.want {
+				t.Fatalf("Classify() = %+v, want %+v", ops[0], tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyStripsCommentsAndOrders(t *testing.T) {
+	sql := `-- Create "users" table
+CREATE TABLE "users" ("id" bigserial NOT NULL, PRIMARY KEY ("id"));
+-- Create index "idx_users_email" to table: "users"
+CREATE UNIQUE INDEX "idx_users_email" ON "users" ("email");`
+
+	ops := Classify(sql)
+	if len(ops) != 2 {
+		t.Fatalf("Classify() = %d ops, want 2: %+v", len(ops), ops)
+	}
+	if ops[0].Kind != OpCreateTable || ops[1].Kind != OpCreateIndex {
+		t.Fatalf("Classify() kinds = %s, %s; want create_table, create_index", ops[0].Kind, ops[1].Kind)
+	}
+}
+
+// SQLite often can't drop a column in place; Atlas rewrites it as a table
+// rebuild (new table, copy, drop old, rename). The old-table DROP still
+// classifies as data loss, so the classifier stays safe-by-default even when
+// the DDL differs by driver.
+func TestClassifySQLiteRebuildFlagsDataLoss(t *testing.T) {
+	sql := `CREATE TABLE ` + "`new_customers`" + ` (` + "`id`" + ` integer NOT NULL);
+INSERT INTO ` + "`new_customers`" + ` (` + "`id`" + `) SELECT ` + "`id`" + ` FROM ` + "`customers`" + `;
+DROP TABLE ` + "`customers`" + `;
+ALTER TABLE ` + "`new_customers`" + ` RENAME TO ` + "`customers`" + `;`
+
+	if !requiresConfirmation(Classify(sql)) {
+		t.Fatalf("SQLite rebuild not flagged as requiring confirmation: %+v", Classify(sql))
+	}
+}
+
+func TestClassifyMixedAlterFlagsDataLoss(t *testing.T) {
+	// A migration that adds one column and drops another must surface the drop.
+	sql := `ALTER TABLE "customers" ADD COLUMN "note" text NOT NULL DEFAULT '';
+ALTER TABLE "customers" DROP COLUMN "legacy_code";`
+	ops := Classify(sql)
+	var sawDrop bool
+	for _, op := range ops {
+		if op.Kind == OpDropColumn && op.Safety == SafetyDataLoss {
+			sawDrop = true
+		}
+	}
+	if !sawDrop {
+		t.Fatalf("Classify() did not flag the drop_column: %+v", ops)
+	}
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -1,0 +1,122 @@
+// Package manifest defines the migration safety manifest and its verifier —
+// the HOST-3 contract (ADR-015). A manifest classifies whether a migration is
+// destructive; the verifier proves that classification matches the executable
+// SQL, so a deployment host (e.g. Gombit Cloud) can gate destructive migrations
+// without blindly trusting a declared "safety" field (DESIGN.md §29–§31).
+//
+// Gombit classifies and verifies. It does not implement the approval gate — a
+// host owns the policy of blocking a data-loss migration pending confirmation
+// (DESIGN.md §32). The manifest does not touch the framework_migrations table
+// (build plan D4); its sql_sha256 is anti-tamper binding, not drift detection.
+package manifest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+// ManifestVersion is the schema version of an emitted manifest. A host can fail
+// loudly on an unknown version.
+const ManifestVersion = 1
+
+// Migration identifies the migration a manifest describes.
+type Migration struct {
+	Version string `json:"version"`
+	Name    string `json:"name"`
+}
+
+// SafetyManifest is the safety classification of one migration's SQL.
+type SafetyManifest struct {
+	ManifestVersion int       `json:"manifest_version"`
+	Migration       Migration `json:"migration"`
+	// SQLSHA256 binds the manifest to the exact reviewed SQL (anti-tamper).
+	SQLSHA256 string `json:"sql_sha256"`
+	// RequiresConfirmation is true when any operation loses data.
+	RequiresConfirmation bool        `json:"requires_confirmation"`
+	Operations           []Operation `json:"operations"`
+}
+
+// Generate builds the canonical manifest for a migration's SQL: the operations
+// classified from the SQL, whether confirmation is required, and the SQL hash.
+func Generate(mig Migration, sql string) SafetyManifest {
+	ops := Classify(sql)
+	return SafetyManifest{
+		ManifestVersion:      ManifestVersion,
+		Migration:            mig,
+		SQLSHA256:            HashSQL(sql),
+		RequiresConfirmation: requiresConfirmation(ops),
+		Operations:           ops,
+	}
+}
+
+// HashSQL returns the hex-encoded SHA-256 of the migration SQL.
+func HashSQL(sql string) string {
+	sum := sha256.Sum256([]byte(sql))
+	return hex.EncodeToString(sum[:])
+}
+
+// Verify proves a manifest is consistent with the executable SQL. It fails when
+//   - the manifest version is unknown;
+//   - sql_sha256 does not match the SQL (the SQL was tampered with after review);
+//   - the declared operations or requires_confirmation disagree with what the
+//     SQL actually does (e.g. a manifest claims non_destructive while the SQL
+//     drops a column).
+//
+// A host consumes Verify's result; it never trusts the manifest's own fields
+// (DESIGN.md §31).
+func Verify(m SafetyManifest, sql string) error {
+	if m.ManifestVersion != ManifestVersion {
+		return fmt.Errorf("manifest: unsupported manifest_version %d (want %d)", m.ManifestVersion, ManifestVersion)
+	}
+	want := Generate(m.Migration, sql)
+
+	if m.SQLSHA256 != want.SQLSHA256 {
+		return fmt.Errorf("%w: manifest sql_sha256 %s does not match SQL %s",
+			ErrHashMismatch, short(m.SQLSHA256), short(want.SQLSHA256))
+	}
+	if m.RequiresConfirmation != want.RequiresConfirmation {
+		return fmt.Errorf("%w: manifest requires_confirmation=%t but the SQL requires %t",
+			ErrClassificationMismatch, m.RequiresConfirmation, want.RequiresConfirmation)
+	}
+	if !operationsEqual(m.Operations, want.Operations) {
+		return fmt.Errorf("%w: declared operations do not match the SQL", ErrClassificationMismatch)
+	}
+	return nil
+}
+
+// ErrHashMismatch and ErrClassificationMismatch let callers distinguish a
+// tampered-SQL failure from a mis-declared-safety failure.
+var (
+	ErrHashMismatch           = errors.New("manifest: sql hash mismatch")
+	ErrClassificationMismatch = errors.New("manifest: classification mismatch")
+)
+
+func requiresConfirmation(ops []Operation) bool {
+	for _, op := range ops {
+		if op.Safety == SafetyDataLoss {
+			return true
+		}
+	}
+	return false
+}
+
+func operationsEqual(a, b []Operation) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func short(hash string) string {
+	if len(hash) > 12 {
+		return hash[:12] + "…"
+	}
+	return hash
+}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -1,0 +1,79 @@
+package manifest
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGenerateAndVerifyRoundTrip(t *testing.T) {
+	sql := `CREATE TABLE "users" ("id" bigserial NOT NULL, PRIMARY KEY ("id"));
+ALTER TABLE "users" DROP COLUMN "legacy";`
+	mig := Migration{Version: "20260901120000", Name: "drop_legacy"}
+
+	m := Generate(mig, sql)
+	if m.ManifestVersion != ManifestVersion {
+		t.Fatalf("manifest_version = %d, want %d", m.ManifestVersion, ManifestVersion)
+	}
+	if !m.RequiresConfirmation {
+		t.Fatal("requires_confirmation = false, want true (SQL drops a column)")
+	}
+	if err := Verify(m, sql); err != nil {
+		t.Fatalf("Verify(generated) error = %v, want nil", err)
+	}
+}
+
+func TestVerifyNonDestructiveMigration(t *testing.T) {
+	sql := `CREATE TABLE "users" ("id" bigserial NOT NULL, PRIMARY KEY ("id"));`
+	m := Generate(Migration{Version: "1", Name: "create_users"}, sql)
+	if m.RequiresConfirmation {
+		t.Fatal("requires_confirmation = true, want false")
+	}
+	if err := Verify(m, sql); err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+}
+
+// Adversarial case (DESIGN.md §100): the SQL was changed after the manifest was
+// written. The hash no longer matches.
+func TestVerifyRejectsTamperedSQL(t *testing.T) {
+	original := `ALTER TABLE "customers" ADD COLUMN "note" text;`
+	m := Generate(Migration{Version: "1", Name: "add_note"}, original)
+
+	tampered := `ALTER TABLE "customers" DROP COLUMN "legacy_code";`
+	err := Verify(m, tampered)
+	if !errors.Is(err, ErrHashMismatch) {
+		t.Fatalf("Verify(tampered) error = %v, want ErrHashMismatch", err)
+	}
+}
+
+// Adversarial case (DESIGN.md §100): a manifest that claims the migration is
+// non-destructive while the SQL drops a column must fail verification (§31).
+func TestVerifyRejectsMisdeclaredSafety(t *testing.T) {
+	sql := `ALTER TABLE "customers" DROP COLUMN "legacy_code";`
+
+	// A hand-forged manifest: correct hash, but lies about the classification.
+	forged := SafetyManifest{
+		ManifestVersion:      ManifestVersion,
+		Migration:            Migration{Version: "1", Name: "drop_legacy"},
+		SQLSHA256:            HashSQL(sql),
+		RequiresConfirmation: false,
+		Operations: []Operation{
+			{Kind: OpOther, Resource: "customers", Safety: SafetyNonDestructive},
+		},
+	}
+
+	err := Verify(forged, sql)
+	if !errors.Is(err, ErrClassificationMismatch) {
+		t.Fatalf("Verify(forged) error = %v, want ErrClassificationMismatch", err)
+	}
+}
+
+func TestVerifyRejectsUnknownManifestVersion(t *testing.T) {
+	sql := `CREATE TABLE "users" ("id" bigserial NOT NULL);`
+	m := Generate(Migration{Version: "1", Name: "create_users"}, sql)
+	m.ManifestVersion = 999
+
+	if err := Verify(m, sql); err == nil {
+		t.Fatal("Verify() error = nil, want error for unknown manifest_version")
+	}
+}


### PR DESCRIPTION
## Summary

Implements **HOST-3** (ADR-015) — the last of the three host contracts. Gombit now classifies whether a migration destroys data and **proves** that classification matches the executable SQL, so a deployment host (Gombit Cloud, CI) can gate destructive migrations without blindly trusting a declared safety field (DESIGN.md §29–§31).

```bash
gombit db verify            # classify each migration; verify existing manifests
gombit db verify --write    # emit <version>_<name>.manifest.json beside each migration
gombit db verify --json     # classification of every migration (for a host)
```

```json
{
  "manifest_version": 1,
  "migration": { "version": "20260901120000", "name": "drop_legacy_code" },
  "sql_sha256": "…",
  "requires_confirmation": true,
  "operations": [
    { "kind": "drop_column", "resource": "customers", "column": "legacy_code", "safety": "data_loss" }
  ]
}
```

- New importable **`manifest`** package: the schema, a statement-level SQL classifier over a **closed** operation set that flags data loss and errs toward `data_loss`, and `Verify` (hash mismatch **and** mis-declared safety both fail).
- `sql_sha256` binds the manifest to the reviewed SQL (**anti-tamper**, not D4 drift); the manifest never touches `framework_migrations`.
- Gombit **classifies and verifies**; the approval gate is the host's policy (DESIGN.md §32). `gombit db verify` gives the host the signal (non-zero exit + `requires_confirmation`).

Closes #284

## Acceptance criteria (HOST-3)

- [x] Manifest format + version; `requires_confirmation` for any data-loss op
- [x] Verifier classifies the closed op set; **verify, don't trust** — re-derives from SQL (§31)
- [x] Both adversarial cases (DESIGN.md §100) fail verification: **hash mismatch** and **declared-safe over a `DROP COLUMN`**
- [x] Does not touch `framework_migrations` (D4); no new migration engine (ADR-012 — reads Atlas SQL)
- [x] Docs (`migration-safety.md`, `cli.md`, index) + CHANGELOG

## On the \"DB matrix\" AC

The verifier is **static SQL analysis** — it never opens a database, so a live SQLite/Postgres/MySQL matrix isn't meaningful here. What differs by driver is the **DDL dialect**, so the classifier tests cover Postgres (`\"`), MySQL (`` ` ``) quoting, bare `DROP col`, `MODIFY`/`CHANGE`, and the **SQLite table-rebuild** pattern (the old-table `DROP` still flags data loss — safe-by-default). Stated plainly rather than faking a DB matrix.

## Design notes for review

- `alter_column` is classified **data_loss** conservatively — a narrowing type change can truncate, and the classifier can't prove otherwise. Over-flagging is the safe direction for a gate.
- One operation per statement (Atlas emits one action per `ALTER`); a combined `ADD…, DROP…` still surfaces the drop.
- A migration with no manifest is reported but not a failure (run `--write` to create them); only a present-but-wrong manifest fails.

## Validation

- [x] `go test ./...` — 46 packages ok
- [x] `golangci-lint v2.12.2` — 0 issues on changed packages
- [x] `gofmt` / `go vet` clean
- [x] Manual: classify, `--write`, `--json`, and tamper-detection (hash mismatch → exit 1)

## Working agreement checklist

- [x] New behavior has tests (`manifest` unit incl. both adversarial cases; `cli` command tests). Static analysis — no DB matrix applies (see above).
- [x] Stable feature ships docs; runs against any app's migrations
- [ ] Generators — N/A
- [ ] OpenAPI/TS client — N/A (CLI + library, not an HTTP route)
- [x] No secrets in frontend — N/A
- [x] Scope stays in `post-v0.1`; no M6 battery
- [x] Links its issue and lists satisfied AC