### PR TITLE
fix: CSRF cookie reuse + request-time read + 403 recovery (#250)

### DIFF
--- a/auth/cookie_handlers_test.go
+++ b/auth/cookie_handlers_test.go
@@ -107,6 +107,78 @@ func fetchCSRF(t *testing.T, app *framework.App) *cookieJar {
 	return jar
 }
 
+func csrfBodyToken(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var env struct {
+		Data struct {
+			CSRFToken string `json:"csrf_token"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode csrf body: %v; body: %s", err, rec.Body.String())
+	}
+	return env.Data.CSRFToken
+}
+
+// TestCSRFBootstrapReusesValidCookie pins the #250 server fix: a re-bootstrap of
+// GET /auth/csrf that already carries a valid signed cookie must REUSE that
+// token, not rotate it. Rotation is what lets a second tab's bootstrap
+// invalidate the token every other tab holds, permanently breaking their writes.
+func TestCSRFBootstrapReusesValidCookie(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieAuthApp(t)
+
+	jar := fetchCSRF(t, app)
+	first := jar.value(auth.CSRFCookieName)
+	if first == "" {
+		t.Fatal("first bootstrap set no csrf cookie")
+	}
+
+	rec := doRequest(app, jar, http.MethodGet, "/api/v1/auth/csrf", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("re-bootstrap status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	if got := jar.value(auth.CSRFCookieName); got != first {
+		t.Fatalf("csrf cookie rotated on re-bootstrap: %q -> %q", first, got)
+	}
+	if tok := csrfBodyToken(t, rec); tok != first {
+		t.Fatalf("csrf body token = %q, want reused cookie value %q", tok, first)
+	}
+
+	// The reused token still authorizes a write (it matches the shared cookie).
+	registerCookieUser(t, app, jar, "csrf-reuse@example.com", testPassword)
+	if rec := loginCookieUser(t, app, jar, "csrf-reuse@example.com", testPassword); rec.Code != http.StatusOK {
+		t.Fatalf("login with reused csrf token status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCSRFBootstrapReplacesInvalidCookie verifies a forged/unsigned cookie is not
+// trusted: the server mints a fresh signed token rather than echoing the bogus one.
+func TestCSRFBootstrapReplacesInvalidCookie(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	app := newCookieAuthApp(t)
+
+	jar := newCookieJar()
+	jar.cookies[auth.CSRFCookieName] = &http.Cookie{Name: auth.CSRFCookieName, Value: "forged-not-signed"}
+
+	rec := doRequest(app, jar, http.MethodGet, "/api/v1/auth/csrf", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("bootstrap status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	got := jar.value(auth.CSRFCookieName)
+	if got == "" || got == "forged-not-signed" {
+		t.Fatalf("invalid cookie not replaced: got %q", got)
+	}
+	if tok := csrfBodyToken(t, rec); tok != got {
+		t.Fatalf("body token %q != minted cookie %q", tok, got)
+	}
+
+	registerCookieUser(t, app, jar, "csrf-fresh@example.com", testPassword)
+	if rec := loginCookieUser(t, app, jar, "csrf-fresh@example.com", testPassword); rec.Code != http.StatusOK {
+		t.Fatalf("login after fresh mint status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func registerCookieUser(t *testing.T, app *framework.App, jar *cookieJar, email, password string) {
 	t.Helper()
 	body, err := json.Marshal(map[string]string{"email": email, "password": password})

--- a/auth/cookie_handlers_test.go
+++ b/auth/cookie_handlers_test.go
@@ -159,7 +159,7 @@ func TestCSRFBootstrapReplacesInvalidCookie(t *testing.T) {
 	app := newCookieAuthApp(t)
 
 	jar := newCookieJar()
-	jar.cookies[auth.CSRFCookieName] = &http.Cookie{Name: auth.CSRFCookieName, Value: "forged-not-signed"}
+	jar.cookies[auth.CSRFCookieName] = &http.Cookie{Name: auth.CSRFCookieName, Value: "forged-not-signed"} //nolint:gosec // G124: test fixture seeds a name/value cookie to exercise the forged-cookie path.
 
 	rec := doRequest(app, jar, http.MethodGet, "/api/v1/auth/csrf", "")
 	if rec.Code != http.StatusOK {

--- a/auth/csrf.go
+++ b/auth/csrf.go
@@ -151,13 +151,33 @@ type csrfOutput struct {
 	Body      contract.Data[csrfResult]
 }
 
+// csrfInput carries the caller's existing gombit_csrf cookie, if any, so the
+// bootstrap endpoint can reuse a still-valid token instead of rotating. The
+// cookie is ambient (not a documented request parameter); it is read here only
+// to make reuse possible.
+type csrfInput struct {
+	Existing http.Cookie `cookie:"gombit_csrf"`
+}
+
 // issueCSRFToken mounts GET /auth/csrf: the bootstrap endpoint an SPA calls
-// once (e.g. on app load) so the first mutating request — including
-// /auth/login — has a CSRF cookie to double-submit against.
-func (s *Service) issueCSRFToken(ctx context.Context, _ *struct{}) (*csrfOutput, error) {
-	value, err := newCSRFTokenValue(s.secret)
-	if err != nil {
-		return nil, contract.WithContext(ctx, contract.Internal("generate csrf token"))
+// (e.g. on app load) so the first mutating request — including /auth/login —
+// has a CSRF cookie to double-submit against.
+//
+// It REUSES a still-valid signed cookie rather than minting a fresh token on
+// every call (#250): the double-submit defense needs a shared signed value, not
+// a per-call-unique one, and rotating on each bootstrap invalidates the token
+// every other tab already holds — permanently breaking writes in those tabs.
+// Re-setting the same value also refreshes the cookie's Max-Age, so a long-lived
+// tab's CSRF cookie does not silently expire out from under it. Only a missing or
+// invalid (unsigned/forged) cookie triggers a fresh mint.
+func (s *Service) issueCSRFToken(ctx context.Context, in *csrfInput) (*csrfOutput, error) {
+	value := strings.TrimSpace(in.Existing.Value)
+	if !validCSRFTokenValue(s.secret, value) {
+		fresh, err := newCSRFTokenValue(s.secret)
+		if err != nil {
+			return nil, contract.WithContext(ctx, contract.Internal("generate csrf token"))
+		}
+		value = fresh
 	}
 	return &csrfOutput{
 		SetCookie: []http.Cookie{csrfCookie(value, s.cfg)},

--- a/docs/auth-cookie.md
+++ b/docs/auth-cookie.md
@@ -76,14 +76,16 @@ app — including feature routes added later via `app.Router()` — not just
   {"error": {"code": "authorization", "message": "csrf token missing or invalid", "request_id": "..."}}
   ```
 
-`GET /auth/csrf` is the bootstrap endpoint: it **always mints a new** signed
-cookie+body pair (it does not reuse an existing `gombit_csrf` cookie). The
-SPA must not overlap these calls — overlapping responses desync the HttpOnly
-cookie from the in-memory `X-CSRF-Token` and login then 403s. The generated
-client serializes that (see [Generated frontend](#generated-frontend)). The
-token is mirrored in both the `Set-Cookie` header and the JSON body
-(`{"data": {"csrf_token": "..."}}`) so the SPA does not need to parse
-`document.cookie` itself.
+`GET /auth/csrf` is the bootstrap endpoint: it **reuses a still-valid signed
+`gombit_csrf` cookie** and only mints a fresh token when the request carries no
+cookie or a forged/invalid one. Re-setting the same value also refreshes the
+cookie's `Max-Age`. This is deliberate (#250): double-submit needs a *shared*
+signed value, not a per-call-unique one. Minting on every call would rotate the
+cookie shared by all tabs, so a second tab's bootstrap would invalidate the
+token the first tab holds and permanently 403 its writes. The token is mirrored
+in both the `Set-Cookie` header and the JSON body (`{"data": {"csrf_token":
+"..."}}`); the SPA reads it from the JS-readable cookie at request time (see
+[Generated frontend](#generated-frontend)).
 
 ### Exempting non-browser endpoints (webhooks)
 
@@ -133,7 +135,7 @@ differs: tokens travel in cookies, not JSON.
 
 | Method | Path | Auth | Notes |
 | --- | --- | --- | --- |
-| `GET` | `/auth/csrf` | Public, safe (CSRF-exempt) | Always issues a **new** CSRF cookie+body pair; body mirrors it as `csrf_token`. |
+| `GET` | `/auth/csrf` | Public, safe (CSRF-exempt) | Reuses a valid `gombit_csrf` cookie (refreshing its `Max-Age`); mints a new one only if missing/invalid. Body mirrors the value as `csrf_token`. |
 | `POST` | `/auth/register` | Public, CSRF-protected | Same as Bearer mode: creates a user, never sets `IsSuperuser`. |
 | `POST` | `/auth/login` | Public, CSRF-protected | Body `{email, password}`. On success, sets `gombit_access` + `gombit_refresh` cookies; body is the public user, not tokens. |
 | `POST` | `/auth/refresh` | Cookie (`gombit_refresh`), CSRF-protected | No request body; reads the refresh cookie. Rotates both session cookies. |
@@ -160,25 +162,27 @@ production JWT-secret-strength check.
 ## Generated frontend
 
 `frontend/src/auth/session.ts` (cookie variant) tracks only a boolean
-"authenticated" flag and the in-memory CSRF token — never the session
+"authenticated" flag and an in-memory CSRF mirror — never the session
 tokens themselves, which the browser holds as HttpOnly cookies this code
 cannot read. `frontend/src/api/client.ts` attaches `X-CSRF-Token` on unsafe
-requests and retries once after a silent `/auth/refresh` on 401. CSRF and
-refresh `fetch()` URLs go through `apiPath()` so they follow
-`GOMBIT_API_PREFIX`. Typed openapi-fetch calls keep `/api/v1/...` path
-keys; `rewriteAPIRequest` maps them to the live prefix. The retry
-rebuilds the request from buffered body bytes so POST/PATCH JSON survives
-that refresh (buffering is gated on method; Firefox does not implement
-the Request.body getter). `RequireAuth` confirms a session by calling
-`GET /me` (it cannot check an in-memory token, unlike Bearer mode).
-`LoginPage` warms the token with `bootstrapCSRF()` on mount and **awaits**
-it before `POST /auth/login` and `POST /auth/register`. `AppProviders` also
-fires `bootstrapCSRF()` so a hard reload on a gated route still has an
-in-memory `X-CSRF-Token` before POST/PATCH/DELETE. Unsafe client requests
-and silent refresh await that in-flight pair. Concurrent callers
-share one in-flight promise (`csrfInFlight`); if a token is already in
-memory the call is a no-op so React StrictMode remounts do not mint a
-second pair. `clearSession` drops the in-memory CSRF token. See the templates under
+requests by reading the JS-readable `gombit_csrf` cookie **at request time**
+(the in-memory value is only a fallback), so a cookie rotated or re-minted by
+another tab or after expiry is always matched. It retries once after a silent
+`/auth/refresh` on 401, and **once after re-bootstrapping CSRF on a 403** —
+clearing the stale mirror, forcing a fresh `GET /auth/csrf`, and replaying the
+request. CSRF and refresh `fetch()` URLs go through `apiPath()` so they follow
+`GOMBIT_API_PREFIX`. Typed openapi-fetch calls keep `/api/v1/...` path keys;
+`rewriteAPIRequest` maps them to the live prefix. Both retries rebuild the
+request from buffered body bytes so POST/PATCH JSON survives (buffering is gated
+on method; Firefox does not implement the Request.body getter). `RequireAuth`
+confirms a session by calling `GET /me`. `LoginPage` warms the cookie with
+`bootstrapCSRF()` on mount and **awaits** it before `POST /auth/login` and
+`POST /auth/register`. `AppProviders` also fires `bootstrapCSRF()` so a hard
+reload on a gated route has a `gombit_csrf` cookie before POST/PATCH/DELETE.
+Concurrent callers share one in-flight promise (`csrfInFlight`); `bootstrapCSRF`
+is a no-op when the cookie is already present (so concurrent tabs converge on
+the one shared cookie), and `force=true` re-fetches for 403 recovery. See the
+templates under
 [`scaffold/templates/frontend/src`](../scaffold/templates/frontend/src) for
 the exact `{{if eq .Auth "cookie"}}` branches.
 

--- a/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
@@ -65,11 +65,23 @@ export function createAppClient(): ApiClient {
     refreshInFlight = (async () => {
       try {
         await bootstrapCSRF();
-        const response = await fetch(baseUrl + apiPath("/auth/refresh"), {
+        let response = await fetch(baseUrl + apiPath("/auth/refresh"), {
           method: "POST",
           credentials: "same-origin",
           headers: csrfRequestHeaders(),
         });
+        if (response.status === 403) {
+          // /auth/refresh is itself CSRF-protected: a stale/rotated cookie 403s
+          // it. Force a fresh CSRF pair and retry the refresh once before giving
+          // up, so a bad cookie can't strand a still-valid session (#250).
+          setCSRFToken(undefined);
+          await bootstrapCSRF(true);
+          response = await fetch(baseUrl + apiPath("/auth/refresh"), {
+            method: "POST",
+            credentials: "same-origin",
+            headers: csrfRequestHeaders(),
+          });
+        }
         if (!response.ok) {
           throw new Error(`refresh failed: ${response.status}`);
         }
@@ -91,14 +103,12 @@ export function createAppClient(): ApiClient {
       return request;
     },
     async onResponse({ request, response }) {
-      if (
-        response.status === 403 &&
-        isUnsafeMethod(request.method) &&
-        !isAuthURL(request.url)
-      ) {
+      if (response.status === 403 && isUnsafeMethod(request.method)) {
         // A CSRF 403 means our cookie was rotated/expired out from under us.
         // Drop the stale in-memory mirror, force a fresh bootstrap, and retry
-        // once — mirroring the 401 silent-refresh path (#250).
+        // once — mirroring the 401 silent-refresh path (#250). This runs for
+        // auth endpoints too (login/register/logout are CSRF-protected): the
+        // auth-URL exclusion applies only to 401 refresh, not CSRF recovery.
         setCSRFToken(undefined);
         await bootstrapCSRF(true);
         const headers = new Headers(request.headers);
@@ -173,7 +183,19 @@ function readCSRFCookie(): string {
     return "";
   }
   const match = document.cookie.match(/(?:^|;\s*)gombit_csrf=([^;]*)/);
-  return match ? decodeURIComponent(match[1]) : "";
+  if (!match) {
+    return "";
+  }
+  // The server token is hex + "." (no encoding), but a malformed cookie such as
+  // "gombit_csrf=%" would make decodeURIComponent throw a URIError before any
+  // request is sent — stranding the tab before the server can replace the bad
+  // cookie. Decode best-effort; fall back to the raw value so it still reaches
+  // the server (which rejects it, triggering 403 recovery) instead of crashing.
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
 }
 
 /** Current CSRF token: the live cookie wins over the in-memory mirror. */

--- a/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
@@ -20,9 +20,11 @@ export { apiPath, apiPrefix, DEFAULT_API_PREFIX, rewriteAPIRequest } from "./api
  * Wire the generated openapi-fetch client for cookie-mode session auth
  * (M5-3). Session cookies (HttpOnly) and the CSRF cookie are managed by the
  * browser on same-origin requests; this wiring adds the X-CSRF-Token
- * double-submit header on state-changing requests and retries once after a
- * silent cookie refresh on 401. The retry rebuilds fetch() from buffered
- * body bytes so POST/PATCH JSON survives that refresh. See docs/auth-cookie.md.
+ * double-submit header (read from the gombit_csrf cookie at request time) on
+ * state-changing requests, retries once after a silent cookie refresh on 401,
+ * and retries once after re-bootstrapping CSRF on a 403. The retry rebuilds
+ * fetch() from buffered body bytes so POST/PATCH JSON survives. See
+ * docs/auth-cookie.md.
  *
  * The CSRF bootstrap and refresh calls below use fetch directly instead of
  * the typed client: they are session infrastructure, not part of the
@@ -41,7 +43,10 @@ export function createAppClient(): ApiClient {
       request = rewriteAPIRequest(request);
       if (isUnsafeMethod(request.method)) {
         await bootstrapCSRF();
-        const token = getCSRFToken();
+        // Read at request time from the JS-readable gombit_csrf cookie (the
+        // authoritative double-submit value) so a cookie rotated/re-minted by
+        // another tab or after expiry is always matched (#250).
+        const token = currentCSRFToken();
         if (token) {
           request.headers.set("X-CSRF-Token", token);
         }
@@ -86,6 +91,23 @@ export function createAppClient(): ApiClient {
       return request;
     },
     async onResponse({ request, response }) {
+      if (
+        response.status === 403 &&
+        isUnsafeMethod(request.method) &&
+        !isAuthURL(request.url)
+      ) {
+        // A CSRF 403 means our cookie was rotated/expired out from under us.
+        // Drop the stale in-memory mirror, force a fresh bootstrap, and retry
+        // once — mirroring the 401 silent-refresh path (#250).
+        setCSRFToken(undefined);
+        await bootstrapCSRF(true);
+        const headers = new Headers(request.headers);
+        const token = currentCSRFToken();
+        if (token) {
+          headers.set("X-CSRF-Token", token);
+        }
+        return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
+      }
       if (response.status !== 401 || isAuthURL(request.url)) {
         return response;
       }
@@ -94,7 +116,7 @@ export function createAppClient(): ApiClient {
         return response;
       }
       const headers = new Headers(request.headers);
-      const token = getCSRFToken();
+      const token = currentCSRFToken();
       if (token) {
         headers.set("X-CSRF-Token", token);
       }
@@ -107,16 +129,16 @@ export function createAppClient(): ApiClient {
 let csrfInFlight: Promise<void> | null = null;
 
 /**
- * Fetches a CSRF cookie/token pair. Concurrent callers share one in-flight
- * promise (GET /auth/csrf always mints a new pair; overlapping responses
- * desync the cookie from the in-memory X-CSRF-Token). If a token is already
- * in memory, this is a no-op so React StrictMode remounts do not mint a
- * second pair. After clearSession the token is gone and the next call
- * bootstraps again. Unsafe requests and silent refresh await this
- * before POST so a reload cannot race GET /auth/csrf.
+ * Ensures a CSRF cookie exists and mirrors its token in memory. Keys off the
+ * JS-readable gombit_csrf cookie, not the in-memory token: if the cookie is
+ * already present this is a no-op, so concurrent tabs converge on the one
+ * shared cookie. GET /auth/csrf reuses a valid cookie server-side (#250), so
+ * overlapping bootstraps no longer rotate it. Pass force=true to re-fetch even
+ * when a cookie is present (403 recovery). Concurrent callers share one
+ * in-flight promise; unsafe requests and silent refresh await this before POST.
  */
-export function bootstrapCSRF(): Promise<void> {
-  if (getCSRFToken()) {
+export function bootstrapCSRF(force = false): Promise<void> {
+  if (!force && readCSRFCookie()) {
     return Promise.resolve();
   }
   if (csrfInFlight) {
@@ -142,8 +164,25 @@ export function bootstrapCSRF(): Promise<void> {
   return csrfInFlight;
 }
 
+/**
+ * Reads the JS-readable gombit_csrf cookie — the authoritative double-submit
+ * value. The cookie is deliberately not HttpOnly so the SPA can echo it.
+ */
+function readCSRFCookie(): string {
+  if (typeof document === "undefined") {
+    return "";
+  }
+  const match = document.cookie.match(/(?:^|;\s*)gombit_csrf=([^;]*)/);
+  return match ? decodeURIComponent(match[1]) : "";
+}
+
+/** Current CSRF token: the live cookie wins over the in-memory mirror. */
+function currentCSRFToken(): string {
+  return readCSRFCookie() || getCSRFToken() || "";
+}
+
 function csrfRequestHeaders(): HeadersInit {
-  const token = getCSRFToken();
+  const token = currentCSRFToken();
   return token ? { "X-CSRF-Token": token } : {};
 }
 

--- a/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
+++ b/goldentest/testdata/golden/new-cookie/frontend/src/api/client.ts
@@ -103,34 +103,42 @@ export function createAppClient(): ApiClient {
       return request;
     },
     async onResponse({ request, response }) {
-      if (response.status === 403 && isUnsafeMethod(request.method)) {
-        // A CSRF 403 means our cookie was rotated/expired out from under us.
-        // Drop the stale in-memory mirror, force a fresh bootstrap, and retry
-        // once — mirroring the 401 silent-refresh path (#250). This runs for
-        // auth endpoints too (login/register/logout are CSRF-protected): the
-        // auth-URL exclusion applies only to 401 refresh, not CSRF recovery.
-        setCSRFToken(undefined);
-        await bootstrapCSRF(true);
+      // Bounded recovery: a CSRF 403 (rotated/expired cookie) and a session 401
+      // (expired access cookie) can each occur — and consecutively on the same
+      // write, e.g. a 403 whose recovered retry then 401s. Recover each kind at
+      // most once, in either order, re-evaluating after each retry and rebuilding
+      // the request from the buffered body. CSRF recovery runs for auth endpoints
+      // too (they are CSRF-protected); the auth-URL exclusion applies only to the
+      // 401 refresh loop (#250).
+      const replay = () => {
         const headers = new Headers(request.headers);
         const token = currentCSRFToken();
         if (token) {
           headers.set("X-CSRF-Token", token);
         }
         return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
+      };
+      let csrfRetried = false;
+      let authRetried = false;
+      for (let i = 0; i < 2; i++) {
+        if (response.status === 403 && isUnsafeMethod(request.method) && !csrfRetried) {
+          csrfRetried = true;
+          setCSRFToken(undefined);
+          await bootstrapCSRF(true);
+          response = await replay();
+          continue;
+        }
+        if (response.status === 401 && !isAuthURL(request.url) && !authRetried) {
+          authRetried = true;
+          if (!(await refreshSession())) {
+            break;
+          }
+          response = await replay();
+          continue;
+        }
+        break;
       }
-      if (response.status !== 401 || isAuthURL(request.url)) {
-        return response;
-      }
-      const ok = await refreshSession();
-      if (!ok) {
-        return response;
-      }
-      const headers = new Headers(request.headers);
-      const token = currentCSRFToken();
-      if (token) {
-        headers.set("X-CSRF-Token", token);
-      }
-      return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
+      return response;
     },
   });
   return client;

--- a/goldentest/tree_test.go
+++ b/goldentest/tree_test.go
@@ -168,8 +168,11 @@ func assertCookieFrontendInvariants(t *testing.T, files fileMap) {
 	if !strings.Contains(client, "csrfInFlight") {
 		t.Error("cookie-mode client.ts missing csrfInFlight lock")
 	}
-	if !strings.Contains(client, "if (getCSRFToken())") {
-		t.Error("cookie-mode client.ts missing skip-if-token-exists no-op")
+	if !strings.Contains(client, "if (!force && readCSRFCookie())") {
+		t.Error("cookie-mode client.ts must skip bootstrap when the gombit_csrf cookie is already present (#250)")
+	}
+	if !strings.Contains(client, "response.status === 403") {
+		t.Error("cookie-mode client.ts missing 403 CSRF recovery retry (#250)")
 	}
 	providers := string(files["frontend/src/app/providers.tsx"])
 	if !strings.Contains(providers, "void bootstrapCSRF()") {

--- a/internal/adminui/src/api/client.test.ts
+++ b/internal/adminui/src/api/client.test.ts
@@ -117,6 +117,89 @@ describe("admin client silent refresh", () => {
   });
 });
 
+describe("admin client CSRF cookie handling (#250)", () => {
+  afterEach(() => {
+    clearSession();
+    vi.unstubAllGlobals(); // also restores any stubbed `document`
+  });
+
+  it("reads the token from document.cookie and skips bootstrap when the cookie is present", async () => {
+    // This file runs under the node environment (no DOM); stub the JS-readable
+    // cookie the SPA would read at request time.
+    vi.stubGlobal("document", { cookie: "gombit_csrf=cookie-tok", querySelector: () => null });
+    let csrfHits = 0;
+    let sentToken: string | null = null;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url.includes("/auth/csrf")) {
+        csrfHits += 1;
+        return jsonResponse(200, { data: { csrf_token: "should-not-be-used" } });
+      }
+      if (url.includes("/admin/resources/widgets")) {
+        sentToken = header(init, "X-CSRF-Token");
+        return jsonResponse(200, { data: { id: 1 } });
+      }
+      return jsonResponse(404, { error: { code: "not_found", message: url } });
+    });
+
+    const client = createAdminClient();
+    await client.create("widgets", { name: "x" });
+    expect(sentToken).toBe("cookie-tok");
+    expect(csrfHits).toBe(0); // cookie already present -> no bootstrap fetch, no rotation
+  });
+
+  it("re-bootstraps CSRF and retries once on a 403 from an unsafe request", async () => {
+    let createHits = 0;
+    let csrfHits = 0;
+    const sentTokens: Array<string | null> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url.includes("/auth/csrf")) {
+        csrfHits += 1;
+        return jsonResponse(200, { data: { csrf_token: `csrf-${csrfHits}` } });
+      }
+      if (url.includes("/admin/resources/widgets")) {
+        createHits += 1;
+        sentTokens.push(header(init, "X-CSRF-Token"));
+        if (createHits === 1) {
+          return jsonResponse(403, {
+            error: { code: "authorization_error", message: "csrf token missing or invalid" },
+          });
+        }
+        return jsonResponse(200, { data: { id: 1 } });
+      }
+      return jsonResponse(404, { error: { code: "not_found", message: url } });
+    });
+
+    const client = createAdminClient();
+    const env = await client.create("widgets", { name: "x" });
+    expect(env.data).toEqual({ id: 1 });
+    expect(createHits).toBe(2); // original + one retry
+    expect(csrfHits).toBeGreaterThanOrEqual(2); // initial bootstrap + forced re-bootstrap after 403
+    // The retry carried the freshly bootstrapped token, not the stale one.
+    expect(sentTokens[0]).not.toEqual(sentTokens[1]);
+  });
+
+  it("does not retry a 403 on a safe method", async () => {
+    let listHits = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL): Promise<Response> => {
+      const url = String(input);
+      if (url.includes("/auth/csrf")) {
+        return jsonResponse(200, { data: { csrf_token: "csrf-1" } });
+      }
+      if (url.includes("/admin/resources/widgets")) {
+        listHits += 1;
+        return jsonResponse(403, { error: { code: "authorization_error", message: "forbidden" } });
+      }
+      return jsonResponse(404, { error: { code: "not_found", message: url } });
+    });
+
+    const client = createAdminClient();
+    await expect(client.list("widgets")).rejects.toThrow();
+    expect(listHits).toBe(1); // GET is not retried on 403
+  });
+});
+
 describe("admin client resource IDs", () => {
   afterEach(() => {
     clearSession();

--- a/internal/adminui/src/api/client.test.ts
+++ b/internal/adminui/src/api/client.test.ts
@@ -198,6 +198,96 @@ describe("admin client CSRF cookie handling (#250)", () => {
     await expect(client.list("widgets")).rejects.toThrow();
     expect(listHits).toBe(1); // GET is not retried on 403
   });
+
+  it("does not crash on a malformed gombit_csrf cookie and recovers via the server", async () => {
+    // "gombit_csrf=%" would make decodeURIComponent throw before any request.
+    const doc = { cookie: "gombit_csrf=%", querySelector: () => null };
+    vi.stubGlobal("document", doc);
+    let createHits = 0;
+    const sentTokens: Array<string | null> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url.includes("/auth/csrf")) {
+        doc.cookie = "gombit_csrf=fresh-tok"; // server Set-Cookie replaces the bad value
+        return jsonResponse(200, { data: { csrf_token: "fresh-tok" } });
+      }
+      if (url.includes("/admin/resources/widgets")) {
+        createHits += 1;
+        sentTokens.push(header(init, "X-CSRF-Token"));
+        if (createHits === 1) {
+          return jsonResponse(403, { error: { code: "authorization_error", message: "csrf" } });
+        }
+        return jsonResponse(200, { data: { id: 1 } });
+      }
+      return jsonResponse(404, { error: { code: "not_found", message: url } });
+    });
+
+    const client = createAdminClient();
+    const env = await client.create("widgets", { name: "x" }); // must not throw URIError
+    expect(env.data).toEqual({ id: 1 });
+    expect(sentTokens[0]).toBe("%"); // malformed value still reached the server (no crash)
+    expect(sentTokens[1]).toBe("fresh-tok"); // retry used the server-replaced cookie
+  });
+
+  it("recovers a CSRF 403 on an auth endpoint (login) and retries once", async () => {
+    const doc = { cookie: "gombit_csrf=stale", querySelector: () => null };
+    vi.stubGlobal("document", doc);
+    let loginHits = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url.includes("/auth/csrf")) {
+        doc.cookie = "gombit_csrf=good";
+        return jsonResponse(200, { data: { csrf_token: "good" } });
+      }
+      if (url.includes("/auth/login")) {
+        loginHits += 1;
+        if (header(init, "X-CSRF-Token") !== "good") {
+          return jsonResponse(403, { error: { code: "authorization_error", message: "csrf" } });
+        }
+        return jsonResponse(200, { data: { id: 1, email: "a@b.c" } });
+      }
+      return jsonResponse(404, { error: { code: "not_found", message: url } });
+    });
+
+    const client = createAdminClient();
+    const env = await client.login("a@b.c", "secret");
+    expect(env.data.email).toBe("a@b.c");
+    expect(loginHits).toBe(2); // stale 403 on the auth endpoint + retry after recovery
+  });
+
+  it("retries /auth/refresh once when a stale CSRF cookie 403s it", async () => {
+    const doc = { cookie: "gombit_csrf=stale", querySelector: () => null };
+    vi.stubGlobal("document", doc);
+    let meHits = 0;
+    let refreshHits = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url.includes("/auth/csrf")) {
+        doc.cookie = "gombit_csrf=good";
+        return jsonResponse(200, { data: { csrf_token: "good" } });
+      }
+      if (url.includes("/auth/refresh")) {
+        refreshHits += 1;
+        if (header(init, "X-CSRF-Token") !== "good") {
+          return jsonResponse(403, { error: { code: "authorization_error", message: "csrf" } });
+        }
+        return jsonResponse(200, { data: { ok: true } });
+      }
+      if (url.includes("/me")) {
+        meHits += 1;
+        if (meHits === 1) {
+          return jsonResponse(401, { error: { code: "authentication", message: "unauthorized" } });
+        }
+        return jsonResponse(200, { data: { id: 1, email: "a@b.c" } });
+      }
+      return jsonResponse(404, { error: { code: "not_found", message: url } });
+    });
+
+    const client = createAdminClient();
+    const env = await client.me();
+    expect(env.data.email).toBe("a@b.c");
+    expect(refreshHits).toBe(2); // stale 403 on refresh + retry after forced bootstrap
+  });
 });
 
 describe("admin client resource IDs", () => {

--- a/internal/adminui/src/api/client.test.ts
+++ b/internal/adminui/src/api/client.test.ts
@@ -288,6 +288,43 @@ describe("admin client CSRF cookie handling (#250)", () => {
     expect(env.data.email).toBe("a@b.c");
     expect(refreshHits).toBe(2); // stale 403 on refresh + retry after forced bootstrap
   });
+
+  it("recovers a CSRF 403 and then a session 401 on the same write (each once)", async () => {
+    const doc = { cookie: "gombit_csrf=stale", querySelector: () => null };
+    vi.stubGlobal("document", doc);
+    let createHits = 0;
+    let refreshHits = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url.includes("/auth/csrf")) {
+        doc.cookie = "gombit_csrf=good";
+        return jsonResponse(200, { data: { csrf_token: "good" } });
+      }
+      if (url.includes("/auth/refresh")) {
+        refreshHits += 1;
+        return jsonResponse(200, { data: { ok: true } });
+      }
+      if (url.includes("/admin/resources/widgets")) {
+        createHits += 1;
+        if (createHits === 1) {
+          // stale CSRF cookie
+          return jsonResponse(403, { error: { code: "authorization_error", message: "csrf" } });
+        }
+        if (createHits === 2) {
+          // CSRF fixed, but the session expired in the meantime
+          return jsonResponse(401, { error: { code: "authentication", message: "expired" } });
+        }
+        return jsonResponse(200, { data: { id: 1, token: header(init, "X-CSRF-Token") } });
+      }
+      return jsonResponse(404, { error: { code: "not_found", message: url } });
+    });
+
+    const client = createAdminClient();
+    const env = await client.create("widgets", { name: "x" });
+    expect(env.data).toEqual({ id: 1, token: "good" });
+    expect(createHits).toBe(3); // 403 -> CSRF-recover -> 401 -> refresh -> 200
+    expect(refreshHits).toBe(1); // session recovered exactly once
+  });
 });
 
 describe("admin client resource IDs", () => {

--- a/internal/adminui/src/api/client.ts
+++ b/internal/adminui/src/api/client.ts
@@ -139,19 +139,32 @@ export function createAdminClient() {
       await bootstrapCSRF();
     }
 
+    // Bounded recovery: a CSRF 403 (rotated/expired cookie) and a session 401
+    // (expired access cookie) can each occur — and can occur consecutively on
+    // the same write, e.g. a 403 whose recovered retry then 401s. Recover each
+    // kind at most once, in either order, re-evaluating after every retry and
+    // rebuilding the request (init() re-reads the live cookie). The auth-path
+    // exclusion applies only to the 401 refresh loop, not to CSRF recovery (#250).
     let response = await fetch(url, init());
-    if (response.status === 401 && !isAuthPath(path)) {
-      const ok = await refreshSession();
-      if (ok) {
+    let csrfRetried = false;
+    let authRetried = false;
+    for (let i = 0; i < 2; i++) {
+      if (response.status === 403 && isUnsafeMethod(method) && !csrfRetried) {
+        csrfRetried = true;
+        setCSRFToken(undefined);
+        await bootstrapCSRF(true);
         response = await fetch(url, init());
+        continue;
       }
-    } else if (response.status === 403 && isUnsafeMethod(method)) {
-      // A CSRF 403 means our cookie was rotated/expired out from under us.
-      // Drop the stale in-memory mirror, force a fresh bootstrap, and retry
-      // once — mirroring the 401 silent-refresh path (#250).
-      setCSRFToken(undefined);
-      await bootstrapCSRF(true);
-      response = await fetch(url, init());
+      if (response.status === 401 && !isAuthPath(path) && !authRetried) {
+        authRetried = true;
+        if (!(await refreshSession())) {
+          break;
+        }
+        response = await fetch(url, init());
+        continue;
+      }
+      break;
     }
 
     const parsed: unknown = await readJSON(response);

--- a/internal/adminui/src/api/client.ts
+++ b/internal/adminui/src/api/client.ts
@@ -57,8 +57,10 @@ function apiPath(path: string): string {
 
 /**
  * Thin same-origin fetch wrapper around D10 `{data, meta, error}`.
- * Cookie session + CSRF double-submit (X-CSRF-Token) on unsafe methods.
- * Concurrent 401s share one refreshInFlight promise. CSRF stays in memory.
+ * Cookie session + CSRF double-submit (X-CSRF-Token) on unsafe methods. The
+ * token is read from the JS-readable gombit_csrf cookie at request time.
+ * Concurrent 401s share one refreshInFlight promise; a 401 silent-refreshes and
+ * a 403 re-bootstraps CSRF, each retrying the request once.
  */
 export function createAdminClient() {
   const baseUrl = apiOrigin();
@@ -99,13 +101,16 @@ export function createAdminClient() {
     options?: { body?: unknown; query?: Record<string, string | number | undefined> },
   ): Promise<Envelope<T, M>> {
     const url = buildURL(baseUrl, path, options?.query);
-    const init = (csrf?: string): RequestInit => {
+    const init = (): RequestInit => {
       const headers = new Headers();
       if (options?.body !== undefined) {
         headers.set("Content-Type", "application/json");
       }
       if (isUnsafeMethod(method)) {
-        const token = csrf ?? getCSRFToken();
+        // Read the token at request time from the JS-readable gombit_csrf
+        // cookie (the authoritative double-submit value), so a cookie rotated
+        // or re-minted by another tab / after expiry is always matched (#250).
+        const token = currentCSRFToken();
         if (token) {
           headers.set("X-CSRF-Token", token);
         }
@@ -128,6 +133,13 @@ export function createAdminClient() {
       if (ok) {
         response = await fetch(url, init());
       }
+    } else if (response.status === 403 && isUnsafeMethod(method)) {
+      // A CSRF 403 means our cookie was rotated/expired out from under us.
+      // Drop the stale in-memory mirror, force a fresh bootstrap, and retry
+      // once — mirroring the 401 silent-refresh path (#250).
+      setCSRFToken(undefined);
+      await bootstrapCSRF(true);
+      response = await fetch(url, init());
     }
 
     const parsed: unknown = await readJSON(response);
@@ -183,16 +195,17 @@ export function useApiClient(): AdminClient {
 let csrfInFlight: Promise<void> | null = null;
 
 /**
- * Fetches a CSRF cookie/token pair. Concurrent callers share one in-flight
- * promise (GET /auth/csrf always mints a new pair; overlapping responses
- * desync the cookie from the in-memory X-CSRF-Token). If a token is already
- * in memory, this is a no-op so React StrictMode remounts do not mint a
- * second pair. After clearSession the token is gone and the next call
- * bootstraps again. Unsafe requests and silent refresh await this
- * before POST so a 401 cannot race GET /auth/csrf.
+ * Ensures a CSRF cookie exists and mirrors its token in memory. Keys off the
+ * JS-readable gombit_csrf cookie, not the in-memory token: if the cookie is
+ * already present this is a no-op (a second tab's bootstrap must not matter),
+ * so concurrent tabs converge on the one shared cookie. GET /auth/csrf reuses a
+ * valid cookie server-side (#250), so overlapping bootstraps no longer rotate
+ * it. Pass force=true to re-fetch even when a cookie is present (403 recovery).
+ * Concurrent callers share one in-flight promise. Unsafe requests and silent
+ * refresh await this before POST so a 401 cannot race GET /auth/csrf.
  */
-export function bootstrapCSRF(): Promise<void> {
-  if (getCSRFToken()) {
+export function bootstrapCSRF(force = false): Promise<void> {
+  if (!force && readCSRFCookie()) {
     return Promise.resolve();
   }
   if (csrfInFlight) {
@@ -217,8 +230,25 @@ export function bootstrapCSRF(): Promise<void> {
   return csrfInFlight;
 }
 
+/**
+ * Reads the JS-readable gombit_csrf cookie — the authoritative double-submit
+ * value. The cookie is deliberately not HttpOnly so the SPA can echo it.
+ */
+function readCSRFCookie(): string {
+  if (typeof document === "undefined") {
+    return "";
+  }
+  const match = document.cookie.match(/(?:^|;\s*)gombit_csrf=([^;]*)/);
+  return match ? decodeURIComponent(match[1]) : "";
+}
+
+/** Current CSRF token: the live cookie wins over the in-memory mirror. */
+function currentCSRFToken(): string {
+  return readCSRFCookie() || getCSRFToken() || "";
+}
+
 function csrfRequestHeaders(): HeadersInit {
-  const token = getCSRFToken();
+  const token = currentCSRFToken();
   return token ? { "X-CSRF-Token": token } : {};
 }
 

--- a/internal/adminui/src/api/client.ts
+++ b/internal/adminui/src/api/client.ts
@@ -75,11 +75,23 @@ export function createAdminClient() {
         // POST /auth/refresh is CSRF-protected. AppProviders fire-and-forget
         // bootstrapCSRF; a 401 on GET /me can race that GET /auth/csrf.
         await bootstrapCSRF();
-        const response = await fetch(baseUrl + apiPath("/auth/refresh"), {
+        let response = await fetch(baseUrl + apiPath("/auth/refresh"), {
           method: "POST",
           credentials: "same-origin",
           headers: csrfRequestHeaders(),
         });
+        if (response.status === 403) {
+          // /auth/refresh is itself CSRF-protected: a stale/rotated cookie 403s
+          // it. Force a fresh CSRF pair and retry the refresh once so a bad
+          // cookie can't strand a still-valid session (#250).
+          setCSRFToken(undefined);
+          await bootstrapCSRF(true);
+          response = await fetch(baseUrl + apiPath("/auth/refresh"), {
+            method: "POST",
+            credentials: "same-origin",
+            headers: csrfRequestHeaders(),
+          });
+        }
         if (!response.ok) {
           throw new Error(`refresh failed: ${response.status}`);
         }
@@ -239,7 +251,19 @@ function readCSRFCookie(): string {
     return "";
   }
   const match = document.cookie.match(/(?:^|;\s*)gombit_csrf=([^;]*)/);
-  return match ? decodeURIComponent(match[1]) : "";
+  if (!match) {
+    return "";
+  }
+  // The server token is hex + "." (no encoding), but a malformed cookie such as
+  // "gombit_csrf=%" would make decodeURIComponent throw a URIError before any
+  // request is sent — stranding the tab before the server can replace the bad
+  // cookie. Decode best-effort; fall back to the raw value so it still reaches
+  // the server (which rejects it, triggering 403 recovery) instead of crashing.
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
 }
 
 /** Current CSRF token: the live cookie wins over the in-memory mirror. */

--- a/scaffold/generate_test.go
+++ b/scaffold/generate_test.go
@@ -761,10 +761,10 @@ func assertSPAHonorsRuntimeAPIPrefix(t *testing.T, dest, auth string) {
 	}
 }
 
-// TestGenerateCookieCSRFBootstrapIsSerialized is the #107 regression: GET
-// /auth/csrf always mints a new cookie+body pair, so overlapping bootstrap
-// calls (React StrictMode remounts, or login before the mount effect
-// finishes) desync the HttpOnly cookie from the in-memory X-CSRF-Token.
+// TestGenerateCookieCSRFBootstrapIsSerialized is the #107 regression (bootstrap
+// is serialized behind csrfInFlight and skips when a cookie already exists) plus
+// the #250 fix (the no-op keys off the JS-readable gombit_csrf cookie, and a 403
+// on an unsafe request re-bootstraps and retries once).
 func TestGenerateCookieCSRFBootstrapIsSerialized(t *testing.T) {
 	workDir := t.TempDir()
 	err := Generate(context.Background(), Options{
@@ -781,11 +781,14 @@ func TestGenerateCookieCSRFBootstrapIsSerialized(t *testing.T) {
 	if !strings.Contains(client, "csrfInFlight") {
 		t.Fatal("cookie client.ts missing csrfInFlight lock")
 	}
-	if !strings.Contains(client, "if (getCSRFToken())") {
-		t.Fatal("cookie client.ts missing skip-if-token-exists no-op")
+	if !strings.Contains(client, "if (!force && readCSRFCookie())") {
+		t.Fatal("cookie client.ts must skip bootstrap when the gombit_csrf cookie is already present (#250)")
 	}
 	if !strings.Contains(client, "if (csrfInFlight)") {
 		t.Fatal("cookie client.ts missing in-flight promise reuse")
+	}
+	if !strings.Contains(client, "response.status === 403") {
+		t.Fatal("cookie client.ts missing 403 CSRF recovery retry (#250)")
 	}
 
 	login := readFile(t, filepath.Join(workDir, "shop", "frontend", "src", "pages", "LoginPage.tsx"))

--- a/scaffold/templates/frontend/src/api/client.ts.tmpl
+++ b/scaffold/templates/frontend/src/api/client.ts.tmpl
@@ -65,11 +65,23 @@ export function createAppClient(): ApiClient {
     refreshInFlight = (async () => {
       try {
         await bootstrapCSRF();
-        const response = await fetch(baseUrl + apiPath("/auth/refresh"), {
+        let response = await fetch(baseUrl + apiPath("/auth/refresh"), {
           method: "POST",
           credentials: "same-origin",
           headers: csrfRequestHeaders(),
         });
+        if (response.status === 403) {
+          // /auth/refresh is itself CSRF-protected: a stale/rotated cookie 403s
+          // it. Force a fresh CSRF pair and retry the refresh once before giving
+          // up, so a bad cookie can't strand a still-valid session (#250).
+          setCSRFToken(undefined);
+          await bootstrapCSRF(true);
+          response = await fetch(baseUrl + apiPath("/auth/refresh"), {
+            method: "POST",
+            credentials: "same-origin",
+            headers: csrfRequestHeaders(),
+          });
+        }
         if (!response.ok) {
           throw new Error(`refresh failed: ${response.status}`);
         }
@@ -91,14 +103,12 @@ export function createAppClient(): ApiClient {
       return request;
     },
     async onResponse({ request, response }) {
-      if (
-        response.status === 403 &&
-        isUnsafeMethod(request.method) &&
-        !isAuthURL(request.url)
-      ) {
+      if (response.status === 403 && isUnsafeMethod(request.method)) {
         // A CSRF 403 means our cookie was rotated/expired out from under us.
         // Drop the stale in-memory mirror, force a fresh bootstrap, and retry
-        // once — mirroring the 401 silent-refresh path (#250).
+        // once — mirroring the 401 silent-refresh path (#250). This runs for
+        // auth endpoints too (login/register/logout are CSRF-protected): the
+        // auth-URL exclusion applies only to 401 refresh, not CSRF recovery.
         setCSRFToken(undefined);
         await bootstrapCSRF(true);
         const headers = new Headers(request.headers);
@@ -173,7 +183,19 @@ function readCSRFCookie(): string {
     return "";
   }
   const match = document.cookie.match(/(?:^|;\s*)gombit_csrf=([^;]*)/);
-  return match ? decodeURIComponent(match[1]) : "";
+  if (!match) {
+    return "";
+  }
+  // The server token is hex + "." (no encoding), but a malformed cookie such as
+  // "gombit_csrf=%" would make decodeURIComponent throw a URIError before any
+  // request is sent — stranding the tab before the server can replace the bad
+  // cookie. Decode best-effort; fall back to the raw value so it still reaches
+  // the server (which rejects it, triggering 403 recovery) instead of crashing.
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
 }
 
 /** Current CSRF token: the live cookie wins over the in-memory mirror. */

--- a/scaffold/templates/frontend/src/api/client.ts.tmpl
+++ b/scaffold/templates/frontend/src/api/client.ts.tmpl
@@ -20,9 +20,11 @@ export { apiPath, apiPrefix, DEFAULT_API_PREFIX, rewriteAPIRequest } from "./api
  * Wire the generated openapi-fetch client for cookie-mode session auth
  * (M5-3). Session cookies (HttpOnly) and the CSRF cookie are managed by the
  * browser on same-origin requests; this wiring adds the X-CSRF-Token
- * double-submit header on state-changing requests and retries once after a
- * silent cookie refresh on 401. The retry rebuilds fetch() from buffered
- * body bytes so POST/PATCH JSON survives that refresh. See docs/auth-cookie.md.
+ * double-submit header (read from the gombit_csrf cookie at request time) on
+ * state-changing requests, retries once after a silent cookie refresh on 401,
+ * and retries once after re-bootstrapping CSRF on a 403. The retry rebuilds
+ * fetch() from buffered body bytes so POST/PATCH JSON survives. See
+ * docs/auth-cookie.md.
  *
  * The CSRF bootstrap and refresh calls below use fetch directly instead of
  * the typed client: they are session infrastructure, not part of the
@@ -41,7 +43,10 @@ export function createAppClient(): ApiClient {
       request = rewriteAPIRequest(request);
       if (isUnsafeMethod(request.method)) {
         await bootstrapCSRF();
-        const token = getCSRFToken();
+        // Read at request time from the JS-readable gombit_csrf cookie (the
+        // authoritative double-submit value) so a cookie rotated/re-minted by
+        // another tab or after expiry is always matched (#250).
+        const token = currentCSRFToken();
         if (token) {
           request.headers.set("X-CSRF-Token", token);
         }
@@ -86,6 +91,23 @@ export function createAppClient(): ApiClient {
       return request;
     },
     async onResponse({ request, response }) {
+      if (
+        response.status === 403 &&
+        isUnsafeMethod(request.method) &&
+        !isAuthURL(request.url)
+      ) {
+        // A CSRF 403 means our cookie was rotated/expired out from under us.
+        // Drop the stale in-memory mirror, force a fresh bootstrap, and retry
+        // once — mirroring the 401 silent-refresh path (#250).
+        setCSRFToken(undefined);
+        await bootstrapCSRF(true);
+        const headers = new Headers(request.headers);
+        const token = currentCSRFToken();
+        if (token) {
+          headers.set("X-CSRF-Token", token);
+        }
+        return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
+      }
       if (response.status !== 401 || isAuthURL(request.url)) {
         return response;
       }
@@ -94,7 +116,7 @@ export function createAppClient(): ApiClient {
         return response;
       }
       const headers = new Headers(request.headers);
-      const token = getCSRFToken();
+      const token = currentCSRFToken();
       if (token) {
         headers.set("X-CSRF-Token", token);
       }
@@ -107,16 +129,16 @@ export function createAppClient(): ApiClient {
 let csrfInFlight: Promise<void> | null = null;
 
 /**
- * Fetches a CSRF cookie/token pair. Concurrent callers share one in-flight
- * promise (GET /auth/csrf always mints a new pair; overlapping responses
- * desync the cookie from the in-memory X-CSRF-Token). If a token is already
- * in memory, this is a no-op so React StrictMode remounts do not mint a
- * second pair. After clearSession the token is gone and the next call
- * bootstraps again. Unsafe requests and silent refresh await this
- * before POST so a reload cannot race GET /auth/csrf.
+ * Ensures a CSRF cookie exists and mirrors its token in memory. Keys off the
+ * JS-readable gombit_csrf cookie, not the in-memory token: if the cookie is
+ * already present this is a no-op, so concurrent tabs converge on the one
+ * shared cookie. GET /auth/csrf reuses a valid cookie server-side (#250), so
+ * overlapping bootstraps no longer rotate it. Pass force=true to re-fetch even
+ * when a cookie is present (403 recovery). Concurrent callers share one
+ * in-flight promise; unsafe requests and silent refresh await this before POST.
  */
-export function bootstrapCSRF(): Promise<void> {
-  if (getCSRFToken()) {
+export function bootstrapCSRF(force = false): Promise<void> {
+  if (!force && readCSRFCookie()) {
     return Promise.resolve();
   }
   if (csrfInFlight) {
@@ -142,8 +164,25 @@ export function bootstrapCSRF(): Promise<void> {
   return csrfInFlight;
 }
 
+/**
+ * Reads the JS-readable gombit_csrf cookie — the authoritative double-submit
+ * value. The cookie is deliberately not HttpOnly so the SPA can echo it.
+ */
+function readCSRFCookie(): string {
+  if (typeof document === "undefined") {
+    return "";
+  }
+  const match = document.cookie.match(/(?:^|;\s*)gombit_csrf=([^;]*)/);
+  return match ? decodeURIComponent(match[1]) : "";
+}
+
+/** Current CSRF token: the live cookie wins over the in-memory mirror. */
+function currentCSRFToken(): string {
+  return readCSRFCookie() || getCSRFToken() || "";
+}
+
 function csrfRequestHeaders(): HeadersInit {
-  const token = getCSRFToken();
+  const token = currentCSRFToken();
   return token ? { "X-CSRF-Token": token } : {};
 }
 

--- a/scaffold/templates/frontend/src/api/client.ts.tmpl
+++ b/scaffold/templates/frontend/src/api/client.ts.tmpl
@@ -103,34 +103,42 @@ export function createAppClient(): ApiClient {
       return request;
     },
     async onResponse({ request, response }) {
-      if (response.status === 403 && isUnsafeMethod(request.method)) {
-        // A CSRF 403 means our cookie was rotated/expired out from under us.
-        // Drop the stale in-memory mirror, force a fresh bootstrap, and retry
-        // once — mirroring the 401 silent-refresh path (#250). This runs for
-        // auth endpoints too (login/register/logout are CSRF-protected): the
-        // auth-URL exclusion applies only to 401 refresh, not CSRF recovery.
-        setCSRFToken(undefined);
-        await bootstrapCSRF(true);
+      // Bounded recovery: a CSRF 403 (rotated/expired cookie) and a session 401
+      // (expired access cookie) can each occur — and consecutively on the same
+      // write, e.g. a 403 whose recovered retry then 401s. Recover each kind at
+      // most once, in either order, re-evaluating after each retry and rebuilding
+      // the request from the buffered body. CSRF recovery runs for auth endpoints
+      // too (they are CSRF-protected); the auth-URL exclusion applies only to the
+      // 401 refresh loop (#250).
+      const replay = () => {
         const headers = new Headers(request.headers);
         const token = currentCSRFToken();
         if (token) {
           headers.set("X-CSRF-Token", token);
         }
         return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
+      };
+      let csrfRetried = false;
+      let authRetried = false;
+      for (let i = 0; i < 2; i++) {
+        if (response.status === 403 && isUnsafeMethod(request.method) && !csrfRetried) {
+          csrfRetried = true;
+          setCSRFToken(undefined);
+          await bootstrapCSRF(true);
+          response = await replay();
+          continue;
+        }
+        if (response.status === 401 && !isAuthURL(request.url) && !authRetried) {
+          authRetried = true;
+          if (!(await refreshSession())) {
+            break;
+          }
+          response = await replay();
+          continue;
+        }
+        break;
       }
-      if (response.status !== 401 || isAuthURL(request.url)) {
-        return response;
-      }
-      const ok = await refreshSession();
-      if (!ok) {
-        return response;
-      }
-      const headers = new Headers(request.headers);
-      const token = currentCSRFToken();
-      if (token) {
-        headers.set("X-CSRF-Token", token);
-      }
-      return fetch(request.url, retryInit(request, headers, retryBodies.get(request)));
+      return response;
     },
   });
   return client;


### PR DESCRIPTION
## Summary

Cookie-mode CSRF broke every write in a first tab once a second tab opened (and hit a single long-lived tab after the 24h cookie `Max-Age`): `GET /auth/csrf` always minted a fresh token and re-set the shared `gombit_csrf` cookie, while both SPAs cached the token in module memory and had no 403 recovery. Fixed with the three coordinated changes the issue suggests:

- **Server** (`auth/csrf.go`): `GET /auth/csrf` now **reuses** a still-valid signed `gombit_csrf` cookie (read via a cookie input) and only mints when the cookie is missing/invalid; re-setting the same value refreshes `Max-Age`. Double-submit needs a *shared* signed value, not a per-call-unique one.
- **Clients** (`internal/adminui` + `scaffold/templates/.../client.ts.tmpl`): read the token from the JS-readable `gombit_csrf` cookie **at request time** (in-memory is only a fallback), so a rotated/expired cookie is always matched; `bootstrapCSRF` keys off cookie presence (not memory) with a `force` flag; and a **403 on an unsafe request** clears the mirror, force-re-bootstraps CSRF, and retries once — mirroring the existing 401 silent-refresh path.

Closes #250

## Acceptance criteria

- [x] Multiple admin tabs work concurrently (a second tab's bootstrap no longer rotates the shared cookie; the server reuses it)
- [x] A tab recovers from a rotated/expired CSRF cookie without a manual reload (request-time cookie read + 403 re-bootstrap-and-retry)

## Scope notes

Both the framework-owned admin SPA (`internal/adminui`) and the scaffold cookie-mode template carry the client fix; the `new-cookie` golden is regenerated. No API contract/envelope change.

## Validation

- [x] `go test ./auth/...` (server reuse + invalid-cookie replacement tests) — pass
- [x] `npm test` + `npm run typecheck` in `internal/adminui` (cookie-read, 403-retry, no-retry-on-safe-403) — pass
- [x] `go test ./goldentest` (regenerated `new-cookie` client.ts) — pass
- [x] `golangci-lint run ./auth/...` — 0 issues
- [x] Project `code-review` skill run against this diff

## Working agreement checklist

- [x] New behavior has tests (Go auth tests + adminui vitest); not a DB-touching change, so the DB matrix is N/A
- [x] Stable features ship docs — `docs/auth-cookie.md` updated to the reuse + request-time-read + 403-recovery behavior; the cookie-mode behavior is exercised by the scaffold template + golden
- [x] Extraction preserves contracts — refactor/extend, existing auth tests still pass
- [ ] Generators: N/A — no generator logic changed (the scaffold client template is edited, and its golden regenerated)
- [x] API changes regenerate OpenAPI + TS client — N/A: the `gombit_csrf` cookie input is ambient and `/auth/csrf` is not part of the committed sample OpenAPI; no generated contract changed
- [x] No secrets in generated frontend source; `VITE_*` is public
- [x] Scope stays inside M5 (auth/frontend) + admin — no M6 battery
- [x] Links its issue (#250) and states the AC it satisfies