### PR TITLE
feat: gombit db hash — rehash migrations without the raw Atlas CLI (#219)

### DIFF
--- a/cli/db.go
+++ b/cli/db.go
@@ -31,7 +31,6 @@ func newDBCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
 	cmd.AddCommand(newSeedCommand(stdout, stderr))
 	cmd.AddCommand(newResetCommand(stdout, stderr))
 	cmd.AddCommand(newHashCommand(stdout, stderr))
-	cmd.AddCommand(newLintCommand(stdout, stderr))
 	return cmd
 }
 
@@ -62,55 +61,6 @@ func newHashCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
 		},
 	})
 	bindApplyFlags(cmd)
-	return cmd
-}
-
-func newLintCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
-	cmd := silence(&cobra.Command{
-		Use:   "lint",
-		Short: "Analyze recent migrations for destructive or non-appliable changes (atlas migrate lint)",
-		Args:  cobra.ArbitraryArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 0 {
-				return fmt.Errorf("gombit db lint: unexpected argument %q", args[0])
-			}
-			cfg, err := LoadConfig()
-			if err != nil {
-				return err
-			}
-			migrationDir, err := cmd.Flags().GetString("dir")
-			if err != nil {
-				return err
-			}
-			atlasBin, err := cmd.Flags().GetString("atlas-bin")
-			if err != nil {
-				return err
-			}
-			devURL, err := cmd.Flags().GetString("dev-url")
-			if err != nil {
-				return err
-			}
-			latest, err := cmd.Flags().GetInt("latest")
-			if err != nil {
-				return err
-			}
-			return migrations.Lint(cmd.Context(), migrations.LintOptions{
-				ApplyOptions: migrations.ApplyOptions{
-					WorkDir:      ".",
-					MigrationDir: migrationDir,
-					AtlasBinary:  atlasBin,
-					Database:     cfg.Database,
-					Stdout:       stdout,
-					Stderr:       stderr,
-				},
-				DevURL: devURL,
-				Latest: latest,
-			})
-		},
-	})
-	bindApplyFlags(cmd)
-	cmd.Flags().String("dev-url", "", "Atlas dev database URL (defaults to in-memory SQLite for the sqlite driver; required for postgres/mysql)")
-	cmd.Flags().Int("latest", 1, "number of most-recent migrations to analyze")
 	return cmd
 }
 

--- a/cli/db.go
+++ b/cli/db.go
@@ -30,6 +30,87 @@ func newDBCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
 	cmd.AddCommand(newVerifyCommand(stdout, stderr))
 	cmd.AddCommand(newSeedCommand(stdout, stderr))
 	cmd.AddCommand(newResetCommand(stdout, stderr))
+	cmd.AddCommand(newHashCommand(stdout, stderr))
+	cmd.AddCommand(newLintCommand(stdout, stderr))
+	return cmd
+}
+
+func newHashCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
+	cmd := silence(&cobra.Command{
+		Use:   "hash",
+		Short: "Recompute the migration directory checksum (atlas.sum) after a manual edit",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("gombit db hash: unexpected argument %q", args[0])
+			}
+			migrationDir, err := cmd.Flags().GetString("dir")
+			if err != nil {
+				return err
+			}
+			atlasBin, err := cmd.Flags().GetString("atlas-bin")
+			if err != nil {
+				return err
+			}
+			return migrations.Hash(cmd.Context(), migrations.ApplyOptions{
+				WorkDir:      ".",
+				MigrationDir: migrationDir,
+				AtlasBinary:  atlasBin,
+				Stdout:       stdout,
+				Stderr:       stderr,
+			})
+		},
+	})
+	bindApplyFlags(cmd)
+	return cmd
+}
+
+func newLintCommand(stdout io.Writer, stderr io.Writer) *cobra.Command {
+	cmd := silence(&cobra.Command{
+		Use:   "lint",
+		Short: "Analyze recent migrations for destructive or non-appliable changes (atlas migrate lint)",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("gombit db lint: unexpected argument %q", args[0])
+			}
+			cfg, err := LoadConfig()
+			if err != nil {
+				return err
+			}
+			migrationDir, err := cmd.Flags().GetString("dir")
+			if err != nil {
+				return err
+			}
+			atlasBin, err := cmd.Flags().GetString("atlas-bin")
+			if err != nil {
+				return err
+			}
+			devURL, err := cmd.Flags().GetString("dev-url")
+			if err != nil {
+				return err
+			}
+			latest, err := cmd.Flags().GetInt("latest")
+			if err != nil {
+				return err
+			}
+			return migrations.Lint(cmd.Context(), migrations.LintOptions{
+				ApplyOptions: migrations.ApplyOptions{
+					WorkDir:      ".",
+					MigrationDir: migrationDir,
+					AtlasBinary:  atlasBin,
+					Database:     cfg.Database,
+					Stdout:       stdout,
+					Stderr:       stderr,
+				},
+				DevURL: devURL,
+				Latest: latest,
+			})
+		},
+	})
+	bindApplyFlags(cmd)
+	cmd.Flags().String("dev-url", "", "Atlas dev database URL (defaults to in-memory SQLite for the sqlite driver; required for postgres/mysql)")
+	cmd.Flags().Int("latest", 1, "number of most-recent migrations to analyze")
 	return cmd
 }
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -145,6 +145,8 @@ func dbUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  status [--dir database/migrations] [--atlas-bin atlas]")
 	_, _ = fmt.Fprintln(w, "  seed [--seeds database/seeds]")
 	_, _ = fmt.Fprintln(w, "  reset [--dir database/migrations] [--seeds database/seeds] [--atlas-bin atlas] [--force]")
+	_, _ = fmt.Fprintln(w, "  hash [--dir database/migrations] [--atlas-bin atlas]")
+	_, _ = fmt.Fprintln(w, "  lint [--dir database/migrations] [--dev-url URL] [--latest N] [--atlas-bin atlas]")
 }
 
 func openapiUsage(w io.Writer) {

--- a/cli/root.go
+++ b/cli/root.go
@@ -146,7 +146,6 @@ func dbUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  seed [--seeds database/seeds]")
 	_, _ = fmt.Fprintln(w, "  reset [--dir database/migrations] [--seeds database/seeds] [--atlas-bin atlas] [--force]")
 	_, _ = fmt.Fprintln(w, "  hash [--dir database/migrations] [--atlas-bin atlas]")
-	_, _ = fmt.Fprintln(w, "  lint [--dir database/migrations] [--dev-url URL] [--latest N] [--atlas-bin atlas]")
 }
 
 func openapiUsage(w io.Writer) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -487,7 +487,20 @@ gombit db status
 gombit db seed
 gombit db reset [--force]
 gombit db verify [--write] [--json] [--strict]
+gombit db lint [--dev-url URL] [--latest N]
+gombit db hash
 ```
+
+`gombit db lint` wraps `atlas migrate lint` to surface **destructive or
+non-appliable** changes — e.g. a field rename (which Atlas emits as a drop + add,
+rebuilding the table) that would drop data or fail `NOT NULL` on apply. It uses an
+in-memory SQLite dev database by default; pass `--dev-url` for postgres/mysql
+(e.g. `docker://postgres/16/dev?search_path=public`), and `--latest N` to analyze
+more than the most recent migration. `makemigrations` prints a reminder to run it.
+
+`gombit db hash` wraps `atlas migrate hash` to recompute the directory checksum
+(`atlas.sum`) after a migration is hand-edited (e.g. to backfill a renamed
+column), so recovery from a checksum mismatch never needs the raw Atlas CLI.
 
 See [migrations.md](migrations.md) for Atlas behavior and
 [migration-safety.md](migration-safety.md) for `gombit db verify` — the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -487,20 +487,18 @@ gombit db status
 gombit db seed
 gombit db reset [--force]
 gombit db verify [--write] [--json] [--strict]
-gombit db lint [--dev-url URL] [--latest N]
 gombit db hash
 ```
-
-`gombit db lint` wraps `atlas migrate lint` to surface **destructive or
-non-appliable** changes — e.g. a field rename (which Atlas emits as a drop + add,
-rebuilding the table) that would drop data or fail `NOT NULL` on apply. It uses an
-in-memory SQLite dev database by default; pass `--dev-url` for postgres/mysql
-(e.g. `docker://postgres/16/dev?search_path=public`), and `--latest N` to analyze
-more than the most recent migration. `makemigrations` prints a reminder to run it.
 
 `gombit db hash` wraps `atlas migrate hash` to recompute the directory checksum
 (`atlas.sum`) after a migration is hand-edited (e.g. to backfill a renamed
 column), so recovery from a checksum mismatch never needs the raw Atlas CLI.
+`atlas migrate hash` is part of Atlas Community Edition ([ADR-012](adr/012-migrations-atlas-gorm-provider.md)).
+
+> Surfacing destructive/non-appliable changes (`atlas migrate lint`) is **not**
+> wrapped here: ADR-012 places `atlas migrate lint` outside the v0.1 Community
+> Edition dependency surface. Migration-safety analysis and the field-rename
+> affordance are tracked in [#299](https://github.com/gombit-dev/gombit/issues/299).
 
 See [migrations.md](migrations.md) for Atlas behavior and
 [migration-safety.md](migration-safety.md) for `gombit db verify` — the

--- a/migrations/hash.go
+++ b/migrations/hash.go
@@ -5,10 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strconv"
-	"strings"
-
-	"github.com/gombit-dev/gombit/config"
 )
 
 // Hash recomputes the Atlas migration directory's checksum file (atlas.sum) by
@@ -16,7 +12,8 @@ import (
 // backfill a renamed column so a NOT NULL rebuild can apply — Atlas refuses to
 // run it with a checksum error. This lets a developer recover with
 // `gombit db hash` instead of reaching for the raw Atlas CLI (#219). It does not
-// touch the application database.
+// touch the application database, and `atlas migrate hash` is part of Atlas
+// Community Edition (ADR-012).
 func Hash(ctx context.Context, opts ApplyOptions) error {
 	if ctx == nil {
 		return errors.New("migrations: nil context")
@@ -36,71 +33,4 @@ func Hash(ctx context.Context, opts ApplyOptions) error {
 	}
 	_, _ = fmt.Fprintln(opts.Stdout, "Rehashed the migration directory (atlas.sum).")
 	return nil
-}
-
-// LintOptions configures Lint. DevURL is the Atlas dev database (a scratch
-// database Atlas replays migrations into to analyze them); it defaults to an
-// in-memory SQLite dev-url for the sqlite driver and is required for postgres /
-// mysql. Latest bounds how many of the most recent migrations are analyzed
-// (default 1 — the migration just generated).
-type LintOptions struct {
-	ApplyOptions
-	DevURL string
-	Latest int
-}
-
-// Lint analyzes recent migrations for destructive or non-appliable changes by
-// wrapping `atlas migrate lint` — so a data-losing column drop or a NOT NULL
-// rebuild that cannot apply to a non-empty table is surfaced before it reaches a
-// real database, instead of failing mid-apply with no warning (#219).
-func Lint(ctx context.Context, opts LintOptions) error {
-	if ctx == nil {
-		return errors.New("migrations: nil context")
-	}
-	opts.ApplyOptions = withApplyDefaults(opts.ApplyOptions)
-	if opts.Latest <= 0 {
-		opts.Latest = 1
-	}
-	devURL := strings.TrimSpace(opts.DevURL)
-	if devURL == "" {
-		var err error
-		devURL, err = defaultDevURL(opts.Database.Driver)
-		if err != nil {
-			return err
-		}
-	}
-	migrationDir, err := resolveMigrationDir(opts.ApplyOptions)
-	if err != nil {
-		return err
-	}
-	absWorkDir, err := filepath.Abs(opts.WorkDir)
-	if err != nil {
-		return fmt.Errorf("migrations: resolve work dir: %w", err)
-	}
-	args := []string{
-		"migrate", "lint",
-		"--dev-url", devURL,
-		"--dir", "file://" + filepath.ToSlash(migrationDir),
-		"--latest", strconv.Itoa(opts.Latest),
-	}
-	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
-		return fmt.Errorf("migrations: atlas migrate lint: %w", err)
-	}
-	return nil
-}
-
-// defaultDevURL returns an Atlas dev-url for drivers where a throwaway scratch
-// database is free (in-memory SQLite). Postgres and MySQL need a real dev
-// database, so the caller must pass one explicitly (--dev-url).
-func defaultDevURL(driver config.DatabaseDriver) (string, error) {
-	switch driver {
-	case config.DatabaseDriverSQLite:
-		return "sqlite://file?mode=memory", nil
-	case config.DatabaseDriverPostgres:
-		return "", fmt.Errorf("migrations: lint needs a dev database for postgres; pass --dev-url (e.g. docker://postgres/16/dev?search_path=public)")
-	case config.DatabaseDriverMySQL:
-		return "", fmt.Errorf("migrations: lint needs a dev database for mysql; pass --dev-url (e.g. docker://mysql/8/dev)")
-	default:
-		return "", fmt.Errorf("migrations: lint needs --dev-url for driver %q", driver)
-	}
 }

--- a/migrations/hash.go
+++ b/migrations/hash.go
@@ -1,0 +1,106 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gombit-dev/gombit/config"
+)
+
+// Hash recomputes the Atlas migration directory's checksum file (atlas.sum) by
+// wrapping `atlas migrate hash`. After a migration is hand-edited — e.g. to
+// backfill a renamed column so a NOT NULL rebuild can apply — Atlas refuses to
+// run it with a checksum error. This lets a developer recover with
+// `gombit db hash` instead of reaching for the raw Atlas CLI (#219). It does not
+// touch the application database.
+func Hash(ctx context.Context, opts ApplyOptions) error {
+	if ctx == nil {
+		return errors.New("migrations: nil context")
+	}
+	opts = withApplyDefaults(opts)
+	migrationDir, err := resolveMigrationDir(opts)
+	if err != nil {
+		return err
+	}
+	absWorkDir, err := filepath.Abs(opts.WorkDir)
+	if err != nil {
+		return fmt.Errorf("migrations: resolve work dir: %w", err)
+	}
+	args := []string{"migrate", "hash", "--dir", "file://" + filepath.ToSlash(migrationDir)}
+	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
+		return fmt.Errorf("migrations: atlas migrate hash: %w", err)
+	}
+	_, _ = fmt.Fprintln(opts.Stdout, "Rehashed the migration directory (atlas.sum).")
+	return nil
+}
+
+// LintOptions configures Lint. DevURL is the Atlas dev database (a scratch
+// database Atlas replays migrations into to analyze them); it defaults to an
+// in-memory SQLite dev-url for the sqlite driver and is required for postgres /
+// mysql. Latest bounds how many of the most recent migrations are analyzed
+// (default 1 — the migration just generated).
+type LintOptions struct {
+	ApplyOptions
+	DevURL string
+	Latest int
+}
+
+// Lint analyzes recent migrations for destructive or non-appliable changes by
+// wrapping `atlas migrate lint` — so a data-losing column drop or a NOT NULL
+// rebuild that cannot apply to a non-empty table is surfaced before it reaches a
+// real database, instead of failing mid-apply with no warning (#219).
+func Lint(ctx context.Context, opts LintOptions) error {
+	if ctx == nil {
+		return errors.New("migrations: nil context")
+	}
+	opts.ApplyOptions = withApplyDefaults(opts.ApplyOptions)
+	if opts.Latest <= 0 {
+		opts.Latest = 1
+	}
+	devURL := strings.TrimSpace(opts.DevURL)
+	if devURL == "" {
+		var err error
+		devURL, err = defaultDevURL(opts.Database.Driver)
+		if err != nil {
+			return err
+		}
+	}
+	migrationDir, err := resolveMigrationDir(opts.ApplyOptions)
+	if err != nil {
+		return err
+	}
+	absWorkDir, err := filepath.Abs(opts.WorkDir)
+	if err != nil {
+		return fmt.Errorf("migrations: resolve work dir: %w", err)
+	}
+	args := []string{
+		"migrate", "lint",
+		"--dev-url", devURL,
+		"--dir", "file://" + filepath.ToSlash(migrationDir),
+		"--latest", strconv.Itoa(opts.Latest),
+	}
+	if err := opts.runner.Run(ctx, absWorkDir, opts.AtlasBinary, args, opts.Stdout, opts.Stderr); err != nil {
+		return fmt.Errorf("migrations: atlas migrate lint: %w", err)
+	}
+	return nil
+}
+
+// defaultDevURL returns an Atlas dev-url for drivers where a throwaway scratch
+// database is free (in-memory SQLite). Postgres and MySQL need a real dev
+// database, so the caller must pass one explicitly (--dev-url).
+func defaultDevURL(driver config.DatabaseDriver) (string, error) {
+	switch driver {
+	case config.DatabaseDriverSQLite:
+		return "sqlite://file?mode=memory", nil
+	case config.DatabaseDriverPostgres:
+		return "", fmt.Errorf("migrations: lint needs a dev database for postgres; pass --dev-url (e.g. docker://postgres/16/dev?search_path=public)")
+	case config.DatabaseDriverMySQL:
+		return "", fmt.Errorf("migrations: lint needs a dev database for mysql; pass --dev-url (e.g. docker://mysql/8/dev)")
+	default:
+		return "", fmt.Errorf("migrations: lint needs --dev-url for driver %q", driver)
+	}
+}

--- a/migrations/hash_test.go
+++ b/migrations/hash_test.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"strings"
 	"testing"
-
-	"github.com/gombit-dev/gombit/config"
 )
 
 type recordRunner struct {
@@ -50,72 +48,5 @@ func TestHashRunsAtlasMigrateHash(t *testing.T) {
 	}
 	if !argsContain(call, "--dir") {
 		t.Fatalf("args = %v, want a --dir", call)
-	}
-}
-
-func TestLintSQLiteUsesInMemoryDevURL(t *testing.T) {
-	r := &recordRunner{}
-	err := Lint(context.Background(), LintOptions{
-		ApplyOptions: ApplyOptions{
-			WorkDir:  t.TempDir(),
-			Database: config.DatabaseConfig{Driver: config.DatabaseDriverSQLite},
-			Stdout:   io.Discard,
-			Stderr:   io.Discard,
-			runner:   r,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Lint: %v", err)
-	}
-	if len(r.calls) != 1 {
-		t.Fatalf("atlas calls = %d, want 1", len(r.calls))
-	}
-	call := r.calls[0]
-	if len(call) < 2 || call[0] != "migrate" || call[1] != "lint" {
-		t.Fatalf("args = %v, want [migrate lint ...]", call)
-	}
-	if !argsContain(call, "--dev-url", "sqlite://file?mode=memory", "--latest", "1") {
-		t.Fatalf("args = %v, want sqlite in-memory dev-url + --latest 1", call)
-	}
-}
-
-func TestLintPostgresRequiresDevURL(t *testing.T) {
-	r := &recordRunner{}
-	err := Lint(context.Background(), LintOptions{
-		ApplyOptions: ApplyOptions{
-			WorkDir:  t.TempDir(),
-			Database: config.DatabaseConfig{Driver: config.DatabaseDriverPostgres},
-			Stdout:   io.Discard,
-			Stderr:   io.Discard,
-			runner:   r,
-		},
-	})
-	if err == nil {
-		t.Fatal("want an error when no dev-url is given for postgres")
-	}
-	if len(r.calls) != 0 {
-		t.Fatalf("atlas must not run without a dev-url; calls = %d", len(r.calls))
-	}
-}
-
-func TestLintCustomDevURLAndLatest(t *testing.T) {
-	r := &recordRunner{}
-	err := Lint(context.Background(), LintOptions{
-		ApplyOptions: ApplyOptions{
-			WorkDir:  t.TempDir(),
-			Database: config.DatabaseConfig{Driver: config.DatabaseDriverPostgres},
-			Stdout:   io.Discard,
-			Stderr:   io.Discard,
-			runner:   r,
-		},
-		DevURL: "docker://postgres/16/dev?search_path=public",
-		Latest: 3,
-	})
-	if err != nil {
-		t.Fatalf("Lint: %v", err)
-	}
-	call := r.calls[0]
-	if !argsContain(call, "--dev-url", "docker://postgres/16/dev?search_path=public", "--latest", "3") {
-		t.Fatalf("args = %v, want custom dev-url + --latest 3", call)
 	}
 }

--- a/migrations/hash_test.go
+++ b/migrations/hash_test.go
@@ -1,0 +1,121 @@
+package migrations
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gombit-dev/gombit/config"
+)
+
+type recordRunner struct {
+	calls [][]string
+	err   error
+}
+
+func (r *recordRunner) Run(_ context.Context, _ string, _ string, args []string, _ io.Writer, _ io.Writer) error {
+	r.calls = append(r.calls, append([]string{}, args...))
+	return r.err
+}
+
+func argsContain(args []string, want ...string) bool {
+	joined := " " + strings.Join(args, " ") + " "
+	for _, w := range want {
+		if !strings.Contains(joined, " "+w+" ") {
+			return false
+		}
+	}
+	return true
+}
+
+func TestHashRunsAtlasMigrateHash(t *testing.T) {
+	r := &recordRunner{}
+	err := Hash(context.Background(), ApplyOptions{
+		WorkDir:      t.TempDir(),
+		MigrationDir: "database/migrations",
+		Stdout:       io.Discard,
+		Stderr:       io.Discard,
+		runner:       r,
+	})
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("atlas calls = %d, want 1", len(r.calls))
+	}
+	call := r.calls[0]
+	if len(call) < 2 || call[0] != "migrate" || call[1] != "hash" {
+		t.Fatalf("args = %v, want [migrate hash ...]", call)
+	}
+	if !argsContain(call, "--dir") {
+		t.Fatalf("args = %v, want a --dir", call)
+	}
+}
+
+func TestLintSQLiteUsesInMemoryDevURL(t *testing.T) {
+	r := &recordRunner{}
+	err := Lint(context.Background(), LintOptions{
+		ApplyOptions: ApplyOptions{
+			WorkDir:  t.TempDir(),
+			Database: config.DatabaseConfig{Driver: config.DatabaseDriverSQLite},
+			Stdout:   io.Discard,
+			Stderr:   io.Discard,
+			runner:   r,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Lint: %v", err)
+	}
+	if len(r.calls) != 1 {
+		t.Fatalf("atlas calls = %d, want 1", len(r.calls))
+	}
+	call := r.calls[0]
+	if len(call) < 2 || call[0] != "migrate" || call[1] != "lint" {
+		t.Fatalf("args = %v, want [migrate lint ...]", call)
+	}
+	if !argsContain(call, "--dev-url", "sqlite://file?mode=memory", "--latest", "1") {
+		t.Fatalf("args = %v, want sqlite in-memory dev-url + --latest 1", call)
+	}
+}
+
+func TestLintPostgresRequiresDevURL(t *testing.T) {
+	r := &recordRunner{}
+	err := Lint(context.Background(), LintOptions{
+		ApplyOptions: ApplyOptions{
+			WorkDir:  t.TempDir(),
+			Database: config.DatabaseConfig{Driver: config.DatabaseDriverPostgres},
+			Stdout:   io.Discard,
+			Stderr:   io.Discard,
+			runner:   r,
+		},
+	})
+	if err == nil {
+		t.Fatal("want an error when no dev-url is given for postgres")
+	}
+	if len(r.calls) != 0 {
+		t.Fatalf("atlas must not run without a dev-url; calls = %d", len(r.calls))
+	}
+}
+
+func TestLintCustomDevURLAndLatest(t *testing.T) {
+	r := &recordRunner{}
+	err := Lint(context.Background(), LintOptions{
+		ApplyOptions: ApplyOptions{
+			WorkDir:  t.TempDir(),
+			Database: config.DatabaseConfig{Driver: config.DatabaseDriverPostgres},
+			Stdout:   io.Discard,
+			Stderr:   io.Discard,
+			runner:   r,
+		},
+		DevURL: "docker://postgres/16/dev?search_path=public",
+		Latest: 3,
+	})
+	if err != nil {
+		t.Fatalf("Lint: %v", err)
+	}
+	call := r.calls[0]
+	if !argsContain(call, "--dev-url", "docker://postgres/16/dev?search_path=public", "--latest", "3") {
+		t.Fatalf("args = %v, want custom dev-url + --latest 3", call)
+	}
+}

--- a/migrations/makemigrations.go
+++ b/migrations/makemigrations.go
@@ -187,6 +187,12 @@ func MakeMigrations(ctx context.Context, opts Options) error {
 	if err := SaveRegistry(migrationDir, allModels); err != nil {
 		return err
 	}
+	// A diff that renames a field shows up as a drop + add, which Atlas turns
+	// into a table rebuild that can lose data or fail to apply to a non-empty
+	// table. Point at the tooling that surfaces/repairs that (#219) rather than
+	// letting it fail silently mid-apply.
+	_, _ = fmt.Fprintln(opts.Stdout, "Run 'gombit db lint' to check the new migration for destructive or non-appliable changes.")
+	_, _ = fmt.Fprintln(opts.Stdout, "If you hand-edit a migration, run 'gombit db hash' to refresh atlas.sum before 'gombit db migrate'.")
 	return nil
 }
 

--- a/migrations/makemigrations.go
+++ b/migrations/makemigrations.go
@@ -189,10 +189,9 @@ func MakeMigrations(ctx context.Context, opts Options) error {
 	}
 	// A diff that renames a field shows up as a drop + add, which Atlas turns
 	// into a table rebuild that can lose data or fail to apply to a non-empty
-	// table. Point at the tooling that surfaces/repairs that (#219) rather than
-	// letting it fail silently mid-apply.
-	_, _ = fmt.Fprintln(opts.Stdout, "Run 'gombit db lint' to check the new migration for destructive or non-appliable changes.")
-	_, _ = fmt.Fprintln(opts.Stdout, "If you hand-edit a migration, run 'gombit db hash' to refresh atlas.sum before 'gombit db migrate'.")
+	// table. Review the generated SQL; if you hand-edit it, `gombit db hash`
+	// refreshes atlas.sum so the migration still applies (#219).
+	_, _ = fmt.Fprintln(opts.Stdout, "Review the generated migration before applying. If you hand-edit it, run 'gombit db hash' to refresh atlas.sum before 'gombit db migrate'.")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Adds **`gombit db hash`** — a wrapper around `atlas migrate hash` that recomputes the migration directory checksum (`atlas.sum`) after a migration is hand-edited (e.g. to backfill a renamed column), so recovering from a checksum mismatch never requires the raw Atlas CLI. `atlas migrate hash` is part of Atlas Community Edition ([ADR-012](docs/adr/012-migrations-atlas-gorm-provider.md)).

`makemigrations` now prints a short reminder to review the generated migration and run `gombit db hash` after a hand-edit.

**Scope correction:** an earlier revision also added `gombit db lint`. That was removed — ADR-012 places `atlas migrate lint` **outside** the v0.1 Community-Edition dependency surface, so Gombit must not expose it as a supported command. Surfacing destructive/non-appliable changes and the field-rename affordance are therefore **not** in this PR.

Addresses #219 (the recovery half only). This PR does **not** close #219; the migration-safety analysis and rename work remain, tracked in #299.

## Acceptance criteria (from #219)

- [x] `gombit db` exposes a rehash command so recovery never needs the raw Atlas CLI → `gombit db hash`
- [ ] surface destructive/non-appliable changes — **not in this PR** (ADR-012 excludes `atlas migrate lint`; tracked in #299)
- [ ] rename affordance — **not in this PR** (tracked in #299)

## Scope notes

- Only `atlas migrate hash` is wrapped (Community Edition). No `atlas migrate lint` dependency is introduced.
- `#219` stays open for the detection + rename work; `#299` carries it with corrected dependency notes.

## Validation

- [x] `go test ./migrations/... ./cli/...` — `Hash` wiring test (fake runner) + existing suites green
- [x] `golangci-lint run ./migrations/... ./cli/...` — no findings in changed code

## Working agreement checklist

- [x] New behavior has tests (the `Hash` wrapper). Not an app-DB change — `atlas migrate hash` rewrites `atlas.sum`, no database matrix needed
- [x] Stable features ship docs — `docs/cli.md` documents `gombit db hash` and notes lint is out of scope per ADR-012
- [x] Extraction preserves contracts — additive subcommand; existing `db` commands unchanged
- [ ] Generators: N/A
- [x] API changes regenerate OpenAPI + TS client — N/A (CLI only)
- [x] No secrets in generated frontend source — N/A
- [x] Scope inside M2/M4 migrations tooling — no M6 battery
- [x] Links its issue (#219) and states which acceptance criteria it satisfies (and what is deferred)
