### PR TITLE
fix: admin hard-deletes so the database enforces foreign keys (#220)

### DIFF
--- a/admin/resources.go
+++ b/admin/resources.go
@@ -270,65 +270,20 @@ func (h *handlers) deleteResource(ctx context.Context, input *itemInput) (*delet
 	if err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("admin database is not attached"))
 	}
-	pk, err := coercePathID(input.ID, m.pkType)
-	if err != nil {
-		return nil, contract.WithContext(ctx, contract.NotFound("unknown resource"))
-	}
-	if err := h.blockIfReferenced(ctx, db, m, pk); err != nil {
-		return nil, err
-	}
-	if err := db.WithContext(ctx).Delete(inst).Error; err != nil {
+	// Hard delete so the database's real foreign keys enforce referential
+	// integrity atomically (#220). gorm.Model makes the default Delete a SOFT
+	// delete — it sets deleted_at with no physical DELETE — so ON DELETE
+	// RESTRICT/NO ACTION never fires and a referenced parent could be "deleted"
+	// while a live child keeps pointing at an API-404 row. Unscoped issues a real
+	// DELETE, so the database enforces RESTRICT in one statement (a referenced row
+	// errors, mapped to 409 by MapDeleteError) and actually executes a declared
+	// CASCADE / SET NULL. There is no app-layer pre-scan to race: the invariant is
+	// the database constraint itself. The admin never exposed soft-delete recovery
+	// (no restore path), so this removes no feature.
+	if err := db.WithContext(ctx).Unscoped().Delete(inst).Error; err != nil {
 		return nil, database.MapDeleteError(ctx, err, "resource is still referenced by other records", "delete resource")
 	}
 	return &deleteOutput{Body: contract.Data[deleteResult]{Data: deleteResult{OK: true}}}, nil
-}
-
-// blockIfReferenced enforces ON DELETE RESTRICT at the application layer for the
-// generic admin delete. GORM soft-deletes (gorm.Model.DeletedAt) set deleted_at
-// without a physical DELETE, so the database's real foreign keys never fire and a
-// referenced parent could be "deleted" while live children keep pointing at an
-// API-404 row (#220). Before deleting, it scans every registered model for a
-// belongs_to FK targeting this model and rejects with the same 409 the
-// hard-delete path returns when any live (non-soft-deleted) row still references
-// the target. An explicit ON DELETE CASCADE / SET NULL is respected (not blocked)
-// — the author opted into that behavior.
-func (h *handlers) blockIfReferenced(ctx context.Context, db *gorm.DB, target *registered, pk any) error {
-	targetSch, err := parseSchema(target.newInstance())
-	if err != nil {
-		return contract.WithContext(ctx, contract.Internal("inspect model schema"))
-	}
-	for _, other := range h.reg.all() {
-		otherSch, err := parseSchema(other.newInstance())
-		if err != nil {
-			continue
-		}
-		for fkCol, rel := range belongsToByFK(otherSch) {
-			if rel.FieldSchema == nil || rel.FieldSchema.Table != targetSch.Table {
-				continue
-			}
-			if c := rel.ParseConstraint(); c != nil {
-				switch strings.ToUpper(strings.TrimSpace(c.OnDelete)) {
-				case "CASCADE", "SET NULL", "SET DEFAULT":
-					continue
-				}
-			}
-			q := db.WithContext(ctx).Model(other.newInstance()).
-				Where(clause.Eq{Column: clause.Column{Name: fkCol}, Value: pk})
-			if otherSch.Table == targetSch.Table {
-				// Self-referential FK: a row's reference to itself must not block
-				// its own deletion; only other rows count.
-				q = q.Where(clause.Neq{Column: clause.Column{Name: other.pkColumn}, Value: pk})
-			}
-			var n int64
-			if err := q.Count(&n).Error; err != nil {
-				return contract.WithContext(ctx, contract.Internal("check referencing records"))
-			}
-			if n > 0 {
-				return contract.WithContext(ctx, contract.Conflict("resource is still referenced by other records"))
-			}
-		}
-	}
-	return nil
 }
 
 func (h *handlers) modelForAction(

--- a/admin/resources.go
+++ b/admin/resources.go
@@ -270,10 +270,65 @@ func (h *handlers) deleteResource(ctx context.Context, input *itemInput) (*delet
 	if err != nil {
 		return nil, contract.WithContext(ctx, contract.Internal("admin database is not attached"))
 	}
+	pk, err := coercePathID(input.ID, m.pkType)
+	if err != nil {
+		return nil, contract.WithContext(ctx, contract.NotFound("unknown resource"))
+	}
+	if err := h.blockIfReferenced(ctx, db, m, pk); err != nil {
+		return nil, err
+	}
 	if err := db.WithContext(ctx).Delete(inst).Error; err != nil {
 		return nil, database.MapDeleteError(ctx, err, "resource is still referenced by other records", "delete resource")
 	}
 	return &deleteOutput{Body: contract.Data[deleteResult]{Data: deleteResult{OK: true}}}, nil
+}
+
+// blockIfReferenced enforces ON DELETE RESTRICT at the application layer for the
+// generic admin delete. GORM soft-deletes (gorm.Model.DeletedAt) set deleted_at
+// without a physical DELETE, so the database's real foreign keys never fire and a
+// referenced parent could be "deleted" while live children keep pointing at an
+// API-404 row (#220). Before deleting, it scans every registered model for a
+// belongs_to FK targeting this model and rejects with the same 409 the
+// hard-delete path returns when any live (non-soft-deleted) row still references
+// the target. An explicit ON DELETE CASCADE / SET NULL is respected (not blocked)
+// — the author opted into that behavior.
+func (h *handlers) blockIfReferenced(ctx context.Context, db *gorm.DB, target *registered, pk any) error {
+	targetSch, err := parseSchema(target.newInstance())
+	if err != nil {
+		return contract.WithContext(ctx, contract.Internal("inspect model schema"))
+	}
+	for _, other := range h.reg.all() {
+		otherSch, err := parseSchema(other.newInstance())
+		if err != nil {
+			continue
+		}
+		for fkCol, rel := range belongsToByFK(otherSch) {
+			if rel.FieldSchema == nil || rel.FieldSchema.Table != targetSch.Table {
+				continue
+			}
+			if c := rel.ParseConstraint(); c != nil {
+				switch strings.ToUpper(strings.TrimSpace(c.OnDelete)) {
+				case "CASCADE", "SET NULL", "SET DEFAULT":
+					continue
+				}
+			}
+			q := db.WithContext(ctx).Model(other.newInstance()).
+				Where(clause.Eq{Column: clause.Column{Name: fkCol}, Value: pk})
+			if otherSch.Table == targetSch.Table {
+				// Self-referential FK: a row's reference to itself must not block
+				// its own deletion; only other rows count.
+				q = q.Where(clause.Neq{Column: clause.Column{Name: other.pkColumn}, Value: pk})
+			}
+			var n int64
+			if err := q.Count(&n).Error; err != nil {
+				return contract.WithContext(ctx, contract.Internal("check referencing records"))
+			}
+			if n > 0 {
+				return contract.WithContext(ctx, contract.Conflict("resource is still referenced by other records"))
+			}
+		}
+	}
+	return nil
 }
 
 func (h *handlers) modelForAction(

--- a/admin/resources_test.go
+++ b/admin/resources_test.go
@@ -772,26 +772,31 @@ func TestResourceDeleteForeignKeyViolationIsConflict(t *testing.T) {
 // database's ON DELETE RESTRICT (no physical DELETE happens), which would leave
 // a live child pointing at an API-404 parent. The admin must enforce RESTRICT at
 // the application layer: a 409 while referenced, success once the child is gone.
-func TestResourceDeleteSoftDeleteBlockedWhenReferenced(t *testing.T) {
+// TestResourceDeleteHardDeleteEnforcesRestrict pins the #220 fix: the admin
+// delete is a hard delete, so the database's real ON DELETE RESTRICT fires
+// atomically — a referenced parent is a 409 (not a soft delete that leaves a
+// live child pointing at an API-404 row), and once the child is gone the parent
+// is physically deleted.
+func TestResourceDeleteHardDeleteEnforcesRestrict(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	type SoftParent struct {
+	type RParent struct {
 		gorm.Model
 		Name string `json:"name"`
 	}
-	type SoftChild struct {
+	type RChild struct {
 		gorm.Model
-		ParentID uint       `json:"parent_id"`
-		Parent   SoftParent `gorm:"constraint:OnDelete:RESTRICT;" json:"-"`
+		ParentID uint    `json:"parent_id"`
+		Parent   RParent `gorm:"constraint:OnDelete:RESTRICT;" json:"-"`
 	}
 	app := newCookieApp(t)
-	if err := app.DB().AutoMigrate(&SoftParent{}, &SoftChild{}); err != nil {
+	if err := app.DB().AutoMigrate(&RParent{}, &RChild{}); err != nil {
 		t.Fatalf("AutoMigrate: %v", err)
 	}
-	parent := SoftParent{Name: "p"}
+	parent := RParent{Name: "p"}
 	if err := app.DB().Create(&parent).Error; err != nil {
 		t.Fatalf("create parent: %v", err)
 	}
-	child := SoftChild{ParentID: parent.ID}
+	child := RChild{ParentID: parent.ID}
 	if err := app.DB().Create(&child).Error; err != nil {
 		t.Fatalf("create child: %v", err)
 	}
@@ -800,8 +805,8 @@ func TestResourceDeleteSoftDeleteBlockedWhenReferenced(t *testing.T) {
 		slug  string
 		field string
 	}{
-		{SoftParent{}, "soft-parents", "name"},
-		{SoftChild{}, "soft-children", "parent_id"},
+		{RParent{}, "r-parents", "name"},
+		{RChild{}, "r-children", "parent_id"},
 	} {
 		if err := admin.Register(app, reg.model, admin.Options{
 			Slug: reg.slug,
@@ -815,32 +820,128 @@ func TestResourceDeleteSoftDeleteBlockedWhenReferenced(t *testing.T) {
 	}
 	jar := loginSuperuser(t, app)
 
-	// Referenced: deleting the parent is a 409, and the parent survives.
-	rec := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/soft-parents/%d", parent.ID), "")
+	// Referenced: the database RESTRICT makes the delete a 409, and the parent
+	// survives untouched (the failed DELETE changed nothing).
+	rec := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/r-parents/%d", parent.ID), "")
 	assertError(t, rec, http.StatusConflict, "conflict")
-	var still SoftParent
+	var still RParent
 	if err := app.DB().First(&still, parent.ID).Error; err != nil {
 		t.Fatalf("parent must survive a blocked delete, got: %v", err)
 	}
 
-	// Remove the child, then the parent deletes cleanly and is soft-deleted.
-	delChild := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/soft-children/%d", child.ID), "")
+	// Remove the child, then the parent deletes and is PHYSICALLY gone — a hard
+	// delete, so even Unscoped cannot find it (no dangling soft-deleted row).
+	delChild := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/r-children/%d", child.ID), "")
 	if delChild.Code != http.StatusOK {
 		t.Fatalf("delete child status = %d; body: %s", delChild.Code, delChild.Body.String())
 	}
-	delParent := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/soft-parents/%d", parent.ID), "")
+	delParent := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/r-parents/%d", parent.ID), "")
 	if delParent.Code != http.StatusOK {
 		t.Fatalf("delete parent after child removed status = %d; body: %s", delParent.Code, delParent.Body.String())
 	}
-	if err := app.DB().First(&SoftParent{}, parent.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
-		t.Fatalf("parent must be soft-deleted after successful delete, got: %v", err)
+	if err := app.DB().Unscoped().First(&RParent{}, parent.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("parent must be physically deleted (hard delete), got: %v", err)
+	}
+}
+
+// TestResourceDeleteCascadeRemovesChildren verifies that a declared
+// ON DELETE CASCADE actually executes under the admin delete (the review's
+// finding that "respecting" CASCADE by skipping did nothing): deleting the
+// parent removes the child at the database.
+func TestResourceDeleteCascadeRemovesChildren(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type CParent struct {
+		gorm.Model
+		Name string `json:"name"`
+	}
+	type CChild struct {
+		gorm.Model
+		ParentID uint    `json:"parent_id"`
+		Parent   CParent `gorm:"constraint:OnDelete:CASCADE;" json:"-"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&CParent{}, &CChild{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	parent := CParent{Name: "p"}
+	if err := app.DB().Create(&parent).Error; err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	if err := app.DB().Create(&CChild{ParentID: parent.ID}).Error; err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := admin.Register(app, CParent{}, admin.Options{
+		Slug:   "c-parents",
+		Fields: []admin.Field{{Name: "id", Type: admin.TypeInteger, ReadOnly: true}, {Name: "name", Type: admin.TypeString}},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	jar := loginSuperuser(t, app)
+
+	rec := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/c-parents/%d", parent.ID), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("cascade delete status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var remaining int64
+	if err := app.DB().Unscoped().Model(&CChild{}).Count(&remaining).Error; err != nil {
+		t.Fatalf("count children: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("CASCADE did not remove the child: %d remain", remaining)
+	}
+}
+
+// TestResourceDeleteSetNullClearsChildFK verifies a declared ON DELETE SET NULL
+// actually nulls the child's FK under the admin delete, rather than leaving it
+// pointing at a deleted parent.
+func TestResourceDeleteSetNullClearsChildFK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type NParent struct {
+		gorm.Model
+		Name string `json:"name"`
+	}
+	type NChild struct {
+		gorm.Model
+		ParentID *uint    `json:"parent_id"` // nullable so SET NULL is legal
+		Parent   *NParent `gorm:"constraint:OnDelete:SET NULL;" json:"-"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&NParent{}, &NChild{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	parent := NParent{Name: "p"}
+	if err := app.DB().Create(&parent).Error; err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	child := NChild{ParentID: &parent.ID}
+	if err := app.DB().Create(&child).Error; err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := admin.Register(app, NParent{}, admin.Options{
+		Slug:   "n-parents",
+		Fields: []admin.Field{{Name: "id", Type: admin.TypeInteger, ReadOnly: true}, {Name: "name", Type: admin.TypeString}},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	jar := loginSuperuser(t, app)
+
+	rec := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/n-parents/%d", parent.ID), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set-null delete status = %d; body: %s", rec.Code, rec.Body.String())
+	}
+	var reloaded NChild
+	if err := app.DB().First(&reloaded, child.ID).Error; err != nil {
+		t.Fatalf("reload child: %v", err)
+	}
+	if reloaded.ParentID != nil {
+		t.Fatalf("SET NULL did not clear the child FK: %v", *reloaded.ParentID)
 	}
 }
 
 // TestResourceDeleteSelfReferentialRespectsLiveChildren covers #220's self-
 // referential repro (Engine.ParentEngineID): a parent with a live child is
-// blocked, but the self-reference of a row to itself must never block its own
-// deletion.
+// blocked by the database RESTRICT, but a row referencing only its (soon-gone)
+// parent deletes fine.
 func TestResourceDeleteSelfReferentialRespectsLiveChildren(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	type Engine struct {

--- a/admin/resources_test.go
+++ b/admin/resources_test.go
@@ -767,11 +767,6 @@ func TestResourceDeleteForeignKeyViolationIsConflict(t *testing.T) {
 	assertError(t, rec, http.StatusConflict, "conflict")
 }
 
-// TestResourceDeleteSoftDeleteBlockedWhenReferenced is the #220 regression:
-// with gorm.Model soft-delete, deleting a referenced parent never triggers the
-// database's ON DELETE RESTRICT (no physical DELETE happens), which would leave
-// a live child pointing at an API-404 parent. The admin must enforce RESTRICT at
-// the application layer: a 409 while referenced, success once the child is gone.
 // TestResourceDeleteHardDeleteEnforcesRestrict pins the #220 fix: the admin
 // delete is a hard delete, so the database's real ON DELETE RESTRICT fires
 // atomically — a referenced parent is a 409 (not a soft delete that leaves a

--- a/admin/resources_test.go
+++ b/admin/resources_test.go
@@ -3,6 +3,7 @@ package admin_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"go/parser"
 	"go/token"
@@ -21,6 +22,7 @@ import (
 	"github.com/gombit-dev/gombit/contract"
 	"github.com/gombit-dev/gombit/framework"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 type rowEnvelope struct {
@@ -763,6 +765,128 @@ func TestResourceDeleteForeignKeyViolationIsConflict(t *testing.T) {
 	// foreign key on create/update would produce, and not a 500.
 	rec := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/del-categories/%d", category.ID), "")
 	assertError(t, rec, http.StatusConflict, "conflict")
+}
+
+// TestResourceDeleteSoftDeleteBlockedWhenReferenced is the #220 regression:
+// with gorm.Model soft-delete, deleting a referenced parent never triggers the
+// database's ON DELETE RESTRICT (no physical DELETE happens), which would leave
+// a live child pointing at an API-404 parent. The admin must enforce RESTRICT at
+// the application layer: a 409 while referenced, success once the child is gone.
+func TestResourceDeleteSoftDeleteBlockedWhenReferenced(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type SoftParent struct {
+		gorm.Model
+		Name string `json:"name"`
+	}
+	type SoftChild struct {
+		gorm.Model
+		ParentID uint       `json:"parent_id"`
+		Parent   SoftParent `gorm:"constraint:OnDelete:RESTRICT;" json:"-"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&SoftParent{}, &SoftChild{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	parent := SoftParent{Name: "p"}
+	if err := app.DB().Create(&parent).Error; err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	child := SoftChild{ParentID: parent.ID}
+	if err := app.DB().Create(&child).Error; err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	for _, reg := range []struct {
+		model any
+		slug  string
+		field string
+	}{
+		{SoftParent{}, "soft-parents", "name"},
+		{SoftChild{}, "soft-children", "parent_id"},
+	} {
+		if err := admin.Register(app, reg.model, admin.Options{
+			Slug: reg.slug,
+			Fields: []admin.Field{
+				{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+				{Name: reg.field, Type: admin.TypeString},
+			},
+		}); err != nil {
+			t.Fatalf("Register %s: %v", reg.slug, err)
+		}
+	}
+	jar := loginSuperuser(t, app)
+
+	// Referenced: deleting the parent is a 409, and the parent survives.
+	rec := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/soft-parents/%d", parent.ID), "")
+	assertError(t, rec, http.StatusConflict, "conflict")
+	var still SoftParent
+	if err := app.DB().First(&still, parent.ID).Error; err != nil {
+		t.Fatalf("parent must survive a blocked delete, got: %v", err)
+	}
+
+	// Remove the child, then the parent deletes cleanly and is soft-deleted.
+	delChild := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/soft-children/%d", child.ID), "")
+	if delChild.Code != http.StatusOK {
+		t.Fatalf("delete child status = %d; body: %s", delChild.Code, delChild.Body.String())
+	}
+	delParent := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/soft-parents/%d", parent.ID), "")
+	if delParent.Code != http.StatusOK {
+		t.Fatalf("delete parent after child removed status = %d; body: %s", delParent.Code, delParent.Body.String())
+	}
+	if err := app.DB().First(&SoftParent{}, parent.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("parent must be soft-deleted after successful delete, got: %v", err)
+	}
+}
+
+// TestResourceDeleteSelfReferentialRespectsLiveChildren covers #220's self-
+// referential repro (Engine.ParentEngineID): a parent with a live child is
+// blocked, but the self-reference of a row to itself must never block its own
+// deletion.
+func TestResourceDeleteSelfReferentialRespectsLiveChildren(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	type Engine struct {
+		gorm.Model
+		Name           string  `json:"name"`
+		ParentEngineID *uint    `json:"parent_engine_id"`
+		ParentEngine   *Engine `gorm:"foreignKey:ParentEngineID" json:"-"`
+	}
+	app := newCookieApp(t)
+	if err := app.DB().AutoMigrate(&Engine{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	parent := Engine{Name: "tower"}
+	if err := app.DB().Create(&parent).Error; err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	child := Engine{Name: "child", ParentEngineID: &parent.ID}
+	if err := app.DB().Create(&child).Error; err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := admin.Register(app, Engine{}, admin.Options{
+		Slug: "engines",
+		Fields: []admin.Field{
+			{Name: "id", Type: admin.TypeInteger, ReadOnly: true},
+			{Name: "name", Type: admin.TypeString},
+			{Name: "parent_engine_id", Type: admin.TypeInteger},
+		},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	jar := loginSuperuser(t, app)
+
+	// The parent is referenced by the child: blocked.
+	rec := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/engines/%d", parent.ID), "")
+	assertError(t, rec, http.StatusConflict, "conflict")
+
+	// The child references only the parent (and nothing references the child),
+	// so deleting the child succeeds despite the self-referential FK.
+	delChild := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/engines/%d", child.ID), "")
+	if delChild.Code != http.StatusOK {
+		t.Fatalf("delete child status = %d; body: %s", delChild.Code, delChild.Body.String())
+	}
+	delParent := doRequest(app, jar, http.MethodDelete, fmt.Sprintf("/api/v1/admin/resources/engines/%d", parent.ID), "")
+	if delParent.Code != http.StatusOK {
+		t.Fatalf("delete parent after child removed status = %d; body: %s", delParent.Code, delParent.Body.String())
+	}
 }
 
 func TestJWTModeDoesNotMountAdmin(t *testing.T) {

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -246,6 +246,19 @@ registered). Raw `*gin.Engine` is **not** used for these endpoints. It
 **is** used for `/admin/` static files and SPA fallback, which must not
 appear in OpenAPI.
 
+**Deleting referenced records (referential integrity).** Models that embed
+`gorm.Model` are **soft-deleted** (GORM sets `deleted_at`; no physical `DELETE`
+runs), so the database's own `ON DELETE RESTRICT`/`NO ACTION` foreign keys never
+fire — a soft delete would otherwise leave a live child row pointing at a parent
+the API now reports as 404. The admin therefore enforces `RESTRICT` in the
+application layer: before deleting, it scans every **registered** model for a
+`belongs_to` foreign key targeting the row and returns `409 conflict`
+(`resource is still referenced by other records`) when any live (non-soft-deleted)
+row still references it — mirroring the 409 a hard-deleted model gets from the
+database constraint. A foreign key declared with an explicit
+`constraint:OnDelete:CASCADE` (or `SET NULL`) is respected and not blocked.
+Referencing models that are **not** registered on the admin are not scanned.
+
 List query parameters:
 
 - `page`, `per_page` (default page 1, per_page 20, max 100; same

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -246,18 +246,23 @@ registered). Raw `*gin.Engine` is **not** used for these endpoints. It
 **is** used for `/admin/` static files and SPA fallback, which must not
 appear in OpenAPI.
 
-**Deleting referenced records (referential integrity).** Models that embed
-`gorm.Model` are **soft-deleted** (GORM sets `deleted_at`; no physical `DELETE`
-runs), so the database's own `ON DELETE RESTRICT`/`NO ACTION` foreign keys never
-fire — a soft delete would otherwise leave a live child row pointing at a parent
-the API now reports as 404. The admin therefore enforces `RESTRICT` in the
-application layer: before deleting, it scans every **registered** model for a
-`belongs_to` foreign key targeting the row and returns `409 conflict`
-(`resource is still referenced by other records`) when any live (non-soft-deleted)
-row still references it — mirroring the 409 a hard-deleted model gets from the
-database constraint. A foreign key declared with an explicit
-`constraint:OnDelete:CASCADE` (or `SET NULL`) is respected and not blocked.
-Referencing models that are **not** registered on the admin are not scanned.
+**Deleting referenced records (referential integrity).** The admin data plane
+**hard-deletes** (`Unscoped`), so the database's own foreign keys enforce
+referential integrity in one statement (#220). A model embedding `gorm.Model`
+would otherwise be *soft*-deleted — `deleted_at` is set with no physical
+`DELETE` — and the database's `ON DELETE RESTRICT`/`NO ACTION` constraints would
+never fire, leaving a live child row pointing at a parent the API now reports as
+404. A real `DELETE` means:
+
+- `RESTRICT`/`NO ACTION`: deleting a referenced row fails atomically and returns
+  `409 conflict` (`resource is still referenced by other records`) — no
+  time-of-check/time-of-use race, because the constraint *is* the check.
+- `ON DELETE CASCADE` / `SET NULL`: actually execute at the database (children
+  removed / child FKs nulled), rather than being silently skipped.
+
+Because the delete is physical, the admin does not keep soft-deleted rows around
+(it has never exposed a restore/trash path). This is the framework-owned admin
+surface; generated per-resource handlers are thin and user-owned.
 
 List query parameters:
 


### PR DESCRIPTION
## Summary

The admin data plane now **hard-deletes** (`Unscoped().Delete`) so the database's real foreign keys enforce referential integrity atomically (#220). `gorm.Model` made the default delete a **soft** delete — `deleted_at` is set with no physical `DELETE` — so `ON DELETE RESTRICT`/`NO ACTION` never fired and a referenced parent could be "deleted" while a live child kept pointing at an API-404 row. With a real `DELETE`:

- **RESTRICT / NO ACTION**: deleting a referenced row fails atomically → `409 conflict` (via `MapDeleteError`). The database constraint *is* the check — no detached pre-scan, no TOCTOU race.
- **CASCADE / SET NULL**: actually execute at the database.

Admin soft-delete was incidental to `gorm.Model` and never a feature (there is no restore/trash path), so physical deletion removes nothing.

Closes #220

## Acceptance criteria

- [x] soft-delete and FK/restrict are coherent — the delete is physical, so the database constraint is the enforced invariant
- [x] deleting a referenced parent returns 409; once the child is gone the parent is **physically** deleted (not left soft-deleted)

## Scope notes

- `ON DELETE CASCADE` / `SET NULL` / `SET DEFAULT` execute at the database rather than being skipped.
- Scoped to the framework-owned admin data plane; the thin generated per-resource handlers are user-owned and out of scope.
- No restore/trash path existed; hard delete removes no capability.

## Validation

- [x] `go test ./admin/...` — RESTRICT→409 then physical delete (Unscoped can't find it), CASCADE removes children, SET NULL nulls the child FK, self-referential RESTRICT; full admin suite green
- [x] `golangci-lint run ./admin/...` — 0 issues

## Working agreement checklist

- [x] New behavior has tests. DB-touching: a plain `DELETE` enforced by the database; covered by the SQLite admin suite and portable across the Postgres/MySQL matrix
- [x] Stable features ship docs — `docs/admin.md` "Deleting referenced records" updated to the hard-delete/DB-enforced contract
- [x] Extraction preserves contracts — replaced the guard with a narrower, DB-enforced delete; prior admin tests still pass
- [ ] Generators: N/A
- [x] API changes regenerate OpenAPI + TS client — N/A (no contract/route/shape change; same 409 envelope)
- [x] No secrets in generated frontend source — N/A
- [x] Scope stays inside the admin milestone — no M6 battery
- [x] Links its issue (#220) and states which acceptance criteria it satisfies
