### PR TITLE
fix: scope security headers by response kind (PERF-9, #267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,21 @@ version.
 
 ### Changed
 
+- **Security headers are now scoped by response kind** (PERF-9,
+  [#267](https://github.com/gombit-dev/gombit/issues/267)). JSON/API responses
+  get the strict, minimal policy `Content-Security-Policy: default-src 'none';
+  frame-ancestors 'none'` plus `X-Content-Type-Options` (and HSTS in
+  production) — no `X-Frame-Options` or `Referrer-Policy`, since
+  `frame-ancestors 'none'` already subsumes the former and a `default-src
+  'none'` document needs neither. HTML responses (the embedded SPA, the admin
+  SPA, and Huma's `/docs`) keep the full browser policy including
+  `Referrer-Policy` and `X-Frame-Options: DENY`. This holds the common API
+  response under Go's 8-header swiss-map threshold, removing ~5 allocs/op of
+  header-map growth from every API response. The dead IE8-only
+  `X-Download-Options: noopen` header is no longer set on any response. If you
+  relied on `X-Frame-Options`/`Referrer-Policy` or the old `default-src 'self'`
+  CSP on JSON responses, note the new API policy. See
+  [docs/security.md](docs/security.md).
 - **Breaking (probe contract):** `GET /readyz` now reflects real readiness
   (HOST-2, [#283](https://github.com/gombit-dev/gombit/issues/283)). Its success
   body is `{"data":{"status":"ready"}}` — `data.status` changed from `"ok"` to

--- a/admin/spa_test.go
+++ b/admin/spa_test.go
@@ -147,8 +147,8 @@ func TestAdminMetaIsJSONNotHTML(t *testing.T) {
 		t.Fatalf("Content-Type = %q, want json", rec.Header().Get("Content-Type"))
 	}
 	apiCSP := rec.Header().Get("Content-Security-Policy")
-	if apiCSP != "default-src 'self'" {
-		t.Fatalf("API CSP = %q, want default-src 'self' (not SPA CSP)", apiCSP)
+	if apiCSP != "default-src 'none'; frame-ancestors 'none'" {
+		t.Fatalf("API CSP = %q, want the API policy default-src 'none'; frame-ancestors 'none' (not SPA CSP)", apiCSP)
 	}
 }
 
@@ -163,8 +163,8 @@ func TestAdminSPALeavesProbesAndDocs(t *testing.T) {
 	if strings.Contains(rec.Body.String(), "<div id=\"root\">") {
 		t.Fatal("GET /readyz served admin index.html")
 	}
-	if rec.Header().Get("Content-Security-Policy") != "default-src 'self'" {
-		t.Fatalf("GET /readyz CSP = %q", rec.Header().Get("Content-Security-Policy"))
+	if rec.Header().Get("Content-Security-Policy") != "default-src 'none'; frame-ancestors 'none'" {
+		t.Fatalf("GET /readyz CSP = %q, want the API policy default-src 'none'; frame-ancestors 'none'", rec.Header().Get("Content-Security-Policy"))
 	}
 
 	rec = doRequest(app, nil, http.MethodGet, "/docs", "")

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ New here? [Install](installation.md), then work through the
 | [router.md](router.md) | Application-owned route registration and the raw `*gin.Engine` escape hatch |
 | [logging.md](logging.md) | Runtime logging |
 | [cache.md](cache.md) | Cache runtime (memory, Redis, noop) |
+| [security.md](security.md) | The security headers applied per response kind (API vs HTML) and why |
 
 ## Data
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -73,11 +73,14 @@ only mounts in cookie mode. See [admin.md](admin.md).
 
 ## SPA Content-Security-Policy
 
-Global middleware sets `Content-Security-Policy: default-src 'self'` on every
-response. When the embedded frontend serves `index.html` (GET `/` and SPA
-fallback), that header is overwritten so `--ui mui` + `--embed` can load
-Roboto and Emotion-injected `<style>` tags:
+The security-headers middleware scopes its policy by response kind (see
+[security.md](security.md)). JSON API responses, probes, and `/metrics` get the
+strict API policy `default-src 'none'; frame-ancestors 'none'`. When the
+embedded frontend serves `index.html` (GET `/` and SPA fallback), the response
+is promoted to the browser policy so `--ui mui` + `--embed` can load Roboto and
+Emotion-injected `<style>` tags:
 
+- `default-src 'self'` — same-origin baseline for the document
 - `script-src 'self'` — Vite production JS is hashed same-origin modules
   (no `'unsafe-inline'` scripts)
 - `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` — Emotion
@@ -86,8 +89,9 @@ Roboto and Emotion-injected `<style>` tags:
 - `connect-src 'self'` — same-origin API
 - `img-src 'self' data:`
 
-JSON API, probes, and `/metrics` keep `default-src 'self'`. `/docs` (when
-enabled) keeps Huma's Swagger UI policy.
+plus `Referrer-Policy` and `X-Frame-Options: DENY`. `/docs` (when enabled)
+keeps Huma's own Swagger UI CSP and additionally gets the browser hardening
+headers. See [security.md](security.md) for the full per-response-kind table.
 
 ## Scaffold hook
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -22,8 +22,10 @@ curl -sS http://127.0.0.1:8080/openapi.json
 Try-it-out requests hit the running app, so D10 validation and category errors
 appear as they would for any client. The docs page uses Huma's Swagger UI
 renderer and loads the UI assets from `unpkg.com`; Huma sets a page-specific
-CSP (`connect-src 'self'`) so try-it-out can call the same origin. Other
-routes keep the runtime `default-src 'self'` policy.
+CSP so try-it-out can call the same origin, and the framework adds the browser
+hardening headers (`Referrer-Policy`, `X-Frame-Options`) on top. JSON API
+routes keep the strict API policy `default-src 'none'; frame-ancestors 'none'`
+(see [security.md](security.md)).
 
 Raw `app.Router()` routes (webhooks, SSE, probes, metrics) stay out of the
 OpenAPI document and therefore out of `/docs`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,7 +8,7 @@ so they get different policies (issue
 
 ## Per-response-kind headers
 
-| Header | API / JSON (default) | HTML: SPA & admin | HTML: `/docs` |
+| Header | API / JSON (default) | HTML: SPA & admin | HTML: `/docs`² |
 | --- | --- | --- | --- |
 | `Content-Security-Policy` | `default-src 'none'; frame-ancestors 'none'` | SPA policy (see below) | Huma's Swagger UI policy |
 | `X-Content-Type-Options` | `nosniff` | `nosniff` | `nosniff` |
@@ -18,6 +18,12 @@ so they get different policies (issue
 
 ¹ `max-age=315360000; includeSubDomains`, set only when
 `Environment == production`.
+
+² Only when docs are enabled (`API.DocsEnabled`, off by default in production).
+The `/docs` column applies to the response the docs handler actually serves; the
+classification is gated on `DocsEnabled`, so with docs disabled there is no
+`/docs` handler and a `/docs` request is an ordinary not-found **API** response
+that gets the API policy, not the browser headers.
 
 The **SPA policy** (embedded frontend `index.html` and the admin SPA) is:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,78 @@
+# Security headers
+
+Every Gombit response carries a baseline set of security headers, applied by
+the runtime `security_headers` middleware. The set is **scoped by response
+kind**: a JSON API response and an HTML document have different threat models,
+so they get different policies (issue
+[#267](https://github.com/gombit-dev/gombit/issues/267) / PERF-9).
+
+## Per-response-kind headers
+
+| Header | API / JSON (default) | HTML: SPA & admin | HTML: `/docs` |
+| --- | --- | --- | --- |
+| `Content-Security-Policy` | `default-src 'none'; frame-ancestors 'none'` | SPA policy (see below) | Huma's Swagger UI policy |
+| `X-Content-Type-Options` | `nosniff` | `nosniff` | `nosniff` |
+| `Strict-Transport-Security` | production only¹ | production only¹ | production only¹ |
+| `Referrer-Policy` | — | `strict-origin-when-cross-origin` | `strict-origin-when-cross-origin` |
+| `X-Frame-Options` | — | `DENY` | `DENY` |
+
+¹ `max-age=315360000; includeSubDomains`, set only when
+`Environment == production`.
+
+The **SPA policy** (embedded frontend `index.html` and the admin SPA) is:
+
+```
+default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'
+```
+
+It is looser than the API default so `--ui mui` + `--embed` can load Roboto and
+Emotion-injected `<style>` tags. `script-src` stays `'self'` — Vite production
+JS is hashed same-origin modules, never `'unsafe-inline'`.
+
+## Why the API default is so strict — and so small
+
+A JSON API response renders nothing and loads no sub-resources, so
+`default-src 'none'` is the correct policy for it: it forbids everything. The
+modern `frame-ancestors 'none'` directive is the clickjacking defense, and it
+**subsumes** `X-Frame-Options: DENY`, so the API response needs neither
+`X-Frame-Options` nor `Referrer-Policy`. Those are browser-document concerns and
+live only on the HTML response kinds above.
+
+Keeping the API set this small is also a measured performance win. The header
+value slices are shared, pre-allocated, and read-only (assigned straight into
+the response header map), so the values themselves allocate nothing. The cost
+was **header count**: correlation IDs (`X-Request-Id`, `X-Trace-Id`) +
+`Content-Type` + the security headers. A ninth entry tips the response past
+Go's 8-slot swiss-map group, at which point both the handler header map and the
+`Header.Clone` net/http performs on `WriteHeader` grow — about 5 allocs/op on
+**every** API response. The pre-#267 set (CSP + `Referrer-Policy` + HSTS +
+`X-Content-Type-Options` + `X-Frame-Options`, plus a dead
+`X-Download-Options`) crossed that boundary. The scoped API set stays at ≤ 6
+headers, so the layer allocates nothing. `TestSecurityHeadersLayerAllocatesNothing`
+and `TestDefaultJSONResponseStaysUnderHeaderBudget` guard both invariants.
+
+### Header budget
+
+Hold the default API response at **≤ 8 total headers**, including correlation
+IDs and `Content-Type`. A route that also sets `Set-Cookie`, `Cache-Control`,
+`Link`, etc. can cross the threshold again and reintroduce the map-growth
+allocations. If you add headers to a hot API path, keep the total at or under
+eight.
+
+## `X-Download-Options` is not set
+
+`X-Download-Options: noopen` was IE8-only guidance for the long-retired IE8
+downloads behavior. No supported browser honors it, so it is set on **no**
+response — carrying it forward was dead weight (and, being the ninth header,
+part of what pushed the API response over the swiss-map threshold).
+
+## Overriding
+
+HTML documents the framework serves through its own handlers (the embedded SPA
+and the admin SPA) start from the API baseline and are promoted to the browser
+policy via `applyBrowserSecurityHeaders`. Overriding a security header from your
+own handler is supported through the standard `http.Header` mutation APIs — use
+`c.Header(key, value)` (which replaces the map entry). **Never** write in place
+through the slice `Header.Values(key)` returns: those backing slices are shared
+process-globals, and an in-place write corrupts the value for every other
+in-flight request. `TestSecurityHeaderSharedValueContract` locks this contract.

--- a/docs/security.md
+++ b/docs/security.md
@@ -19,11 +19,13 @@ so they get different policies (issue
 ¹ `max-age=315360000; includeSubDomains`, set only when
 `Environment == production`.
 
-² Only when docs are enabled (`API.DocsEnabled`, off by default in production).
-The `/docs` column applies to the response the docs handler actually serves; the
-classification is gated on `DocsEnabled`, so with docs disabled there is no
-`/docs` handler and a `/docs` request is an ordinary not-found **API** response
-that gets the API policy, not the browser headers.
+² Only the **exact** `/docs` route, and only when docs are enabled
+(`API.DocsEnabled`, off by default in production). Huma registers the docs UI at
+that one path, not the `/docs/` subtree, so an unknown descendant like
+`/docs/not-a-route` — a 404 served by no handler — is an ordinary **API**
+response and gets the API policy, as does any `/docs` request when docs are
+disabled. Classification follows the route that is actually served, never a URL
+prefix.
 
 The **SPA policy** (embedded frontend `index.html` and the admin SPA) is:
 

--- a/framework/adminui.go
+++ b/framework/adminui.go
@@ -90,7 +90,7 @@ func serveAdminIndexHTML(c *gin.Context, fsys fs.FS, apiPrefix string) {
 		return
 	}
 	data = injectAPIPrefixHTML(data, apiPrefix)
-	applySPAContentSecurityPolicy(c)
+	applyBrowserSecurityHeaders(c)
 	writeBytes(c, "text/html; charset=utf-8", data)
 }
 

--- a/framework/app.go
+++ b/framework/app.go
@@ -721,7 +721,7 @@ func runtimeMiddlewareStack(cfg config.Config, metrics *httpMetrics, csrfExemptP
 		{name: "metrics", handler: metricsMiddleware(metrics)},
 		{
 			name:    "security_headers",
-			handler: securityHeadersMiddleware(cfg.Environment == config.EnvironmentProduction),
+			handler: securityHeadersMiddleware(cfg.Environment == config.EnvironmentProduction, cfg.API.DocsEnabled),
 		},
 		// Raw-body paths (webhooks) skip input sanitization so their body reaches
 		// the handler unmodified for signature verification (WithRawBodyPaths).

--- a/framework/embed.go
+++ b/framework/embed.go
@@ -102,15 +102,35 @@ func isReservedFrontendPath(urlPath, apiPrefix string) bool {
 	return false
 }
 
-// spaContentSecurityPolicy overwrites the global default-src 'self' header
-// when serving SPA index.html so --ui mui + --embed can load Roboto and
-// Emotion-injected <style> tags. script-src stays 'self' (hashed Vite
-// modules; no unsafe-inline scripts). JSON API and probe responses keep
-// the global policy.
+// spaContentSecurityPolicy is the Content-Security-Policy for HTML documents
+// the framework serves through its own handlers — the embedded SPA index.html
+// and the admin SPA. It is looser than the API default (which is
+// default-src 'none'; frame-ancestors 'none') so --ui mui + --embed can load
+// Roboto and Emotion-injected <style> tags. script-src stays 'self' (hashed
+// Vite modules; no unsafe-inline scripts). JSON API and probe responses keep
+// the strict API policy set in securityHeadersMiddleware.
 const spaContentSecurityPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'"
 
-func applySPAContentSecurityPolicy(c *gin.Context) {
-	c.Header("Content-Security-Policy", spaContentSecurityPolicy)
+var spaContentSecurityPolicyValue = []string{spaContentSecurityPolicy}
+
+// applyBrowserSecurityHeaders promotes a response from the API/JSON security
+// baseline (set by securityHeadersMiddleware) to the full browser policy that
+// an HTML document rendered in a browser needs (issue #267 / PERF-9): the
+// looser SPA Content-Security-Policy, plus Referrer-Policy and the legacy
+// X-Frame-Options: DENY for user agents that do not honor frame-ancestors.
+// X-Content-Type-Options and Strict-Transport-Security are already set by the
+// middleware and carry through unchanged.
+//
+// It replaces map entries (never writing through the shared read-only slices),
+// so the shared-value contract in securityHeadersMiddleware still holds. This
+// is not on the JSON hot path, so the map growth it may cause past the 8-header
+// threshold is acceptable here — the allocation budget in issue #267 is about
+// the default API response, not HTML documents.
+func applyBrowserSecurityHeaders(c *gin.Context) {
+	header := c.Writer.Header()
+	header["Content-Security-Policy"] = spaContentSecurityPolicyValue
+	header["Referrer-Policy"] = referrerPolicyValue
+	header["X-Frame-Options"] = frameOptionsValue
 }
 
 func serveEmbeddedFile(c *gin.Context, fsys fs.FS, name string) bool {
@@ -126,7 +146,7 @@ func serveEmbeddedFile(c *gin.Context, fsys fs.FS, name string) bool {
 	}
 
 	if name == "index.html" {
-		applySPAContentSecurityPolicy(c)
+		applyBrowserSecurityHeaders(c)
 	}
 
 	if rs, ok := f.(io.ReadSeeker); ok {
@@ -149,7 +169,7 @@ func serveIndexHTML(c *gin.Context, fsys fs.FS, apiPrefix string) {
 		return
 	}
 	data = injectAPIPrefixHTML(data, apiPrefix)
-	applySPAContentSecurityPolicy(c)
+	applyBrowserSecurityHeaders(c)
 	writeBytes(c, "text/html; charset=utf-8", data)
 }
 

--- a/framework/embed_test.go
+++ b/framework/embed_test.go
@@ -238,8 +238,8 @@ func TestEmbeddedFrontendIndexUsesSPACSP(t *testing.T) {
 		t.Fatalf("GET /readyz status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	readyCSP := rec.Header().Get("Content-Security-Policy")
-	if readyCSP != "default-src 'self'" {
-		t.Fatalf("GET /readyz CSP = %q, want default-src 'self'", readyCSP)
+	if readyCSP != "default-src 'none'; frame-ancestors 'none'" {
+		t.Fatalf("GET /readyz CSP = %q, want the API policy default-src 'none'; frame-ancestors 'none'", readyCSP)
 	}
 	if strings.Contains(readyCSP, "fonts.googleapis.com") {
 		t.Fatalf("GET /readyz CSP = %q, must not get SPA font hosts", readyCSP)

--- a/framework/http_middleware.go
+++ b/framework/http_middleware.go
@@ -101,10 +101,24 @@ var (
 	referrerPolicyValue     = []string{"strict-origin-when-cross-origin"}
 	hstsHeaderValue         = []string{"max-age=315360000; includeSubDomains"}
 	contentTypeOptionsValue = []string{"nosniff"}
-	downloadOptionsValue    = []string{"noopen"}
 	frameOptionsValue       = []string{"DENY"}
 )
 
+// securityHeadersMiddleware sets the framework's fixed set of security
+// headers on every response (API and HTML/SPA alike). X-Download-Options
+// ("noopen") is IE8-only guidance for the long-retired IE8 downloads
+// behavior; no supported browser honors it, so it is not set at all rather
+// than carried forward as dead weight on every response (issue #267). Every
+// other header here is still meaningful in current browsers:
+//   - Content-Security-Policy and X-Frame-Options are the load-bearing
+//     clickjacking/injection defenses.
+//   - Referrer-Policy and X-Content-Type-Options are cheap, still-honored
+//     hardening with no compatibility downside.
+//
+// HTML responses (the embedded SPA) override Content-Security-Policy via
+// applySPAContentSecurityPolicy (see embed.go) to allow the styling the SPA
+// needs; JSON API responses keep the strict default-src 'self' policy set
+// here. See docs/security.md for the full per-response-type header table.
 func securityHeadersMiddleware(includeHSTS bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		header := c.Writer.Header()
@@ -114,7 +128,6 @@ func securityHeadersMiddleware(includeHSTS bool) gin.HandlerFunc {
 			header["Strict-Transport-Security"] = hstsHeaderValue
 		}
 		header["X-Content-Type-Options"] = contentTypeOptionsValue
-		header["X-Download-Options"] = downloadOptionsValue
 		header["X-Frame-Options"] = frameOptionsValue
 		c.Next()
 	}

--- a/framework/http_middleware.go
+++ b/framework/http_middleware.go
@@ -163,14 +163,15 @@ func securityHeadersMiddleware(includeHSTS, docsEnabled bool) gin.HandlerFunc {
 	}
 }
 
-// isDocsPath reports whether urlPath is Huma's interactive docs UI. Docs is an
-// HTML document served by Huma (contract.DocsPath, root-mounted), so — when it
-// is enabled — its response kind is decided here by path rather than by an
-// override in a framework handler. The caller gates this on docsEnabled: a
-// /docs path with docs disabled has no docs handler behind it and is not an
-// HTML response.
+// isDocsPath reports whether urlPath is Huma's interactive docs UI. Huma
+// registers exactly one route, contract.DocsPath ("/docs") — not the "/docs/"
+// subtree — so only that exact path is an HTML document. A descendant like
+// /docs/not-a-route is served by no handler (404) and is an ordinary API
+// response, not HTML; matching the whole prefix would hand those 404s the
+// browser policy. The caller additionally gates this on docsEnabled: with docs
+// disabled the route is not registered at all.
 func isDocsPath(urlPath string) bool {
-	return urlPath == contract.DocsPath || strings.HasPrefix(urlPath, contract.DocsPath+"/")
+	return urlPath == contract.DocsPath
 }
 
 // httpMetrics accumulates request metrics without locking the request path.

--- a/framework/http_middleware.go
+++ b/framework/http_middleware.go
@@ -129,11 +129,15 @@ var (
 //     response with correlation IDs and Content-Type at <= 6 headers, one
 //     under the swiss-map 8-slot group boundary, so the layer allocates
 //     nothing (the map and net/http's WriteHeader Header.Clone no longer grow).
-//   - Interactive docs (/docs): the full browser policy, applied here by path
-//     because Huma owns that handler. Huma's docs renderer sets its own
-//     Content-Security-Policy (it must allow the Swagger UI assets), so it
-//     overrides the CSP set here; what this branch contributes that Huma does
-//     not is Referrer-Policy and the legacy X-Frame-Options: DENY.
+//   - Interactive docs (/docs), only when docs are enabled: the full browser
+//     policy, applied here by path because Huma owns that handler. Huma's docs
+//     renderer sets its own Content-Security-Policy (it must allow the Swagger
+//     UI assets), so it overrides the CSP set here; what this branch
+//     contributes that Huma does not is Referrer-Policy and the legacy
+//     X-Frame-Options: DENY. When docs are disabled (the production default)
+//     no /docs route exists, so a /docs request is an ordinary API/not-found
+//     response and gets the API policy — the classification follows the
+//     response that will actually be served, not the URL alone.
 //
 // HTML documents the framework serves through its own handlers — the admin SPA
 // and the embedded frontend — start from the API baseline set here and then
@@ -141,14 +145,14 @@ var (
 // and adminui.go), which is where the richer SPA CSP, Referrer-Policy, and
 // X-Frame-Options are added. X-Download-Options ("noopen") is IE8-only and set
 // nowhere: no supported browser honors it (issue #267).
-func securityHeadersMiddleware(includeHSTS bool) gin.HandlerFunc {
+func securityHeadersMiddleware(includeHSTS, docsEnabled bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		header := c.Writer.Header()
 		header["X-Content-Type-Options"] = contentTypeOptionsValue
 		if includeHSTS {
 			header["Strict-Transport-Security"] = hstsHeaderValue
 		}
-		if isDocsPath(c.Request.URL.Path) {
+		if docsEnabled && isDocsPath(c.Request.URL.Path) {
 			header["Content-Security-Policy"] = browserContentSecurityPolicyValue
 			header["Referrer-Policy"] = referrerPolicyValue
 			header["X-Frame-Options"] = frameOptionsValue
@@ -160,9 +164,11 @@ func securityHeadersMiddleware(includeHSTS bool) gin.HandlerFunc {
 }
 
 // isDocsPath reports whether urlPath is Huma's interactive docs UI. Docs is an
-// HTML document served by Huma (contract.DocsPath, root-mounted), so its
-// response kind is decided here by path rather than by an override in a
-// framework handler.
+// HTML document served by Huma (contract.DocsPath, root-mounted), so — when it
+// is enabled — its response kind is decided here by path rather than by an
+// override in a framework handler. The caller gates this on docsEnabled: a
+// /docs path with docs disabled has no docs handler behind it and is not an
+// HTML response.
 func isDocsPath(urlPath string) bool {
 	return urlPath == contract.DocsPath || strings.HasPrefix(urlPath, contract.DocsPath+"/")
 }

--- a/framework/http_middleware.go
+++ b/framework/http_middleware.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gombit-dev/gombit/contract"
 )
 
 // TraceparentHeader is the W3C trace context header.
@@ -80,8 +81,8 @@ func GetTraceIDFromContext(ctx context.Context) string {
 // Security-header values are request-invariant. Rather than allocate a fresh
 // []string per header on every response (what http.Header.Set does), the
 // middleware assigns these shared, read-only backing slices directly into the
-// response header map (keys are already in canonical MIME form). That saves
-// six allocations per response on the hot path.
+// response header map (keys are already in canonical MIME form). That saves an
+// allocation per header on the hot path.
 //
 // http.Header is a mutable map of mutable slices, so sharing is safe only
 // under its documented mutation APIs, and that constraint is load-bearing:
@@ -94,43 +95,76 @@ func GetTraceIDFromContext(ctx context.Context) string {
 // Header.Values(k)[0] = ... or append(h[k][:0], ...) — writes straight through
 // to the process-global value, corrupting it for every other request and
 // racing with them. Override a security header with Set (as
-// applySPAContentSecurityPolicy does), never an in-place slice write.
+// applyBrowserSecurityHeaders does), never an in-place slice write.
 // TestSecurityHeaderSharedValueContract locks all three paths.
 var (
-	cspHeaderValue          = []string{"default-src 'self'"}
-	referrerPolicyValue     = []string{"strict-origin-when-cross-origin"}
-	hstsHeaderValue         = []string{"max-age=315360000; includeSubDomains"}
-	contentTypeOptionsValue = []string{"nosniff"}
-	frameOptionsValue       = []string{"DENY"}
+	// apiContentSecurityPolicy is the JSON/API default (issue #267 / PERF-9):
+	// the OWASP REST minimum. default-src 'none' forbids the response from
+	// loading or executing anything (a JSON body needs no resources), and
+	// frame-ancestors 'none' is the modern anti-clickjacking directive that
+	// subsumes X-Frame-Options: DENY — so an API response needs neither
+	// X-Frame-Options nor Referrer-Policy, keeping it well under the 8-header
+	// swiss-map threshold that used to cost the layer ~5 allocs/op.
+	apiContentSecurityPolicyValue = []string{"default-src 'none'; frame-ancestors 'none'"}
+	// browserContentSecurityPolicy is the policy for HTML documents the
+	// framework itself serves but whose handler cannot set its own headers —
+	// today only Huma's interactive docs at /docs. It matches the pre-#267
+	// full browser policy so nothing about the docs page regresses.
+	browserContentSecurityPolicyValue = []string{"default-src 'self'"}
+	referrerPolicyValue               = []string{"strict-origin-when-cross-origin"}
+	hstsHeaderValue                   = []string{"max-age=315360000; includeSubDomains"}
+	contentTypeOptionsValue           = []string{"nosniff"}
+	frameOptionsValue                 = []string{"DENY"}
 )
 
-// securityHeadersMiddleware sets the framework's fixed set of security
-// headers on every response (API and HTML/SPA alike). X-Download-Options
-// ("noopen") is IE8-only guidance for the long-retired IE8 downloads
-// behavior; no supported browser honors it, so it is not set at all rather
-// than carried forward as dead weight on every response (issue #267). Every
-// other header here is still meaningful in current browsers:
-//   - Content-Security-Policy and X-Frame-Options are the load-bearing
-//     clickjacking/injection defenses.
-//   - Referrer-Policy and X-Content-Type-Options are cheap, still-honored
-//     hardening with no compatibility downside.
+// securityHeadersMiddleware sets the framework's baseline security headers on
+// every response, scoped by response kind (issue #267 / PERF-9). See
+// docs/security.md for the full per-response-kind header table.
 //
-// HTML responses (the embedded SPA) override Content-Security-Policy via
-// applySPAContentSecurityPolicy (see embed.go) to allow the styling the SPA
-// needs; JSON API responses keep the strict default-src 'self' policy set
-// here. See docs/security.md for the full per-response-type header table.
+// X-Content-Type-Options and (in production) Strict-Transport-Security apply
+// to every response. The Content-Security-Policy differs by kind:
+//
+//   - API/JSON (the default, and the hot path): default-src 'none';
+//     frame-ancestors 'none'. Nothing else — this holds the common JSON
+//     response with correlation IDs and Content-Type at <= 6 headers, one
+//     under the swiss-map 8-slot group boundary, so the layer allocates
+//     nothing (the map and net/http's WriteHeader Header.Clone no longer grow).
+//   - Interactive docs (/docs): the full browser policy, applied here by path
+//     because Huma owns that handler. Huma's docs renderer sets its own
+//     Content-Security-Policy (it must allow the Swagger UI assets), so it
+//     overrides the CSP set here; what this branch contributes that Huma does
+//     not is Referrer-Policy and the legacy X-Frame-Options: DENY.
+//
+// HTML documents the framework serves through its own handlers — the admin SPA
+// and the embedded frontend — start from the API baseline set here and then
+// override to the browser policy via applyBrowserSecurityHeaders (see embed.go
+// and adminui.go), which is where the richer SPA CSP, Referrer-Policy, and
+// X-Frame-Options are added. X-Download-Options ("noopen") is IE8-only and set
+// nowhere: no supported browser honors it (issue #267).
 func securityHeadersMiddleware(includeHSTS bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		header := c.Writer.Header()
-		header["Content-Security-Policy"] = cspHeaderValue
-		header["Referrer-Policy"] = referrerPolicyValue
+		header["X-Content-Type-Options"] = contentTypeOptionsValue
 		if includeHSTS {
 			header["Strict-Transport-Security"] = hstsHeaderValue
 		}
-		header["X-Content-Type-Options"] = contentTypeOptionsValue
-		header["X-Frame-Options"] = frameOptionsValue
+		if isDocsPath(c.Request.URL.Path) {
+			header["Content-Security-Policy"] = browserContentSecurityPolicyValue
+			header["Referrer-Policy"] = referrerPolicyValue
+			header["X-Frame-Options"] = frameOptionsValue
+		} else {
+			header["Content-Security-Policy"] = apiContentSecurityPolicyValue
+		}
 		c.Next()
 	}
+}
+
+// isDocsPath reports whether urlPath is Huma's interactive docs UI. Docs is an
+// HTML document served by Huma (contract.DocsPath, root-mounted), so its
+// response kind is decided here by path rather than by an override in a
+// framework handler.
+func isDocsPath(urlPath string) bool {
+	return urlPath == contract.DocsPath || strings.HasPrefix(urlPath, contract.DocsPath+"/")
 }
 
 // httpMetrics accumulates request metrics without locking the request path.

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -358,6 +358,31 @@ func TestDisabledDocsPathGetsAPIPolicy(t *testing.T) {
 	}
 }
 
+// TestEnabledDocsUnknownPathGetsAPIPolicy is the second adversarial case (issue
+// #267 review): Huma registers the docs UI at exactly /docs, not the /docs/
+// subtree, so even with docs enabled a request like /docs/not-a-route is served
+// by no handler (404) and must get the strict API policy — the classification
+// follows the registered route, not a broad URL prefix. Only the exact /docs
+// document is HTML (TestBrowserResponseKindsCarryFullPolicy covers that).
+func TestEnabledDocsUnknownPathGetsAPIPolicy(t *testing.T) {
+	app := newTestApp(t) // test env: /docs enabled
+
+	rec := httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/docs/not-a-route", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /docs/not-a-route: status = %d, want %d (no handler under the docs subtree)", rec.Code, http.StatusNotFound)
+	}
+	if got := rec.Header().Get("Content-Security-Policy"); got != "default-src 'none'; frame-ancestors 'none'" {
+		t.Errorf("GET /docs/not-a-route CSP = %q, want the API policy (unknown path is not the /docs document)", got)
+	}
+	for _, browserOnly := range []string{"Referrer-Policy", "X-Frame-Options"} {
+		if got := rec.Header().Get(browserOnly); got != "" {
+			t.Errorf("GET /docs/not-a-route %s = %q, want empty — an unknown /docs descendant is not an HTML response", browserOnly, got)
+		}
+	}
+}
+
 // TestSecurityHeaderSharedValueContract locks the invariant behind the
 // allocation optimization in securityHeadersMiddleware: the header values are
 // shared, read-only package-level slices assigned straight into each

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -115,7 +116,13 @@ func TestDefaultRouterCarriesTraceContext(t *testing.T) {
 	}
 }
 
-func TestDefaultRouterAddsSecurityHeaders(t *testing.T) {
+// TestDefaultRouterAddsAPISecurityHeaders pins the API/JSON response kind
+// (issue #267 / PERF-9): the strict, minimal policy that lets the common JSON
+// response stay under the 8-header allocation threshold. The CSP is
+// default-src 'none'; frame-ancestors 'none' — no X-Frame-Options and no
+// Referrer-Policy, which are the browser-only headers moved to HTML responses
+// (see TestBrowserResponseKindsCarryFullPolicy).
+func TestDefaultRouterAddsAPISecurityHeaders(t *testing.T) {
 	app := newTestApp(t)
 
 	rec := httptest.NewRecorder()
@@ -127,14 +134,20 @@ func TestDefaultRouterAddsSecurityHeaders(t *testing.T) {
 	}
 
 	want := map[string]string{
-		"Content-Security-Policy": "default-src 'self'",
-		"Referrer-Policy":         "strict-origin-when-cross-origin",
+		"Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
 		"X-Content-Type-Options":  "nosniff",
-		"X-Frame-Options":         "DENY",
 	}
 	for header, value := range want {
 		if got := rec.Header().Get(header); got != value {
 			t.Fatalf("%s = %q, want %q", header, got, value)
+		}
+	}
+	// Browser-only headers do not belong on an API/JSON response — they are the
+	// allocations #267 removed from the hot path. frame-ancestors 'none' in the
+	// CSP already provides the clickjacking defense X-Frame-Options gave.
+	for _, header := range []string{"X-Frame-Options", "Referrer-Policy"} {
+		if got := rec.Header().Get(header); got != "" {
+			t.Fatalf("%s = %q on API response, want empty (browser-only header, HTML responses only)", header, got)
 		}
 	}
 	if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
@@ -150,6 +163,167 @@ func TestDefaultRouterAddsSecurityHeaders(t *testing.T) {
 	}
 }
 
+// TestDefaultJSONResponseStaysUnderHeaderBudget pins the invariant behind the
+// #267 allocation win: the default API/JSON response — correlation IDs +
+// Content-Type + the API security headers — must stay at or below 8 total
+// headers, the swiss-map group boundary past which the header map (and
+// net/http's WriteHeader Header.Clone) grow and cost the security_headers layer
+// ~5 allocs/op. A route that later adds Set-Cookie, Cache-Control, Link, etc.
+// will cross 8 again; keep the default API response lean.
+func TestDefaultJSONResponseStaysUnderHeaderBudget(t *testing.T) {
+	app := newTestApp(t)
+	app.Router().GET("/budget", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"ok": true}})
+	})
+
+	rec := httptest.NewRecorder()
+	app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/budget", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /budget status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	const budget = 8
+	if n := len(rec.Header()); n > budget {
+		t.Fatalf("default JSON response carries %d headers (%v), want <= %d — crossing the swiss-map "+
+			"threshold reintroduces the map-growth allocations #267 removed", n, headerNames(rec.Header()), budget)
+	}
+}
+
+func headerNames(h http.Header) []string {
+	names := make([]string, 0, len(h))
+	for name := range h {
+		names = append(names, name)
+	}
+	return names
+}
+
+// TestSecurityHeadersLayerAllocatesNothing is the in-repo guard for the #267 /
+// PERF-9 allocation win: adding the security-headers layer to the JSON hot path
+// must cost 0 allocs/op. Before #267 the layer added ~5 allocs/op — not from
+// the header values (they are shared, pre-allocated slices) but from header
+// count: a ninth entry tipped the response past Go's 8-slot swiss-map group, so
+// both the handler header map and the Header.Clone net/http does on WriteHeader
+// grew. Scoping the browser-only headers (X-Frame-Options, Referrer-Policy) to
+// HTML responses keeps the API response at <= 8 headers, so the growth — and
+// its allocations — no longer happen. This measures the layer in isolation by
+// comparing an otherwise-identical stack with and without it, under production
+// config (HSTS on: the largest API header set).
+func TestSecurityHeadersLayerAllocatesNothing(t *testing.T) {
+	previous := gin.Mode()
+	t.Cleanup(func() { gin.SetMode(previous) })
+	gin.SetMode(gin.ReleaseMode)
+
+	build := func(withSecurity bool) http.Handler {
+		router := gin.New()
+		router.Use(requestContextMiddleware())
+		router.Use(metricsMiddleware(newHTTPMetrics()))
+		if withSecurity {
+			router.Use(securityHeadersMiddleware(true)) // includeHSTS: production
+		}
+		router.GET("/json", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"data": gin.H{"ok": true}})
+		})
+		return router
+	}
+
+	allocs := func(handler http.Handler) float64 {
+		return testing.AllocsPerRun(200, func() {
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/json", nil))
+		})
+	}
+
+	withSecurity := allocs(build(true))
+	withoutSecurity := allocs(build(false))
+	if diff := withSecurity - withoutSecurity; diff > 0.5 {
+		t.Fatalf("security-headers layer adds %.1f allocs/op (with=%.1f, without=%.1f), want 0 — "+
+			"the API response has likely crossed the 8-header swiss-map threshold again (issue #267)",
+			diff, withSecurity, withoutSecurity)
+	}
+}
+
+// TestBrowserResponseKindsCarryFullPolicy pins the HTML/browser response kinds
+// (issue #267 / PERF-9): the embedded SPA, the admin SPA, and Huma's
+// interactive docs each keep the full browser policy — a browser-appropriate
+// Content-Security-Policy plus Referrer-Policy and X-Frame-Options: DENY —
+// rather than the stripped API baseline. X-Content-Type-Options is present on
+// every kind.
+func TestBrowserResponseKindsCarryFullPolicy(t *testing.T) {
+	assertBrowserHeaders := func(t *testing.T, h http.Header, wantCSPContains string) {
+		t.Helper()
+		if got := h.Get("Content-Security-Policy"); !strings.Contains(got, wantCSPContains) {
+			t.Fatalf("Content-Security-Policy = %q, want it to contain %q", got, wantCSPContains)
+		}
+		if got := h.Get("Referrer-Policy"); got != "strict-origin-when-cross-origin" {
+			t.Fatalf("Referrer-Policy = %q, want strict-origin-when-cross-origin", got)
+		}
+		if got := h.Get("X-Frame-Options"); got != "DENY" {
+			t.Fatalf("X-Frame-Options = %q, want DENY", got)
+		}
+		if got := h.Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+		}
+	}
+
+	t.Run("embedded SPA index", func(t *testing.T) {
+		app := newTestApp(t, WithEmbeddedFrontend(spaFixtureFS()))
+		rec := httptest.NewRecorder()
+		app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET / status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+		}
+		// The SPA CSP is the looser document policy (fonts/styles), not the API
+		// default-src 'none'.
+		assertBrowserHeaders(t, rec.Header(), "fonts.googleapis.com")
+	})
+
+	t.Run("admin SPA index", func(t *testing.T) {
+		// The admin SPA mounts only under cookie auth (ADR-013), which needs a
+		// database; exercise the same composition it runs under — the security
+		// middleware plus the admin handler — directly instead.
+		router := gin.New()
+		router.Use(securityHeadersMiddleware(false))
+		mountAdminSPA(router, adminFixtureFS(), "/api/v1")
+
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/admin/", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /admin/ status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+		}
+		assertBrowserHeaders(t, rec.Header(), "default-src 'self'")
+	})
+
+	t.Run("interactive docs", func(t *testing.T) {
+		app := newTestApp(t) // test env: /docs enabled
+		rec := httptest.NewRecorder()
+		app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/docs", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET /docs status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+		}
+		// Huma's docs renderer sets its own Content-Security-Policy (it must
+		// allow the Swagger UI assets), so the framework does not dictate the
+		// docs CSP — it only contributes the browser hardening Huma omits.
+		if got := rec.Header().Get("Referrer-Policy"); got != "strict-origin-when-cross-origin" {
+			t.Fatalf("/docs Referrer-Policy = %q, want strict-origin-when-cross-origin", got)
+		}
+		if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
+			t.Fatalf("/docs X-Frame-Options = %q, want DENY", got)
+		}
+		if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Fatalf("/docs X-Content-Type-Options = %q, want nosniff", got)
+		}
+		if got := rec.Header().Get("Content-Security-Policy"); got == "" {
+			t.Fatal("/docs Content-Security-Policy is empty, want Huma's docs policy")
+		}
+	})
+}
+
+func adminFixtureFS() fstest.MapFS {
+	return fstest.MapFS{
+		"index.html": {Data: []byte("<!doctype html><div id=\"root\">admin</div>")},
+	}
+}
+
 // TestSecurityHeaderSharedValueContract locks the invariant behind the
 // allocation optimization in securityHeadersMiddleware: the header values are
 // shared, read-only package-level slices assigned straight into each
@@ -158,30 +332,33 @@ func TestDefaultRouterAddsSecurityHeaders(t *testing.T) {
 // in-place slice write leaks into the process-global value. All three paths
 // are exercised so the contract is proven, not merely self-consistent.
 func TestSecurityHeaderSharedValueContract(t *testing.T) {
-	const key = "X-Frame-Options"
+	const key = "Content-Security-Policy"
+	// The API/JSON policy the middleware assigns to /livez from the shared
+	// apiContentSecurityPolicyValue slice.
+	const apiCSP = "default-src 'none'; frame-ancestors 'none'"
 
-	// Set is the supported override API — applySPAContentSecurityPolicy uses
-	// it. It replaces the map entry, so the shared value stays request-local.
+	// Set is the supported override API — applyBrowserSecurityHeaders uses it.
+	// It replaces the map entry, so the shared value stays request-local.
 	t.Run("set override stays request-local", func(t *testing.T) {
 		app := newTestApp(t)
 		app.Router().GET("/set-header", func(c *gin.Context) {
-			c.Header(key, "SAMEORIGIN")
+			c.Header(key, "default-src 'test'")
 			c.Status(http.StatusOK)
 		})
 
 		overridden := httptest.NewRecorder()
 		app.Router().ServeHTTP(overridden, httptest.NewRequest(http.MethodGet, "/set-header", nil))
-		if got := overridden.Header().Get(key); got != "SAMEORIGIN" {
-			t.Fatalf("overridden %s = %q, want SAMEORIGIN", key, got)
+		if got := overridden.Header().Get(key); got != "default-src 'test'" {
+			t.Fatalf("overridden %s = %q, want default-src 'test'", key, got)
 		}
 
 		next := httptest.NewRecorder()
 		app.Router().ServeHTTP(next, httptest.NewRequest(http.MethodGet, "/livez", nil))
-		if got := next.Header().Get(key); got != "DENY" {
-			t.Fatalf("later %s = %q, want DENY — Set must not touch the shared value", key, got)
+		if got := next.Header().Get(key); got != apiCSP {
+			t.Fatalf("later %s = %q, want %q — Set must not touch the shared value", key, got, apiCSP)
 		}
-		if frameOptionsValue[0] != "DENY" {
-			t.Fatalf("frameOptionsValue = %v, want [DENY]", frameOptionsValue)
+		if apiContentSecurityPolicyValue[0] != apiCSP {
+			t.Fatalf("apiContentSecurityPolicyValue = %v, want [%q]", apiContentSecurityPolicyValue, apiCSP)
 		}
 	})
 
@@ -190,23 +367,23 @@ func TestSecurityHeaderSharedValueContract(t *testing.T) {
 	t.Run("add reallocates and stays request-local", func(t *testing.T) {
 		app := newTestApp(t)
 		app.Router().GET("/add-header", func(c *gin.Context) {
-			c.Writer.Header().Add(key, "SAMEORIGIN")
+			c.Writer.Header().Add(key, "default-src 'extra'")
 			c.Status(http.StatusOK)
 		})
 
 		added := httptest.NewRecorder()
 		app.Router().ServeHTTP(added, httptest.NewRequest(http.MethodGet, "/add-header", nil))
-		if got := added.Header().Values(key); len(got) != 2 || got[0] != "DENY" || got[1] != "SAMEORIGIN" {
-			t.Fatalf("added %s = %v, want [DENY SAMEORIGIN]", key, got)
+		if got := added.Header().Values(key); len(got) != 2 || got[0] != apiCSP || got[1] != "default-src 'extra'" {
+			t.Fatalf("added %s = %v, want [%q default-src 'extra']", key, got, apiCSP)
 		}
 
 		next := httptest.NewRecorder()
 		app.Router().ServeHTTP(next, httptest.NewRequest(http.MethodGet, "/livez", nil))
-		if got := next.Header().Values(key); len(got) != 1 || got[0] != "DENY" {
-			t.Fatalf("later %s = %v, want [DENY]", key, got)
+		if got := next.Header().Values(key); len(got) != 1 || got[0] != apiCSP {
+			t.Fatalf("later %s = %v, want [%q]", key, got, apiCSP)
 		}
-		if frameOptionsValue[0] != "DENY" {
-			t.Fatalf("frameOptionsValue = %v, want [DENY]", frameOptionsValue)
+		if apiContentSecurityPolicyValue[0] != apiCSP {
+			t.Fatalf("apiContentSecurityPolicyValue = %v, want [%q]", apiContentSecurityPolicyValue, apiCSP)
 		}
 	})
 
@@ -216,19 +393,19 @@ func TestSecurityHeaderSharedValueContract(t *testing.T) {
 	// Cleanup) so the read-only constraint in securityHeadersMiddleware is
 	// executable, not just prose. Real handlers MUST NOT do this — use Set.
 	t.Run("in-place mutation leaks into the shared value (unsupported)", func(t *testing.T) {
-		t.Cleanup(func() { frameOptionsValue = []string{"DENY"} })
+		t.Cleanup(func() { apiContentSecurityPolicyValue = []string{apiCSP} })
 
 		app := newTestApp(t)
 		app.Router().GET("/mutate-in-place", func(c *gin.Context) {
-			c.Writer.Header().Values(key)[0] = "ALLOWALL"
+			c.Writer.Header().Values(key)[0] = "default-src *"
 			c.Status(http.StatusOK)
 		})
 		app.Router().ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/mutate-in-place", nil))
 
-		if frameOptionsValue[0] != "ALLOWALL" {
-			t.Fatalf("frameOptionsValue = %v; an in-place Values() write was expected to leak into the "+
+		if apiContentSecurityPolicyValue[0] != "default-src *" {
+			t.Fatalf("apiContentSecurityPolicyValue = %v; an in-place Values() write was expected to leak into the "+
 				"shared value. If it no longer does, in-place mutation became safe and the middleware "+
-				"comment must be updated to match", frameOptionsValue)
+				"comment must be updated to match", apiContentSecurityPolicyValue)
 		}
 	})
 }

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -130,7 +130,6 @@ func TestDefaultRouterAddsSecurityHeaders(t *testing.T) {
 		"Content-Security-Policy": "default-src 'self'",
 		"Referrer-Policy":         "strict-origin-when-cross-origin",
 		"X-Content-Type-Options":  "nosniff",
-		"X-Download-Options":      "noopen",
 		"X-Frame-Options":         "DENY",
 	}
 	for header, value := range want {
@@ -143,6 +142,11 @@ func TestDefaultRouterAddsSecurityHeaders(t *testing.T) {
 	}
 	if got := rec.Header().Get("X-XSS-Protection"); got != "" {
 		t.Fatalf("X-XSS-Protection = %q, want empty deprecated header", got)
+	}
+	// X-Download-Options is IE8-only guidance; no supported browser honors
+	// it, so the framework intentionally does not set it (issue #267).
+	if got := rec.Header().Get("X-Download-Options"); got != "" {
+		t.Fatalf("X-Download-Options = %q, want empty deprecated header", got)
 	}
 }
 

--- a/framework/observability_security_test.go
+++ b/framework/observability_security_test.go
@@ -218,7 +218,7 @@ func TestSecurityHeadersLayerAllocatesNothing(t *testing.T) {
 		router.Use(requestContextMiddleware())
 		router.Use(metricsMiddleware(newHTTPMetrics()))
 		if withSecurity {
-			router.Use(securityHeadersMiddleware(true)) // includeHSTS: production
+			router.Use(securityHeadersMiddleware(true, false)) // includeHSTS: production; docs disabled
 		}
 		router.GET("/json", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"data": gin.H{"ok": true}})
@@ -282,7 +282,7 @@ func TestBrowserResponseKindsCarryFullPolicy(t *testing.T) {
 		// database; exercise the same composition it runs under — the security
 		// middleware plus the admin handler — directly instead.
 		router := gin.New()
-		router.Use(securityHeadersMiddleware(false))
+		router.Use(securityHeadersMiddleware(false, false))
 		mountAdminSPA(router, adminFixtureFS(), "/api/v1")
 
 		rec := httptest.NewRecorder()
@@ -321,6 +321,40 @@ func TestBrowserResponseKindsCarryFullPolicy(t *testing.T) {
 func adminFixtureFS() fstest.MapFS {
 	return fstest.MapFS{
 		"index.html": {Data: []byte("<!doctype html><div id=\"root\">admin</div>")},
+	}
+}
+
+// TestDisabledDocsPathGetsAPIPolicy is the adversarial case for the docs
+// classification (issue #267 review): with docs disabled (the production
+// default) there is no /docs handler, so a /docs request is an ordinary
+// not-found API response and must get the strict API policy — not the
+// HTML-only Referrer-Policy/X-Frame-Options it would get if classification
+// keyed on the URL prefix alone. The security-headers layer must not promote a
+// response to HTML for a route that does not exist in this configuration.
+func TestDisabledDocsPathGetsAPIPolicy(t *testing.T) {
+	previous := gin.Mode()
+	t.Cleanup(func() { gin.SetMode(previous) })
+
+	cfg := config.DefaultFor(config.EnvironmentProduction) // DocsEnabled=false
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	app := newTestApp(t, WithConfig(cfg))
+
+	for _, path := range []string{"/docs", "/docs/index.html"} {
+		rec := httptest.NewRecorder()
+		app.Router().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+		// No docs route exists, so this is a not-found API response.
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("GET %s with docs disabled: status = %d, want %d", path, rec.Code, http.StatusNotFound)
+		}
+		if got := rec.Header().Get("Content-Security-Policy"); got != "default-src 'none'; frame-ancestors 'none'" {
+			t.Errorf("GET %s CSP = %q, want the API policy (docs disabled → not an HTML response)", path, got)
+		}
+		for _, browserOnly := range []string{"Referrer-Policy", "X-Frame-Options"} {
+			if got := rec.Header().Get(browserOnly); got != "" {
+				t.Errorf("GET %s %s = %q, want empty — a disabled-docs path is not an HTML response", path, browserOnly, got)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Scopes the runtime security headers **by response kind** (issue #267 / PERF-9): API/JSON responses get a strict, minimal policy while HTML responses (the SPA, the admin SPA, and Huma's `/docs`) keep the full browser policy. This holds the common JSON response under Go's 8-header swiss-map threshold, removing ~5 allocs/op of header-map growth from every API response, and drops the dead IE8-only `X-Download-Options` header.

Before this change `securityHeadersMiddleware` set one fixed policy (CSP `default-src 'self'` + `Referrer-Policy` + `X-Frame-Options` + `X-Content-Type-Options` + HSTS) on **every** response — the ninth header that tipped API responses over the swiss-map group boundary.

### What changed

- **`framework/http_middleware.go`** — `securityHeadersMiddleware(includeHSTS, docsEnabled bool)`:
  - **API/JSON (default, hot path):** `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'` + `X-Content-Type-Options: nosniff` (+ HSTS in production). No `X-Frame-Options` or `Referrer-Policy` — `frame-ancestors 'none'` subsumes the former, and a `default-src 'none'` document needs neither. ≤ 6 headers with correlation IDs + Content-Type, so the layer allocates nothing.
  - **`/docs` (only when `DocsEnabled`):** the browser hardening headers Huma's docs renderer omits (`Referrer-Policy`, `X-Frame-Options`); Huma sets its own CSP for the Swagger UI assets. Classification is gated on `DocsEnabled`, so with docs disabled a `/docs` request is an ordinary not-found **API** response and gets the API policy — the response kind follows what is actually served, not the URL prefix.
- **`framework/embed.go` / `framework/adminui.go`** — HTML documents the framework serves through its own handlers (embedded SPA `index.html`, admin SPA) start from the API baseline and are promoted to the full browser policy (SPA CSP + `Referrer-Policy` + `X-Frame-Options`) via `applyBrowserSecurityHeaders`.
- **`X-Download-Options` removed** — IE8-only, honored by no supported browser, and part of what pushed the API response over the header threshold.
- **Tests** — a test per response kind (`TestDefaultRouterAddsAPISecurityHeaders`, `TestBrowserResponseKindsCarryFullPolicy` for SPA/admin/docs, `TestDisabledDocsPathGetsAPIPolicy` for the disabled-docs adversarial case), a header-budget invariant (`TestDefaultJSONResponseStaysUnderHeaderBudget`), an allocation-regression test proving the layer adds 0 allocs/op (`TestSecurityHeadersLayerAllocatesNothing`), and the shared-value contract re-anchored on the API CSP header.
- **Docs** — new [`docs/security.md`](docs/security.md) with the per-response-kind header table + rationale; `docs/build.md`, `docs/openapi.md`, the docs index, and `CHANGELOG.md` updated.

Fixes #267.

## Validation

- [x] `go test ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run`

## Working agreement checklist

- [x] New behavior has tests (a test per response kind + header-budget + 0-alloc regression tests)
- [x] Stable features ship docs — new `docs/security.md`, CHANGELOG note for the removed header and the CSP change
- [x] Extraction preserves contracts — HTML responses keep the full browser policy; only the API response kind is narrowed
- [x] Scope stays inside this issue's milestone — runtime security headers only
- [x] This PR links its issue (#267)
